### PR TITLE
{config,excmds}.ts: Implement DocBlur/DocFocus autocommands

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -263,6 +263,20 @@ class default_config {
      */
     autocmds = {
         /**
+         * Commands that will be run every time the javascript "blur" event is triggered on a page.
+         *
+         * Each key corresponds to a URL fragment which, if contained within the page URL, will run the corresponding command.
+         */
+        DocBlur: {},
+
+        /**
+         * Commands that will be run every time the javascript "focus" event is triggered on a page.
+         *
+         * Each key corresponds to a URL fragment which, if contained within the page URL, will run the corresponding command.
+         */
+        DocFocus: {},
+
+        /**
          * Commands that will be run as soon as Tridactyl loads into a page.
          *
          * Each key corresponds to a URL fragment which, if contained within the page URL, will run the corresponding command.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1788,11 +1788,13 @@ export async function reader() {
 loadaucmds("DocStart")
 window.addEventListener("pagehide", () => loadaucmds("DocEnd"))
 window.addEventListener("DOMContentLoaded", () => loadaucmds("DocLoad"))
+document.addEventListener("blur", () => loadaucmds("DocBlur"))
+document.addEventListener("focus", () => loadaucmds("DocFocus"))
 // }
 
 /** @hidden */
 //#content
-export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "TabEnter" | "TabLeft") {
+export async function loadaucmds(cmdType: "DocBlur" | "DocFocus" | "DocStart" | "DocLoad" | "DocEnd" | "TabEnter" | "TabLeft") {
     let aucmds = await config.getAsync("autocmds", cmdType)
     const ausites = Object.keys(aucmds)
     const aukeyarr = ausites.filter(e => window.document.location.href.search(e) >= 0)
@@ -3094,19 +3096,16 @@ export function set(key: string, ...values: string[]) {
 
 /** @hidden */
 //#background_helper
-let AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft"]
+let AUCMDS = ["DocFocus", "DocBlur", "DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft"]
 /** Set autocmds to run when certain events happen.
 
- @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter' and 'TabLeft' are supported.
+ @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'DocFocus', 'DocBlur', 'TabEnter' and 'TabLeft' are supported.
 
- @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
+ @param url For DocStart, DocEnd, DocFocus, DocBlur, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
 
  We just use [URL.search](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/search).
 
- For TriStart: A regular expression that matches the hostname of the computer
- the autocmd should be run on. This requires the native messenger to be
- installed, except for the ".*" regular expression which will always be
- triggered, even without the native messenger.
+ For TriStart: A regular expression that matches the hostname of the computer the autocmd should be run on. This requires the native messenger to be installed, except for the ".*" regular expression which will always be triggered, even without the native messenger.
 
  @param excmd The excmd to run (use [[composite]] to run multiple commands)
 


### PR DESCRIPTION
This implements the DocFocus/DocBlur events discussed in https://github.com/cmcaine/tridactyl/issues/57 .
Unfortunately I'm hitting https://github.com/cmcaine/tridactyl/issues/727 , DocBlur is triggered in the newly-focused tab rather than the one it should be triggered in.
I believe this can be fixed by https://github.com/cmcaine/tridactyl/issues/434 .

Closes #1109