### PR TITLE
[RFC] Fix #639: pepper code with awaits and hides until it works

### DIFF
--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -47,7 +47,7 @@ async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
 }
 
 export async function show(focus = true) {
-    Messaging.messageActiveTab("commandline_content", "show")
+    await Messaging.messageActiveTab("commandline_content", "show")
     if (focus) {
         await Messaging.messageActiveTab("commandline_content", "focus")
         await Messaging.messageActiveTab("commandline_frame", "focus")

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2114,8 +2114,8 @@ export async function sleep(time_ms: number) {
 
 /** @hidden */
 //#background
-function showcmdline(focus = true) {
-    CommandLineBackground.show(focus)
+async function showcmdline(focus = true) {
+    await CommandLineBackground.show(focus)
 }
 
 /** @hidden */
@@ -2126,9 +2126,9 @@ export function hidecmdline() {
 
 /** Set the current value of the commandline to string *with* a trailing space */
 //#background
-export function fillcmdline(...strarr: string[]) {
+export async function fillcmdline(...strarr: string[]) {
     let str = strarr.join(" ")
-    showcmdline()
+    await showcmdline()
     messageActiveTab("commandline_frame", "fillcmdline", [str])
 }
 


### PR DESCRIPTION
Might also fix some of #804 (but, as I recall, these tabs probably already have had the iframe opened on them as they were around for a while).

I don't have time to work on this any more today, so I'd be delighted if someone could take this up.

There's probably a few race conditions lying around that necessitate the use of `hide`.

As a bonus, this means that the command line and iframe flashes madly as you type.