### PR TITLE
[WIP/RFC] Improve pagination by fixing the websites themselves

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,15 @@ const DEFAULTS = o({
     }),
     autocmds: o({
         DocStart: o({
-            // "addons.mozilla.org": "mode ignore",
+            /** chocolateboy's pagination fixes */
+            "news.ycombinator.com": `js try{document.getElementsByClassName("morelink")[0].rel += " next"}catch(e){}`,
+            /** ars needs more work */
+            // "arstechnica.com": `js try{Array.from(document.querySelectorAll("[rel=next],[rel=prev]")).map(x=>x.rel=""); document.getElementsByClassName("next")[0].rel="next";}catch(e){}`,
+            // "arstechnica.co.uk": `js try{Array.from(document.querySelectorAll("[rel=next],[rel=prev]")).map(x=>x.rel=""); document.getElementsByClassName("next")[0].rel="next";}catch(e){}`,
+            /** prev links need more complex logic, it seems */
+            "amazon.co.uk": `js try{document.getElementById("pagnNextLink").rel="next";}catch(e){}`,
+            // "amazon.co.uk":
+            // "amazon.de":
         }),
         TriStart: o({
             ".*": "source_quiet",
@@ -187,7 +195,7 @@ const DEFAULTS = o({
         current_url: "composite get_current_url | fillcmdline_notrail ",
     }),
     followpagepatterns: o({
-        next: "^(next|newer)\\b|»|>>|more",
+        next: "^(next|newer)\\b|»|>>",
         prev: "^(prev(ious)?|older)\\b|«|<<",
     }),
     searchengine: "google",


### PR DESCRIPTION
Related: #120 #276

I'm wondering whether we should have a separate "site-specific fixes" part to Tridactyl. Things might get a bit messy if we just have a bunch of autocmds.