### PR TITLE
Fix JavaScript-Python Unicode issues on Windows

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -463,7 +463,7 @@ def handleMessage(message):
                 os.path.expandvars(
                     os.path.expanduser(message["file"])
                 ),
-                "rb",
+                "r",
             ) as file:
                 message_content = file.read()
                 reply["content"] = message_content
@@ -481,8 +481,9 @@ def handleMessage(message):
         reply["code"] = 0
 
     elif cmd == "write":
-        with open(message["file"], "wb") as file:
-            content = ipc_decode(message["content"])
+        with open(message["file"], "w") as file:
+            content = message.get("b64content")
+            content = ipc_decode(content) if content else message["content"]
             file.write(content)
 
     elif cmd == "temp":
@@ -493,7 +494,8 @@ def handleMessage(message):
 
         (handle, filepath) = tempfile.mkstemp(prefix=prefix)
         with open(handle, "wb") as file:
-            content = ipc_decode(message["content"])
+            content = message.get("b64content")
+            content = ipc_decode(content) if content else message["content"]
             file.write(content)
 
         reply["content"] = filepath

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -87,6 +87,9 @@ def getMessage():
 # given its content.
 def encodeMessage(messageContent):
     """ Encode a message for transmission, given its content."""
+    c = messageContent.get("content")
+    if (c):
+        messageContent["b64content"] = ipc_encode(c)
     encodedContent = json.dumps(messageContent).encode("utf-8")
     encodedLength = struct.pack("@I", len(encodedContent))
     return {"length": encodedLength, "content": encodedContent}
@@ -432,7 +435,7 @@ def handleMessage(message):
     elif cmd == "getconfig":
         file_content = getUserConfig()
         if file_content:
-            reply["content"] = ipc_encode(file_content)
+            reply["content"] = file_content
         else:
             reply["code"] = "File not found"
 
@@ -447,14 +450,12 @@ def handleMessage(message):
             stdout=subprocess.PIPE,
         )
 
-        reply["content"] = ipc_encode(
-            p.communicate(stdin)[0].decode("utf-8")
-        )
+        reply["content"] = p.communicate(stdin)[0].decode("utf-8")
         reply["code"] = p.returncode
 
     elif cmd == "eval":
         output = eval(message["command"])
-        reply["content"] = ipc_encode(output)
+        reply["content"] = output
 
     elif cmd == "read":
         try:
@@ -464,7 +465,7 @@ def handleMessage(message):
                 ),
                 "rb",
             ) as file:
-                message_content = ipc_encode(file.read())
+                message_content = file.read()
                 reply["content"] = message_content
                 reply["code"] = 0
         except FileNotFoundError:
@@ -495,10 +496,10 @@ def handleMessage(message):
             content = ipc_decode(message["content"])
             file.write(content)
 
-        reply["content"] = ipc_encode(filepath)
+        reply["content"] = filepath
 
     elif cmd == "env":
-        content = ipc_encode(getenv(message["var"], ""))
+        content = getenv(message["var"], "")
         reply["content"] = content
 
     elif cmd == "win_firefox_restart":

--- a/package-lock.json
+++ b/package-lock.json
@@ -4668,7 +4668,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5083,7 +5084,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5139,6 +5141,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5182,12 +5185,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -32,7 +32,7 @@
     A "splat" operator (...) means that the excmd will accept any number of space-delimited arguments into that parameter.
 
     Above each function signature you will see any aliases or key sequences bound to it. The internal names for the various modes are used, which are listed here:
-    
+
         - `nmaps`: normal mode binds
         - `imaps`: insert mode binds
         - `inputmaps`: input mode binds
@@ -1820,7 +1820,7 @@ export async function tabmove(index = "$") {
     } else if (["start", "^"].includes(index)) {
         newindex = 0
     } else {
-        newindex = Number(index)  + minindex - 1
+        newindex = Number(index) + minindex - 1
     }
 
     if (newindex > maxindex) {
@@ -1854,7 +1854,7 @@ export async function pin() {
  Passing "all" to the excmd will operate on  the mute state of all tabs.
  Passing "unmute" to the excmd will unmute.
  Passing "toggle" to the excmd will toggle the state of `browser.tabs.tab.MutedInfo`
- @param string[] muteArgs 
+ @param string[] muteArgs
  */
 //#background
 export async function mute(...muteArgs: string[]): Promise<void> {

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -263,8 +263,8 @@ function ipcEncode(content: string) {
 }
 
 export async function write(file: string, content: string) {
-    content = ipcEncode(content)
-    return sendNativeMsg("write", { file, content })
+    let b64content = ipcEncode(content)
+    return sendNativeMsg("write", { file, content, b64content })
 }
 
 export async function mkdir(dir: string, exist_ok: boolean) {
@@ -272,8 +272,8 @@ export async function mkdir(dir: string, exist_ok: boolean) {
 }
 
 export async function temp(content: string, prefix: string) {
-    content = ipcEncode(content)
-    let message = await sendNativeMsg("temp", { content, prefix })
+    let b64content = ipcEncode(content)
+    let message = await sendNativeMsg("temp", { content, b64content, prefix })
 
     message.content = respHandler(message)
     return message


### PR DESCRIPTION
Dear Maintainers,

The following patches fix Unicode handling issues between JavaScript
and Python on Windows currently being discussed at #876 and #878.

The patches introduce encoding of native-messages (with URI and
Base64 encoding) exchanged between JavaScript and Python.

In short, we exchange Base64 "over the wire" to avoid Unicode
characters causing interoperability issues, and URI encoding is
necessary for `atob()/btoa()` to be successful with UTF-8 as
discussed here [0].

This patch requires lower-level changes around native-messaging both
on the JavaScript and Python end. So the users must upgrade to
native messenger version `0.1.9` _and_ the Tridactyl add-on before
using this.

Hope this helps. Thanks.

[0] https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
