### PR TITLE
[WIP]: Completions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,12 @@
       "resolved": "https://registry.npmjs.org/@types/css/-/css-0.0.31.tgz",
       "integrity": "sha512-Xt3xp8o0zueqrdIkAOO5gy5YNs+jYfmIUPeoeKiwrcmCRXuNWkIgR2Ph6vHuVfi1y6c9Tx214EQBWPEkU97djw=="
     },
+    "@types/fast-levenshtein": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.1.tgz",
+      "integrity": "sha1-OjYVzxc2Rcj8pY0FHk4ygk5L0oY=",
+      "dev": true
+    },
     "@types/fs-extra": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.0.tgz",
@@ -200,6 +206,48 @@
           "integrity": "sha1-XG9FmaumszPuM0Li7ZeGcvEAH40=",
           "dev": true
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -214,6 +262,12 @@
           "requires": {
             "source-map": "0.5.7"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
@@ -235,6 +289,38 @@
           "requires": {
             "tr46": "0.0.3",
             "webidl-conversions": "3.0.1"
+          }
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
           }
         }
       }
@@ -2222,6 +2308,48 @@
             "lodash": "4.17.4"
           }
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -2235,6 +2363,44 @@
           "dev": true,
           "requires": {
             "source-map": "0.5.7"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
           }
         }
       }
@@ -2830,8 +2996,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
       "version": "1.2.0",
@@ -3139,8 +3304,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "ansi-regex": {
@@ -3571,7 +3736,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -3671,8 +3836,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
           }
         },
         "npmlog": {
@@ -3730,8 +3895,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4552,6 +4717,11 @@
       "integrity": "sha512-HrxmNxKTGZ9a3uAl/FNG66Sdt0G9L4TtMbbUQjP1WhGmSj0FOyHvSgx7623aGJvXfPOur8MwmarlHT+37jmzlw==",
       "dev": true
     },
+    "immutable": {
+      "version": "4.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.9.tgz",
+      "integrity": "sha512-uw4u9Jy3G2Y1qkIFtEGy9NgJxFJT1l3HKgeSFHfrvy91T8W54cJoQ+qK3fTwhil8XkEHuc2S+MI+fbD0vKObDA=="
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -5273,6 +5443,17 @@
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
           }
         }
       }
@@ -5552,6 +5733,17 @@
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
           }
         }
       }
@@ -6208,12 +6400,6 @@
         "brace-expansion": "1.1.8"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
     "mississippi": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
@@ -6249,6 +6435,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "moment": {
@@ -6682,8 +6876,16 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
+        "minimist": "0.0.10",
         "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -8921,6 +9123,17 @@
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
           }
         }
       }
@@ -9632,7 +9845,7 @@
       }
     },
     "web-ext-types": {
-      "version": "github:kelseasy/web-ext-types#5fa885198a9d43a35dfd0afec64c5ff89338f8a0",
+      "version": "github:kelseasy/web-ext-types#5f6e888318984c185413f8943d2616915e2af88f",
       "dev": true
     },
     "webidl-conversions": {
@@ -9715,6 +9928,54 @@
             "tapable": "0.2.8"
           }
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
@@ -9756,6 +10017,68 @@
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "read-pkg-up": "2.0.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "7.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "dev": true,
+              "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.1.0"
+              },
+              "dependencies": {
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "dev": true,
+              "requires": {
+                "camelcase": "4.1.0"
+              }
+            }
+          }
         }
       }
     },
@@ -9967,86 +10290,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-      "dev": true,
-      "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-      "dev": true,
-      "requires": {
-        "camelcase": "4.1.0"
-      }
     },
     "yauzl": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "@types/css": "0.0.31",
     "@types/nearley": "^2.11.0",
     "css": "^2.2.1",
+    "fast-levenshtein": "^2.0.6",
     "fuse.js": "^3.2.0",
+    "immutable": "^4.0.0-rc.9",
     "mark.js": "^8.11.1",
     "nearley": "^2.11.0",
     "semver-compare": "^1.0.0"
