### PR TITLE
Let tabs() accept filters, ameliorates #223

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,7 @@ const DEFAULTS = o({
         "M": "gobble 1 quickmark",
         "xx": "something",
         // "B": "fillcmdline bufferall",
-        "b": "fillcmdline buffer",
+        "b": "tabs",
         "ZZ": "qall",
         "f": "hint",
         "F": "hint -b",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -272,7 +272,7 @@ export function open(...urlarr: string[]) {
 
 
 /** Go to your homepage(s)
- 
+
     @param all
         - if "true", opens all homepages in new tabs
         - if "false" or not given, opens the last homepage in the current tab
@@ -1011,8 +1011,9 @@ export async function clipboard(excmd: "open"|"yank"|"yankshort"|"yankcanon"|"ta
     Sort of Vimperator alias
 */
 //#background
-export async function tabs() {
-    fillcmdline("buffer")
+export async function tabs(...strarr: string[]) {
+    if (strarr.length) fillcmdline_notrail(["buffer"].concat(strarr).join(" "))
+    else fillcmdline("buffer")
 }
 
 /** Equivalent to `fillcmdline buffer`
@@ -1020,8 +1021,8 @@ export async function tabs() {
     Sort of Vimperator alias
 */
 //#background
-export async function buffers() {
-    tabs()
+export async function buffers(...strarr: string[]) {
+    tabs(strarr.join(" "))
 }
 
 /** Change active tab.
@@ -1214,7 +1215,7 @@ export async function sanitize(...args: string[]) {
 
     Afterwards use go[key], gn[key], or gw[key] to [[open]], [[tabopen]], or
     [[winopen]] the URL respectively.
-    
+
 */
 //#background
 export async function quickmark(key: string, ...addressarr: string[]) {
@@ -1249,7 +1250,7 @@ export function get(target: string, property?: string){
     (i.e. not nmaps.)
 
     It can be used on any string <-> string settings found [here](/static/docs/modules/_config_.html#defaults)
- 
+
 */
 //#background
 export function set(setting: string, ...value: string[]){
@@ -1431,13 +1432,13 @@ export async function ttscontrol(action: string) {
 /** Add or remove a bookmark.
 *
 * Optionally, you may give the bookmark a title. If no URL is given, a bookmark is added for the current page.
-* 
+*
 * If a bookmark already exists for the URL, it is removed.
 */
 //#background
 export async function bmark(url?: string, ...titlearr: string[] ){
     url = url === undefined ? (await activeTab()).url : url
-    let title = titlearr.join(" ") 
+    let title = titlearr.join(" ")
     let dupbmarks = await browser.bookmarks.search({url})
     dupbmarks.map((bookmark) => browser.bookmarks.remove(bookmark.id))
     if (dupbmarks.length == 0 ) {browser.bookmarks.create({url, title})}


### PR DESCRIPTION
> In Vimperator, buffers(...args) displays a
> filtered buffer list with ...args as the query.
> This commit has tabs() resemble _that_ functionality
> making use of fillcmdline_notrail.
> 
> Exploiting the fact that providing the buffer
> completions system with a single number n and no
> trailing space completes only the tab at index
> (n % #tabs), using this in normal mode grants us
> a count-supported tabIndexSetActive() that ties
> "gt" in keypresses while retaining the usual
> "fillcmdline buffer" behavior if no counts are
> supplied.

I say it only ameliorates #223 because behavior still diverges from Vimperator/Pentadactyl, but I think this is acceptable at present.