### PR TITLE
background.ts: Ignore errors when TabLeft/TabEnter can't be triggered

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -106,10 +106,17 @@ browser.runtime.onStartup.addListener(_ => {
 
 let curTab = null
 browser.tabs.onActivated.addListener(ev => {
-    if (curTab !== null)
-        messaging.messageTab(curTab, "excmd_content", "loadaucmds", ["TabLeft"])
+    let ignore = _ => _
+    if (curTab !== null) {
+        // messaging.messageTab failing can happen when leaving privileged tabs (e.g. about:addons)
+        messaging
+            .messageTab(curTab, "excmd_content", "loadaucmds", ["TabLeft"])
+            .catch(ignore)
+    }
     curTab = ev.tabId
-    messaging.messageTab(curTab, "excmd_content", "loadaucmds", ["TabEnter"])
+    messaging
+        .messageTab(curTab, "excmd_content", "loadaucmds", ["TabEnter"])
+        .catch(ignore)
 })
 
 // {{{ AUTOCONTAINERS


### PR DESCRIPTION
When switching to or from a tab, Tridactyl sends a message to the
previously and newly-active tabs in order to trigger the TabLeft and
TabEnter autocommands.

This didn't work with privileged tabs as these tabs do not have a
content script. Instead, an exception was thrown. This commit adds
exception handling for these exceptions.