@@ -14,6 +16,7 @@
   "devDependencies": {
     "@types/jest": "^21.1.4",
     "@types/node": "^8.0.46",
+    "@types/fast-levenshtein": "0.0.1",
     "awesome-typescript-loader": "^3.2.3",
     "chokidar-cli": "^1.2.0",
     "cleanslate": "^0.10.1",

--- a/src/command_background.ts
+++ b/src/command_background.ts
@@ -1,15 +1,16 @@
 import { List, Map } from "immutable"
-import { MayList, toList, HistItem, RArray } from "./util"
+import { BrowserTab, MayList, toList, HistItem, RArray } from "./util"
 import minimist from "./minimist"
 import { get as levenshtein } from "fast-levenshtein"
 import * as I from "immutable"
 import * as Util from "./util"
 import * as Alias from "./aliases"
 import * as Config from "./config"
+import { IP_BOOLEAN } from "./command_inputs"
 
 let commandRegistry: CommandSpec[] = []
 type CmdAction = (ctx: CmdContext, ...args: any[]) => any
-type Completer = (exstr: string) => List<CompletionGroup>
+type Completer = (exstr: string) => Promise<List<CompletionGroup>>
 
 interface CmdContext {
     readonly count: number
@@ -17,7 +18,7 @@ interface CmdContext {
     readonly state: Map<string, any>
 }
 
-interface CmdOption {
+export interface CmdOption {
     readonly short?: string
     readonly long: string
     readonly type: InputType
@@ -26,14 +27,14 @@ interface CmdOption {
     readonly argname?: string
 }
 
-interface CommandSpec {
+export interface CommandSpec {
     readonly names: List<string>
     readonly description: string
     readonly documentation: string
     readonly argumentTypes: List<InputType>
     readonly optionTypes: List<CmdOption>
     readonly action: CmdAction
-    readonly completer: (exstr: string) => List<CompletionGroup>
+    readonly completer: (exstr: string) => Promise<List<CompletionGroup>>
 }
 
 export interface Completion {
@@ -46,6 +47,7 @@ export interface Completion {
 
 export interface CompletionGroup {
     readonly name: string
+    readonly selectable: boolean
     readonly completions: List<Completion>
 }
 
@@ -59,182 +61,6 @@ interface ParsedCommand {
     readonly options: Map<string, any>
     readonly arguments: List<any>
 }
-
-/**
- * Make an input with the provided list of completions
- *
- * @param name Name of the list
- * @param comprehensive If true, the parser will reject strings not in the
- * provided list
- * @param l The list of completions
- */
-export function makeListInput(
-    name: string,
-    comprehensive: boolean,
-    l: List<Completion>,
-): InputType {
-    const completed = l.map(x => x.completed)
-    return {
-        getCompletions: async i => {
-            const c = l
-                .filter(
-                    x =>
-                        x.title.includes(i) ||
-                        (x.description && x.description.includes(i)),
-                )
-                .sortBy(x => x.title)
-            return {
-                name: name,
-                completions: c,
-            }
-        },
-        parseInput: async i => {
-            if (!comprehensive) return i
-            if (completed.includes(i)) return i
-            throw Error(`Argument '${i}' is not valid`)
-        },
-    }
-}
-
-export function stringListToComp(...l: string[]): List<Completion> {
-    return List(l.map(x => ({ title: x })))
-}
-
-export const SEARCH_ENGINE_INPUT: InputType = {
-    getCompletions: async i => {
-        const cfg = Config.get("searchurls") as object
-        // 'searchurls' is a map of engine -> searchurl
-        const comps = stringListToComp(...Object.keys(cfg))
-        return {
-            name: "Search Engines",
-            completions: comps,
-        }
-    },
-    parseInput: async i => i,
-}
-
-export const STRING_INPUT: InputType = {
-    getCompletions: async i => ({ name: "String", completions: List() }),
-    parseInput: async i => i,
-}
-
-export const AUCMD_EVENTS_INPUT: InputType = makeListInput(
-    "AutoCommand Events",
-    true,
-    stringListToComp("DocStart"),
-)
-
-export const BOOLEAN_INPUT: InputType = {
-    ...makeListInput("True/False", false, stringListToComp("true", "false")),
-    parseInput: async i => Util.parseBool(i),
-}
-
-export const HISTORY_INPUT: InputType = {
-    getCompletions: async i => {
-        const h = await browser.history.search({ text: i, maxResults: 20 })
-        const transformed = toList(h)
-            // One day the TS compiler will be smart enough to see the filter
-            // below as a null check
-            .filter(x => x.title && x.visitCount && x.url)
-            .sortBy(x => x.visitCount!)
-            .map(x => ({
-                title: x.title!,
-                description: x.url!,
-                completed: x.url!,
-            }))
-        return {
-            name: "History",
-            completions: transformed,
-        }
-    },
-    parseInput: async i => new URL(i),
-}
-
-export const BMARK_INPUT: InputType = {
-    getCompletions: async i => {
-        const query = await browser.bookmarks.search(i)
-        const mapped = toList(query)
-            .filter(x => x.url)
-            .map(x => ({
-                title: x.title,
-                description: x.url,
-                completed: x.url,
-            }))
-        return {
-            name: "Bookmarks",
-            completions: mapped,
-        }
-    },
-    parseInput: async i => new URL(i),
-}
-
-export const CONTXID_INPUT: InputType = {
-    getCompletions: async i => {
-        const query = await browser.contextualIdentities.query({ name: i })
-        const comps = toList(query).map(x => ({
-            title: x.name,
-            // TODO: add icon to the completions
-            completed: x.cookieStoreId,
-        }))
-        return {
-            name: "Contextual Identities",
-            completions: comps,
-        }
-    },
-    parseInput: async i => {
-        const c = browser.contextualIdentities.get(i)
-        if (!i) throw Error(`Contextual Identity ${i} not found`)
-        return c
-    },
-}
-
-function tabToComp(t: BrowserTab): Completion | null {
-    if (!t.url || !t.title) return null
-
-    let flags = ""
-    if (t.active) flags += "%"
-    if (t.pinned) flags += "@"
-    // if (t.isInReaderMode) flags += "R"
-
-    const icon = t.favIconUrl ? new URL(t.favIconUrl) : undefined
-
-    return {
-        title: `${t.index}: ${t.title}`,
-        description: t.url,
-        icon: icon,
-        completed: t.index.toString(),
-    }
-}
-
-export const TAB_INPUT: InputType = {
-    getCompletions: async i => {
-        const q = await browser.tabs.query({ title: i })
-        const comps = toList(q)
-            .map(tabToComp)
-            // TS doesn't recognise the null filter
-            .filter(Boolean) as List<Completion>
-        return {
-            name: "Tabs",
-            completions: comps,
-        }
-    },
-    parseInput: async i => {
-        const idx = parseInt(i)
-        return browser.tabs.query({ currentWindow: true, index: idx })[0]
-    },
-}
-
-export const EXSTR_INPUT: InputType = {
-    getCompletions: async i => List(getCompletionsForExstr(i)),
-    parseInput: async i => i,
-}
-
-const optionToComp = (opt: CmdOption): Completion => ({
-    /** Example: '-f, --foobar' */
-    title: `-${opt.short}, --${opt.long}`,
-    description: opt.description,
-    completed: "--" + opt.long,
-})
 
 /**
  * Parse a list of specs for the name of a command. Adapted from vimperator.
@@ -260,23 +86,30 @@ export function registerNewCommand(
         argumentTypes?: InputType | InputType[]
         optionTypes?: CmdOption | CmdOption[]
         action: CmdAction
-        completer?: (exstr: string) => List<CompletionGroup>
+        completer?: Completer
     },
 ): CommandSpec {
+    const optionTypes = toList(opts.optionTypes)
+    const argumentTypes = toList(opts.argumentTypes)
+
     const cmd: CommandSpec = {
         names: parseNameSpecs(opts.nameSpecs),
         description: opts.description,
         documentation: opts.documentation || "No documentation provided",
-        argumentTypes: toList(opts.argumentTypes),
-        optionTypes: toList(opts.optionTypes),
+        optionTypes,
+        argumentTypes,
         action: opts.action,
-        completer: opts.completer || (x => List()),
+        completer:
+            opts.completer ||
+            getDefaultCommandCompleter(optionTypes, argumentTypes),
     }
     commandRegistry.push(cmd)
     return cmd
 }
 
-export function getCompletionsForExstr(exstr: string): RArray<CompletionGroup> {
+export async function getCompletionsForExstr(
+    exstr: string,
+): Promise<RArray<CompletionGroup>> {
     const cmd = Util.extractCommandFromExstr(exstr)
     const expanded = Alias.expandCommand(cmd)
     const cmdSpec = commandRegistry.find(x => x.names.includes(expanded))
@@ -285,39 +118,111 @@ export function getCompletionsForExstr(exstr: string): RArray<CompletionGroup> {
     if (!cmdSpec) return []
 
     // Use the command's own completer
-    return cmdSpec.completer(exstr).toArray()
+    return (await cmdSpec.completer(exstr)).toArray()
 }
 
-type CompletionContext = "option-name" | "option-value" | "argument"
+const optionToCompletion = (opt: CmdOption): Completion => ({
+    // Title: '-f, --foo' or '--foo'
+    title: opt.short ? `-${opt.short}, --${opt.long}` : `--${opt.long}`,
+    description: opt.description,
+    // Completes into the long '--foo' upon hitting tab
+    completed: `--${opt.long}`,
+})
 
-function getDefaultCompleter(
+const completeOptionName = (options: List<CmdOption>) => (partial: string) =>
+    toList({
+        name: "Options",
+        selectable: true,
+        completions: options
+            .sortBy(x => levenshtein(partial, x.long))
+            .map(optionToCompletion),
+    })
+
+const completeArgument = (args: List<InputType>) => async (
+    tokens: List<string>,
+) => {
+    const joined = Util.joinAfter(args.size - 1, tokens)
+    const input = args.get(joined.size)!
+    const last = tokens.slice(-1).get(0)!
+    const comps = await input.getCompletions(last)
+    return toList(comps)
+}
+
+const completeOptionValue = async (option: CmdOption, partial: string) =>
+    toList(await option.type.getCompletions(partial))
+
+const isOpt = (t: string) => t.indexOf("-") === 0
+const isLongOpt = (t: string) => t.indexOf("--") === 0
+const isShortOpt = (t: string) => t.indexOf("-") === 0 && !isLongOpt(t)
+const isSingleShortOpt = (t: string) => isShortOpt(t) && t.length === 2
+const isMultipleShortOpt = (t: string) => isShortOpt(t) && t.length > 2
+const extractLongName = (t: string) =>
+    isLongOpt(t) ? t.match(/--(\w+)/)![1] : null
+const extractSingleShortName = (t: string) =>
+    isShortOpt(t) ? t.match(/-(\w+)/)![1] : null
+const extractLastShortName = (t: string) =>
+    isShortOpt(t) ? t.match(/-\w*(\w)/)![1] : null
+
+const getOptionFromToken = (opts: List<CmdOption>, tk: string) => {
+    if (isLongOpt(tk)) return opts.find(x => x.long === extractLongName(tk))
+    if (isOpt(tk)) return opts.find(x => x.short === extractLastShortName(tk))
+    // If it passes neither test, it's not an option
+    return undefined
+}
+
+const optionNotFound = (tk: string): CompletionGroup => ({
+    name: "ERROR: Option Not Found",
+    selectable: false,
+    completions: List.of({
+        title: `An option for the token '${tk}' could not be found.`,
+    }),
+})
+
+function getDefaultCommandCompleter(
     optionTypes: List<CmdOption>,
     argumentTypes: List<InputType>,
 ): Completer {
-    return exstr => {
-        // Step 1: tokenise
-        const tokens = Util.tokeniseOnWhitespace(exstr).splice(1)
+    const bools = optionTypes
+        .filter(x => x.type === IP_BOOLEAN)
+        .map(x => x.long)
+        .toArray()
 
-        // This shouldn't happen, since in means we're getting called when
-        // no command has been typed which means that we should be showing the
-        // command completer
-        if (Util.isEmpty(tokens)) throw Error("No command")
+    const aliases = Util.listToObjMap<string>(optionTypes, "long", "short")
+    const defaults = Util.listToObjMap<string>(optionTypes, "long", "default")
+    const parseOpts = { boolean: bools, alias: aliases, default: defaults }
 
-        // Step 2: determine which context we're using completions
+    const completeArgs = completeArgument(argumentTypes)
+    const completeOpts = completeOptionName(optionTypes)
 
-        return List()
-    }
-}
+    return async (exstr: string) => {
+        // TODO: show documentation as part of completions
 
-function getOptionsCompleter(optionTypes: List<CmdOption>): Completer {
-    return currentToken => {
-        // Sort by levenshtein distance between input and command's long name
-        const comps = optionTypes
-            .sortBy(x => levenshtein(currentToken, x.long))
-            .map(optionToComp)
-        return toList({
-            name: "Command Options",
-            completions: comps,
-        })
+        // The slice is to remove the first element, which should be the name
+        // of the command
+        const tokenArr = Util.tokeniseOnWhitespace(exstr).slice(1)
+        const parsed = minimist(tokenArr, parseOpts)
+        const tokens = toList(tokenArr)
+        const lastToken = tokens.get(-1)!
+        const tokenL2 = tokens.get(-2)
+        const argTokens = toList(parsed._)
+
+        // This is if the previous token was an option. We check if it's a
+        // valid option, where if it's not a boolean, we accept an argument,
+        // and if it is, we get the normal arguments completer
+        if (tokenL2 && isOpt(tokenL2)) {
+            const option = getOptionFromToken(optionTypes, tokenL2)
+            if (option) {
+                if (option.type === IP_BOOLEAN) return completeArgs(argTokens)
+                else return completeOptionValue(option, lastToken)
+            }
+            return toList(optionNotFound(tokenL2))
+        }
+
+        // If the previous token is not an option, and this is, then use the
+        // name completer
+        if (isOpt(lastToken)) return completeOpts(lastToken)
+
+        // If nobody is an option, use the normal arguments completer
+        return completeArgs(argTokens)
     }
 }

--- a/src/command_background.ts
+++ b/src/command_background.ts
@@ -1,0 +1,323 @@
+import { List, Map } from "immutable"
+import { MayList, toList, HistItem, RArray } from "./util"
+import minimist from "./minimist"
+import { get as levenshtein } from "fast-levenshtein"
+import * as I from "immutable"
+import * as Util from "./util"
+import * as Alias from "./aliases"
+import * as Config from "./config"
+
+let commandRegistry: CommandSpec[] = []
+type CmdAction = (ctx: CmdContext, ...args: any[]) => any
+type Completer = (exstr: string) => List<CompletionGroup>
+
+interface CmdContext {
+    readonly count: number
+    readonly options: Map<string, any>
+    readonly state: Map<string, any>
+}
+
+interface CmdOption {
+    readonly short?: string
+    readonly long: string
+    readonly type: InputType
+    readonly default?: any
+    readonly description?: string
+    readonly argname?: string
+}
+
+interface CommandSpec {
+    readonly names: List<string>
+    readonly description: string
+    readonly documentation: string
+    readonly argumentTypes: List<InputType>
+    readonly optionTypes: List<CmdOption>
+    readonly action: CmdAction
+    readonly completer: (exstr: string) => List<CompletionGroup>
+}
+
+export interface Completion {
+    readonly title: string
+    readonly description?: string
+    readonly icon?: URL
+    readonly flags?: string
+    readonly completed?: string
+}
+
+export interface CompletionGroup {
+    readonly name: string
+    readonly completions: List<Completion>
+}
+
+export interface InputType {
+    readonly getCompletions: (q: string) => Promise<MayList<CompletionGroup>>
+    readonly parseInput: (input: string) => Promise<any>
+}
+
+interface ParsedCommand {
+    readonly commandName: string
+    readonly options: Map<string, any>
+    readonly arguments: List<any>
+}
+
+/**
+ * Make an input with the provided list of completions
+ *
+ * @param name Name of the list
+ * @param comprehensive If true, the parser will reject strings not in the
+ * provided list
+ * @param l The list of completions
+ */
+export function makeListInput(
+    name: string,
+    comprehensive: boolean,
+    l: List<Completion>,
+): InputType {
+    const completed = l.map(x => x.completed)
+    return {
+        getCompletions: async i => {
+            const c = l
+                .filter(
+                    x =>
+                        x.title.includes(i) ||
+                        (x.description && x.description.includes(i)),
+                )
+                .sortBy(x => x.title)
+            return {
+                name: name,
+                completions: c,
+            }
+        },
+        parseInput: async i => {
+            if (!comprehensive) return i
+            if (completed.includes(i)) return i
+            throw Error(`Argument '${i}' is not valid`)
+        },
+    }
+}
+
+export function stringListToComp(...l: string[]): List<Completion> {
+    return List(l.map(x => ({ title: x })))
+}
+
+export const SEARCH_ENGINE_INPUT: InputType = {
+    getCompletions: async i => {
+        const cfg = Config.get("searchurls") as object
+        // 'searchurls' is a map of engine -> searchurl
+        const comps = stringListToComp(...Object.keys(cfg))
+        return {
+            name: "Search Engines",
+            completions: comps,
+        }
+    },
+    parseInput: async i => i,
+}
+
+export const STRING_INPUT: InputType = {
+    getCompletions: async i => ({ name: "String", completions: List() }),
+    parseInput: async i => i,
+}
+
+export const AUCMD_EVENTS_INPUT: InputType = makeListInput(
+    "AutoCommand Events",
+    true,
+    stringListToComp("DocStart"),
+)
+
+export const BOOLEAN_INPUT: InputType = {
+    ...makeListInput("True/False", false, stringListToComp("true", "false")),
+    parseInput: async i => Util.parseBool(i),
+}
+
+export const HISTORY_INPUT: InputType = {
+    getCompletions: async i => {
+        const h = await browser.history.search({ text: i, maxResults: 20 })
+        const transformed = toList(h)
+            // One day the TS compiler will be smart enough to see the filter
+            // below as a null check
+            .filter(x => x.title && x.visitCount && x.url)
+            .sortBy(x => x.visitCount!)
+            .map(x => ({
+                title: x.title!,
+                description: x.url!,
+                completed: x.url!,
+            }))
+        return {
+            name: "History",
+            completions: transformed,
+        }
+    },
+    parseInput: async i => new URL(i),
+}
+
+export const BMARK_INPUT: InputType = {
+    getCompletions: async i => {
+        const query = await browser.bookmarks.search(i)
+        const mapped = toList(query)
+            .filter(x => x.url)
+            .map(x => ({
+                title: x.title,
+                description: x.url,
+                completed: x.url,
+            }))
+        return {
+            name: "Bookmarks",
+            completions: mapped,
+        }
+    },
+    parseInput: async i => new URL(i),
+}
+
+export const CONTXID_INPUT: InputType = {
+    getCompletions: async i => {
+        const query = await browser.contextualIdentities.query({ name: i })
+        const comps = toList(query).map(x => ({
+            title: x.name,
+            // TODO: add icon to the completions
+            completed: x.cookieStoreId,
+        }))
+        return {
+            name: "Contextual Identities",
+            completions: comps,
+        }
+    },
+    parseInput: async i => {
+        const c = browser.contextualIdentities.get(i)
+        if (!i) throw Error(`Contextual Identity ${i} not found`)
+        return c
+    },
+}
+
+function tabToComp(t: BrowserTab): Completion | null {
+    if (!t.url || !t.title) return null
+
+    let flags = ""
+    if (t.active) flags += "%"
+    if (t.pinned) flags += "@"
+    // if (t.isInReaderMode) flags += "R"
+
+    const icon = t.favIconUrl ? new URL(t.favIconUrl) : undefined
+
+    return {
+        title: `${t.index}: ${t.title}`,
+        description: t.url,
+        icon: icon,
+        completed: t.index.toString(),
+    }
+}
+
+export const TAB_INPUT: InputType = {
+    getCompletions: async i => {
+        const q = await browser.tabs.query({ title: i })
+        const comps = toList(q)
+            .map(tabToComp)
+            // TS doesn't recognise the null filter
+            .filter(Boolean) as List<Completion>
+        return {
+            name: "Tabs",
+            completions: comps,
+        }
+    },
+    parseInput: async i => {
+        const idx = parseInt(i)
+        return browser.tabs.query({ currentWindow: true, index: idx })[0]
+    },
+}
+
+export const EXSTR_INPUT: InputType = {
+    getCompletions: async i => List(getCompletionsForExstr(i)),
+    parseInput: async i => i,
+}
+
+const optionToComp = (opt: CmdOption): Completion => ({
+    /** Example: '-f, --foobar' */
+    title: `-${opt.short}, --${opt.long}`,
+    description: opt.description,
+    completed: "--" + opt.long,
+})
+
+/**
+ * Parse a list of specs for the name of a command. Adapted from vimperator.
+ *
+ * @param specs A list of specs
+ */
+function parseNameSpecs(specs: string | string[]): List<string> {
+    const l = toList(specs).map(spec => {
+        const m = spec.match(/([^[]+)(?:\[(.*)])?/)
+        if (!m) throw Error("Specs cannot be empty")
+        const [_, head, tail] = m
+        return List.of(head + tail, tail)
+    })
+    return Util.flattenList(l).filter(Boolean)
+}
+
+export function registerNewCommand(
+    name: string,
+    opts: {
+        nameSpecs: string | string[]
+        description: string
+        documentation?: string
+        argumentTypes?: InputType | InputType[]
+        optionTypes?: CmdOption | CmdOption[]
+        action: CmdAction
+        completer?: (exstr: string) => List<CompletionGroup>
+    },
+): CommandSpec {
+    const cmd: CommandSpec = {
+        names: parseNameSpecs(opts.nameSpecs),
+        description: opts.description,
+        documentation: opts.documentation || "No documentation provided",
+        argumentTypes: toList(opts.argumentTypes),
+        optionTypes: toList(opts.optionTypes),
+        action: opts.action,
+        completer: opts.completer || (x => List()),
+    }
+    commandRegistry.push(cmd)
+    return cmd
+}
+
+export function getCompletionsForExstr(exstr: string): RArray<CompletionGroup> {
+    const cmd = Util.extractCommandFromExstr(exstr)
+    const expanded = Alias.expandCommand(cmd)
+    const cmdSpec = commandRegistry.find(x => x.names.includes(expanded))
+
+    // Command not found
+    if (!cmdSpec) return []
+
+    // Use the command's own completer
+    return cmdSpec.completer(exstr).toArray()
+}
+
+type CompletionContext = "option-name" | "option-value" | "argument"
+
+function getDefaultCompleter(
+    optionTypes: List<CmdOption>,
+    argumentTypes: List<InputType>,
+): Completer {
+    return exstr => {
+        // Step 1: tokenise
+        const tokens = Util.tokeniseOnWhitespace(exstr).splice(1)
+
+        // This shouldn't happen, since in means we're getting called when
+        // no command has been typed which means that we should be showing the
+        // command completer
+        if (Util.isEmpty(tokens)) throw Error("No command")
+
+        // Step 2: determine which context we're using completions
+
+        return List()
+    }
+}
+
+function getOptionsCompleter(optionTypes: List<CmdOption>): Completer {
+    return currentToken => {
+        // Sort by levenshtein distance between input and command's long name
+        const comps = optionTypes
+            .sortBy(x => levenshtein(currentToken, x.long))
+            .map(optionToComp)
+        return toList({
+            name: "Command Options",
+            completions: comps,
+        })
+    }
+}

--- a/src/command_inputs.ts
+++ b/src/command_inputs.ts
@@ -1,0 +1,197 @@
+import { List, Map } from "immutable"
+import { BrowserTab, MayList, toList, HistItem, RArray } from "./util"
+import { get as levenshtein } from "fast-levenshtein"
+import {
+    getCompletionsForExstr,
+    CmdOption,
+    Completion,
+    InputType,
+} from "./command_background"
+import * as Util from "./util"
+import * as Config from "./config"
+
+/**
+ * Make an input with the provided list of completions
+ *
+ * @param name Name of the list
+ * @param comprehensive If true, the parser will reject strings not in the
+ * provided list
+ * @param l The list of completions
+ */
+export function makeListInput(
+    name: string,
+    comprehensive: boolean,
+    l: List<Completion>,
+): InputType {
+    const completed = l.map(x => x.completed)
+    return {
+        getCompletions: async i => {
+            const c = l
+                .filter(
+                    x =>
+                        x.title.includes(i) ||
+                        (x.description && x.description.includes(i)),
+                )
+                .sortBy(x => levenshtein(i, x.title))
+            return {
+                name: name,
+                selectable: true,
+                completions: c,
+            }
+        },
+        parseInput: async i => {
+            if (!comprehensive) return i
+            if (completed.includes(i)) return i
+            throw Error(`Argument '${i}' is not valid`)
+        },
+    }
+}
+
+export function stringListToComp(...l: string[]): List<Completion> {
+    return List(l.map(x => ({ title: x })))
+}
+
+export const IP_SEARCH_ENGINE: InputType = {
+    getCompletions: async i => {
+        const cfg = Config.get("searchurls") as object
+        // 'searchurls' is a map of engine -> searchurl
+        const comps = stringListToComp(...Object.keys(cfg))
+        return {
+            name: "Search Engines",
+            selectable: true,
+            completions: comps,
+        }
+    },
+    parseInput: async i => i,
+}
+
+export const IP_STRING: InputType = {
+    getCompletions: async i => ({
+        name: "String",
+        selectable: true,
+        completions: List(),
+    }),
+    parseInput: async i => i,
+}
+
+export const IP_AUCMD_EVENTS: InputType = makeListInput(
+    "AutoCommand Events",
+    true,
+    stringListToComp("DocStart"),
+)
+
+export const IP_BOOLEAN: InputType = {
+    ...makeListInput("True/False", false, stringListToComp("true", "false")),
+    parseInput: async i => Util.parseBool(i),
+}
+
+export const IP_HISTORY: InputType = {
+    getCompletions: async i => {
+        const h = await browser.history.search({ text: i, maxResults: 20 })
+        const transformed = toList(h)
+            // One day the TS compiler will be smart enough to see the filter
+            // below as a null check
+            .filter(x => x.title && x.visitCount && x.url)
+            .sortBy(x => x.visitCount!)
+            .map(x => ({
+                title: x.title!,
+                description: x.url!,
+                completed: x.url!,
+            }))
+        return {
+            name: "History",
+            selectable: true,
+            completions: transformed,
+        }
+    },
+    parseInput: async i => new URL(i),
+}
+
+export const IP_BOOKMARK: InputType = {
+    getCompletions: async i => {
+        const query = await browser.bookmarks.search(i)
+        const mapped = toList(query)
+            .filter(x => x.url)
+            .map(x => ({
+                title: x.title,
+                description: x.url,
+                completed: x.url,
+            }))
+        return {
+            name: "Bookmarks",
+            selectable: true,
+            completions: mapped,
+        }
+    },
+    parseInput: async i => new URL(i),
+}
+
+export const IP_CONTEXT_ID: InputType = {
+    getCompletions: async i => {
+        const query = await browser.contextualIdentities.query({ name: i })
+        const comps = toList(query).map(x => ({
+            title: x.name,
+            // TODO: add icon to the completions
+            completed: x.cookieStoreId,
+        }))
+        return {
+            name: "Contextual Identities",
+            selectable: true,
+            completions: comps,
+        }
+    },
+    parseInput: async i => {
+        const c = browser.contextualIdentities.get(i)
+        if (!i) throw Error(`Contextual Identity ${i} not found`)
+        return c
+    },
+}
+
+function tabToComp(t: BrowserTab): Completion | null {
+    if (!t.url || !t.title) return null
+
+    let flags = ""
+    if (t.active) flags += "%"
+    if (t.pinned) flags += "@"
+    // if (t.isInReaderMode) flags += "R"
+
+    const icon = t.favIconUrl ? new URL(t.favIconUrl) : undefined
+
+    return {
+        title: `${t.index}: ${t.title}`,
+        description: t.url,
+        icon: icon,
+        completed: t.index.toString(),
+    }
+}
+
+export const IP_TAB: InputType = {
+    getCompletions: async i => {
+        const q = await browser.tabs.query({ title: i })
+        const comps = toList(q)
+            .map(tabToComp)
+            // TS doesn't recognise the null filter
+            .filter(Boolean) as List<Completion>
+        return {
+            name: "Tabs",
+            selectable: true,
+            completions: comps,
+        }
+    },
+    parseInput: async i => {
+        const idx = parseInt(i)
+        return browser.tabs.query({ currentWindow: true, index: idx })[0]
+    },
+}
+
+export const EXSTR_INPUT: InputType = {
+    getCompletions: async i => List(await getCompletionsForExstr(i)),
+    parseInput: async i => i,
+}
+
+const optionToComp = (opt: CmdOption): Completion => ({
+    /** Example: '-f, --foobar' */
+    title: `-${opt.short}, --${opt.long}`,
+    description: opt.description,
+    completed: "--" + opt.long,
+})

--- a/src/command_list.ts
+++ b/src/command_list.ts
@@ -1,13 +1,20 @@
 import { registerNewCommand } from "./command_background"
 import * as CB from "./command_background"
+import {
+    IP_BOOLEAN,
+    IP_STRING,
+    IP_AUCMD_EVENTS,
+    IP_HISTORY,
+    IP_SEARCH_ENGINE,
+} from "./command_inputs"
 
-const OPT_NEWTAB = { short: "t", long: "newtab", type: CB.BOOLEAN_INPUT }
-const OPT_NEWWIN = { short: "w", long: "newwindow", type: CB.BOOLEAN_INPUT }
+const OPT_NEWTAB = { short: "t", long: "newtab", type: IP_BOOLEAN }
+const OPT_NEWWIN = { short: "w", long: "newwindow", type: IP_BOOLEAN }
 
 const autocmd = registerNewCommand("autocmd", {
     nameSpecs: ["aucmd", "autocmd"],
     description: "Set autocmds to run when certain events happen.",
-    argumentTypes: [CB.AUCMD_EVENTS_INPUT, CB.STRING_INPUT],
+    argumentTypes: [IP_AUCMD_EVENTS, IP_STRING],
     optionTypes: [],
     action: (ctx, ev: string, cmd: string) => {},
 })
@@ -16,7 +23,7 @@ const open = registerNewCommand("open", {
     nameSpecs: "o[pen]",
     description: "Open a url",
     documentation: "",
-    argumentTypes: [CB.HISTORY_INPUT],
+    argumentTypes: [IP_HISTORY],
     optionTypes: [OPT_NEWTAB, OPT_NEWWIN],
     action: (ctx, url: string) => {},
 })
@@ -24,7 +31,7 @@ const open = registerNewCommand("open", {
 const search = registerNewCommand("search", {
     nameSpecs: "s[earch]",
     description: "Search the internet",
-    argumentTypes: [CB.SEARCH_ENGINE_INPUT, CB.STRING_INPUT],
+    argumentTypes: [IP_SEARCH_ENGINE, IP_STRING],
     optionTypes: [OPT_NEWTAB, OPT_NEWWIN],
     action: (ctx, s: string) => {},
 })

--- a/src/command_list.ts
+++ b/src/command_list.ts
@@ -1,0 +1,30 @@
+import { registerNewCommand } from "./command_background"
+import * as CB from "./command_background"
+
+const OPT_NEWTAB = { short: "t", long: "newtab", type: CB.BOOLEAN_INPUT }
+const OPT_NEWWIN = { short: "w", long: "newwindow", type: CB.BOOLEAN_INPUT }
+
+const autocmd = registerNewCommand("autocmd", {
+    nameSpecs: ["aucmd", "autocmd"],
+    description: "Set autocmds to run when certain events happen.",
+    argumentTypes: [CB.AUCMD_EVENTS_INPUT, CB.STRING_INPUT],
+    optionTypes: [],
+    action: (ctx, ev: string, cmd: string) => {},
+})
+
+const open = registerNewCommand("open", {
+    nameSpecs: "o[pen]",
+    description: "Open a url",
+    documentation: "",
+    argumentTypes: [CB.HISTORY_INPUT],
+    optionTypes: [OPT_NEWTAB, OPT_NEWWIN],
+    action: (ctx, url: string) => {},
+})
+
+const search = registerNewCommand("search", {
+    nameSpecs: "s[earch]",
+    description: "Search the internet",
+    argumentTypes: [CB.SEARCH_ENGINE_INPUT, CB.STRING_INPUT],
+    optionTypes: [OPT_NEWTAB, OPT_NEWWIN],
+    action: (ctx, s: string) => {},
+})

--- a/src/messaging.ts
+++ b/src/messaging.ts
@@ -9,11 +9,14 @@ export type TabMessageType =
     | "commandline_frame"
     | "hinting_content"
     | "finding_content"
+
 export type NonTabMessageType =
     | "keydown_background"
     | "commandline_background"
     | "browser_proxy_background"
     | "download_background"
+    | "command_background"
+
 export type MessageType = TabMessageType | NonTabMessageType
 
 export interface Message {

--- a/src/minimist.ts
+++ b/src/minimist.ts
@@ -1,0 +1,302 @@
+/**
+ * Copied from substack/minimist and the corresponding DefinitelyTyped definitions
+ */
+export default function minimist(
+    args: string[],
+    opts?: {
+        /**
+         * A string or array of strings argument names to always treat as strings
+         */
+        string?: string | string[]
+
+        /**
+         * A boolean, string or array of strings to always treat as booleans. If true will treat
+         * all double hyphenated arguments without equals signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
+         */
+        boolean?: boolean | string | string[]
+
+        /**
+         * An object mapping string names to strings or arrays of string argument names to use as aliases
+         */
+        alias?: { [key: string]: string | string[] }
+
+        /**
+         * An object mapping string argument names to default values
+         */
+        default?: { [key: string]: any }
+
+        /**
+         * When true, populate argv._ with everything after the first non-option
+         */
+        stopEarly?: boolean
+
+        /**
+         * A function which is invoked with a command line parameter not defined in the opts
+         * configuration object. If the function returns false, the unknown option is not added to argv
+         */
+        unknown?: (arg: string) => boolean
+
+        /**
+         * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --.
+         * Note that with -- set, parsing for arguments still stops after the `--`.
+         */
+        "--"?: boolean
+    },
+): {
+    [arg: string]: any
+
+    /**
+     * If opts['--'] is true, populated with everything after the --
+     */
+    "--"?: string[]
+
+    /**
+     * Contains all the arguments that didn't have an option associated with them
+     */
+    _: string[]
+} {
+    if (!opts) opts = {}
+
+    var flags = { bools: {}, strings: {}, unknownFn: null as any }
+
+    if (typeof opts["unknown"] === "function") {
+        flags.unknownFn = opts["unknown"]
+    }
+
+    if (typeof opts["boolean"] === "boolean" && opts["boolean"]) {
+        flags.allBools = true
+    } else {
+        ;[]
+            .concat(opts["boolean"])
+            .filter(Boolean)
+            .forEach(function(key) {
+                flags.bools[key] = true
+            })
+    }
+
+    var aliases = {}
+    Object.keys(opts.alias || {}).forEach(function(key) {
+        aliases[key] = [].concat(opts.alias[key])
+        aliases[key].forEach(function(x) {
+            aliases[x] = [key].concat(
+                aliases[key].filter(function(y) {
+                    return x !== y
+                }),
+            )
+        })
+    })
+    ;[]
+        .concat(opts.string)
+        .filter(Boolean)
+        .forEach(function(key) {
+            flags.strings[key] = true
+            if (aliases[key]) {
+                flags.strings[aliases[key]] = true
+            }
+        })
+
+    var defaults = opts["default"] || {}
+
+    var argv = { _: [] }
+    Object.keys(flags.bools).forEach(function(key) {
+        setArg(key, defaults[key] === undefined ? false : defaults[key])
+    })
+
+    var notFlags = []
+
+    if (args.indexOf("--") !== -1) {
+        notFlags = args.slice(args.indexOf("--") + 1)
+        args = args.slice(0, args.indexOf("--"))
+    }
+
+    function argDefined(key, arg) {
+        return (
+            (flags.allBools && /^--[^=]+$/.test(arg)) ||
+            flags.strings[key] ||
+            flags.bools[key] ||
+            aliases[key]
+        )
+    }
+
+    function setArg(key, val, arg) {
+        if (arg && flags.unknownFn && !argDefined(key, arg)) {
+            if (flags.unknownFn(arg) === false) return
+        }
+
+        var value = !flags.strings[key] && isNumber(val) ? Number(val) : val
+        setKey(argv, key.split("."), value)
+        ;(aliases[key] || []).forEach(function(x) {
+            setKey(argv, x.split("."), value)
+        })
+    }
+
+    function setKey(obj, keys, value) {
+        var o = obj
+        keys.slice(0, -1).forEach(function(key) {
+            if (o[key] === undefined) o[key] = {}
+            o = o[key]
+        })
+
+        var key = keys[keys.length - 1]
+        if (
+            o[key] === undefined ||
+            flags.bools[key] ||
+            typeof o[key] === "boolean"
+        ) {
+            o[key] = value
+        } else if (Array.isArray(o[key])) {
+            o[key].push(value)
+        } else {
+            o[key] = [o[key], value]
+        }
+    }
+
+    function aliasIsBoolean(key) {
+        return aliases[key].some(function(x) {
+            return flags.bools[x]
+        })
+    }
+
+    for (var i = 0; i < args.length; i++) {
+        var arg = args[i]
+
+        if (/^--.+=/.test(arg)) {
+            // Using [\s\S] instead of . because js doesn't support the
+            // 'dotall' regex modifier. See:
+            // http://stackoverflow.com/a/1068308/13216
+            var m = arg.match(/^--([^=]+)=([\s\S]*)$/)
+            var key = m[1]
+            var value = m[2]
+            if (flags.bools[key]) {
+                value = value !== "false"
+            }
+            setArg(key, value, arg)
+        } else if (/^--no-.+/.test(arg)) {
+            var key = arg.match(/^--no-(.+)/)[1]
+            setArg(key, false, arg)
+        } else if (/^--.+/.test(arg)) {
+            var key = arg.match(/^--(.+)/)[1]
+            var next = args[i + 1]
+            if (
+                next !== undefined &&
+                !/^-/.test(next) &&
+                !flags.bools[key] &&
+                !flags.allBools &&
+                (aliases[key] ? !aliasIsBoolean(key) : true)
+            ) {
+                setArg(key, next, arg)
+                i++
+            } else if (/^(true|false)$/.test(next)) {
+                setArg(key, next === "true", arg)
+                i++
+            } else {
+                setArg(key, flags.strings[key] ? "" : true, arg)
+            }
+        } else if (/^-[^-]+/.test(arg)) {
+            var letters = arg.slice(1, -1).split("")
+
+            var broken = false
+            for (var j = 0; j < letters.length; j++) {
+                var next = arg.slice(j + 2)
+
+                if (next === "-") {
+                    setArg(letters[j], next, arg)
+                    continue
+                }
+
+                if (/[A-Za-z]/.test(letters[j]) && /=/.test(next)) {
+                    setArg(letters[j], next.split("=")[1], arg)
+                    broken = true
+                    break
+                }
+
+                if (
+                    /[A-Za-z]/.test(letters[j]) &&
+                    /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)
+                ) {
+                    setArg(letters[j], next, arg)
+                    broken = true
+                    break
+                }
+
+                if (letters[j + 1] && letters[j + 1].match(/\W/)) {
+                    setArg(letters[j], arg.slice(j + 2), arg)
+                    broken = true
+                    break
+                } else {
+                    setArg(
+                        letters[j],
+                        flags.strings[letters[j]] ? "" : true,
+                        arg,
+                    )
+                }
+            }
+
+            var key = arg.slice(-1)[0]
+            if (!broken && key !== "-") {
+                if (
+                    args[i + 1] &&
+                    !/^(-|--)[^-]/.test(args[i + 1]) &&
+                    !flags.bools[key] &&
+                    (aliases[key] ? !aliasIsBoolean(key) : true)
+                ) {
+                    setArg(key, args[i + 1], arg)
+                    i++
+                } else if (args[i + 1] && /true|false/.test(args[i + 1])) {
+                    setArg(key, args[i + 1] === "true", arg)
+                    i++
+                } else {
+                    setArg(key, flags.strings[key] ? "" : true, arg)
+                }
+            }
+        } else {
+            if (!flags.unknownFn || flags.unknownFn(arg) !== false) {
+                argv._.push(
+                    flags.strings["_"] || !isNumber(arg) ? arg : Number(arg),
+                )
+            }
+            if (opts.stopEarly) {
+                argv._.push.apply(argv._, args.slice(i + 1))
+                break
+            }
+        }
+    }
+
+    Object.keys(defaults).forEach(function(key) {
+        if (!hasKey(argv, key.split("."))) {
+            setKey(argv, key.split("."), defaults[key])
+            ;(aliases[key] || []).forEach(function(x) {
+                setKey(argv, x.split("."), defaults[key])
+            })
+        }
+    })
+
+    if (opts["--"]) {
+        argv["--"] = new Array()
+        notFlags.forEach(function(key) {
+            argv["--"].push(key)
+        })
+    } else {
+        notFlags.forEach(function(key) {
+            argv._.push(key)
+        })
+    }
+
+    return argv
+}
+
+function hasKey(obj, keys) {
+    var o = obj
+    keys.slice(0, -1).forEach(function(key) {
+        o = o[key] || {}
+    })
+
+    var key = keys[keys.length - 1]
+    return key in o
+}
+
+function isNumber(x) {
+    if (typeof x === "number") return true
+    if (/^0x[0-9a-f]+$/i.test(x)) return true
+    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x)
+}

--- a/src/minimist.ts
+++ b/src/minimist.ts
@@ -57,7 +57,7 @@ export default function minimist(
 } {
     if (!opts) opts = {}
 
-    var flags = { bools: {}, strings: {}, unknownFn: null as any }
+    var flags: any = { bools: {}, strings: {}, unknownFn: null as any }
 
     if (typeof opts["unknown"] === "function") {
         flags.unknownFn = opts["unknown"]
@@ -99,7 +99,11 @@ export default function minimist(
 
     var argv = { _: [] }
     Object.keys(flags.bools).forEach(function(key) {
-        setArg(key, defaults[key] === undefined ? false : defaults[key])
+        setArg(
+            key,
+            defaults[key] === undefined ? false : defaults[key],
+            undefined,
+        )
     })
 
     var notFlags = []
@@ -166,7 +170,7 @@ export default function minimist(
             // http://stackoverflow.com/a/1068308/13216
             var m = arg.match(/^--([^=]+)=([\s\S]*)$/)
             var key = m[1]
-            var value = m[2]
+            var value: any = m[2]
             if (flags.bools[key]) {
                 value = value !== "false"
             }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,95 @@
+import { List, Map } from "immutable"
+
+export type MayPromise<T> = T | Promise<T>
+export type Maybe<T> = T | null
+export type MayArray<T> = T | T[]
+export type MayList<T> = T | List<T>
+export type ContxID = browser.contextualIdentities.ContextualIdentity
+export type BrowserTab = browser.tabs.Tab
+export type HistItem = browser.history.HistoryItem
+export type Bookmark = browser.bookmarks.BookmarkTreeNode
+export type RArray<T> = ReadonlyArray<T>
+export type OMAP<T> = { [k: string]: T }
+
+/**
+ * Takes a list of strings and joins all the strings after x
+ *
+ * @param x Index after which args should be joined together
+ * @param list List of strings
+ */
+export function joinAfter(x: number, list: List<string>): List<string> {
+    const head = list.slice(0, x - 1)
+    const tail = list.slice(x).join(" ")
+    return head.concat(tail)
+}
+
+export function parseBool(str: string): boolean {
+    if (str === "true") return true
+    if (str === "false") return false
+    throw Error(`'${str}' is not a boolean`)
+}
+
+export const identity = <T>(x: T) => x
+export const flattenList = <T>(list: List<List<T>>): List<T> =>
+    List().concat(...list)
+export const flattenArray = <T>(arr: T[][]): T[] =>
+    Array.prototype.concat(...arr)
+export const unimplemented = () => {
+    throw Error("this functionality is not yet implemented")
+}
+export const isContentScript = () => !("tabs" in browser)
+export const isEmpty = (l: { length: number }) => l.length === 0
+
+export async function getStorage(key: string): Promise<any> {
+    const store = await browser.storage.sync.get(key)
+    return store[key]
+}
+
+export async function setStorage(
+    key: string,
+    store: browser.storage.StorageValue,
+): Promise<void> {
+    browser.storage.sync.set({ [key]: store })
+}
+
+export function toArray<T>(arg: T | T[] | null | undefined): T[] {
+    if (!arg) return []
+    return Array.isArray(arg) ? arg : [arg]
+}
+
+export function toList<T>(arg: T | T[] | List<T> | null | undefined): List<T> {
+    if (!arg) return List()
+    if (List.isList(arg)) return arg
+    if (Array.isArray(arg)) return List(arg)
+    return List.of(arg)
+}
+
+export function errorIfNull<T>(
+    a: T | null | undefined,
+    emsg = "Value not found",
+): T {
+    if (a) return a
+    throw Error(emsg)
+}
+
+export const tokeniseOnWhitespace = (s: string) => s.trim().split(/\s+/)
+
+/**
+ * Extracts the command name from the raw exstring. The command is always the
+ * first space-delimited token
+ *
+ * @param exstr The raw exstr
+ */
+export const extractCommandFromExstr = (exstr: string) =>
+    tokeniseOnWhitespace(exstr)[0]
+
+export function listToObjMap<V>(
+    list: List<any>,
+    key: string,
+    val: string,
+): { [key: string]: V } {
+    return list.filter(x => x[val]).reduce((obj, item) => {
+        obj[item[key]] = item[val]
+        return obj
+    }, {})
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,15 +12,19 @@ export type RArray<T> = ReadonlyArray<T>
 export type OMAP<T> = { [k: string]: T }
 
 /**
- * Takes a list of strings and joins all the strings after x
+ * Takes a list of strings and joins all the strings after x. Ex:
+ * `['a', 'b', 'c', 'd'] at x=1 => ['ab', 'cd']` since 1 is 'b' and everything
+ * after that is joined together
  *
- * @param x Index after which args should be joined together
+ * @param x 0-based index after which elements are joined
  * @param list List of strings
  */
 export function joinAfter(x: number, list: List<string>): List<string> {
-    const head = list.slice(0, x - 1)
-    const tail = list.slice(x).join(" ")
-    return head.concat(tail)
+    const i = x - 1
+    const head = list.slice(0, i)
+    const tail = list.slice(i)
+    if (isListEmpty(tail)) return list
+    return head.concat(tail.join(" "))
 }
 
 export function parseBool(str: string): boolean {
@@ -39,6 +43,7 @@ export const unimplemented = () => {
 }
 export const isContentScript = () => !("tabs" in browser)
 export const isEmpty = (l: { length: number }) => l.length === 0
+export const isListEmpty = (l: List<any>) => l.size === 0
 
 export async function getStorage(key: string): Promise<any> {
     const store = await browser.storage.sync.get(key)
@@ -72,7 +77,7 @@ export function errorIfNull<T>(
     throw Error(emsg)
 }
 
-export const tokeniseOnWhitespace = (s: string) => s.trim().split(/\s+/)
+export const tokeniseOnWhitespace = (s: string) => s.split(/\s+/)
 
 /**
  * Extracts the command name from the raw exstring. The command is always the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "target": "ES2017",
     "lib": ["ES2017","dom", "dom.iterable"],
     "typeRoots": ["node_modules/@types", "node_modules/web-ext-types/"],
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "strictNullChecks": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Completely rewrite the completion engine to have real support for options and documentation and the parser with a formal grammar.

Goals:
1. Implement support for gnu-style `-f --foo` arguments
2. Let devs make a formal spec of each command and the options/arguments that are accepted
3. Completions generation based on the spec mentioned in 2

Why?
- We need a real parser
- Our current completions system is ... a thing that exists and is in danger of falling apart at the slightest touch
- Instead of one command with several options, we have multiple command that do their own options parsing all over the place and do it poorly

What would this solve?
- Command discovery
- Speed of command input (via tab completions)
- Error reporting (when the parser detects an error)