### PR TITLE
Improve config

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,11 +37,11 @@ fi
 
 # It's important to generate the metadata before the documentation because
 # missing imports might break documentation generation on clean builds
-"$(npm bin)/tsc" compiler/gen_metadata.ts -m commonjs \
+"$(npm bin)/tsc" compiler/gen_metadata.ts -m commonjs --target es2016 \
   && node compiler/gen_metadata.js \
           --out src/.metadata.generated.ts \
           --themeDir src/static/themes \
-          src/*.ts
+          src/excmds.ts src/config.ts
 
 scripts/newtab.md.sh
 scripts/make_tutorial.sh

--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -49,7 +49,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
     private async updateOptions(exstr?: string) {
         if (!exstr) exstr = ""
         this.lastExstr = exstr
-        let fns = Metadata.everything["src/excmds.ts"]
+        let fns = Metadata.everything["src/excmds.ts"].functions
         this.options = (await this.scoreOptions(
             Object.keys(fns).filter(f => f.startsWith(exstr)),
         )).map(f => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -418,17 +418,13 @@ class default_config {
 
     /**
      * Whether `:viewsource` will use our own page that you can use Tridactyl binds on, or Firefox's default viewer, which you cannot use Tridactyl on.
-     *
-     * Permitted values: `tridactyl` or `default`.
      */
-    viewsource = "tridactyl" // "tridactyl" or "default"
+    viewsource: "tridactyl" | "default" = "tridactyl"
 
     /**
      * Which storage to use. Sync storage will synchronise your settings via your Firefox Account.
-     *
-     * Permitted values: `sync` or `local`
      */
-    storageloc = "sync"
+    storageloc: "sync" | "local" = "sync"
 
     /**
      * Pages opened with `gH`.
@@ -444,22 +440,18 @@ class default_config {
 
     /**
      * The type of hinting to use. `vimperator` will allow you to filter links based on their names by typing non-hint chars. It is recommended that you use this in conjuction with the [[hintchars]] setting, which you should probably set to e.g, `5432167890`.
-     *
-     * Permitted values: `simple`, `vimperator`, or `vimperator-reflow`.
      */
-    hintfiltermode = "simple" // "simple", "vimperator" "vimperator-reflow"
+    hintfiltermode: "simple" | "vimperator" | "vimperator-reflow" = "simple"
 
     /**
      * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric`, overrides `hintchars` setting.
-     *
-     * Permitted values: `short` or `numeric`
      */
-    hintnames = "short"
+    hintnames: "short" | "numeric" = "short"
 
     /**
      * Whether to display the names for hints in uppercase.
      */
-    hintuppercase = "true"
+    hintuppercase: "true" | "false" = "true"
 
     /**
      * The delay in milliseconds in `vimperator` style hint modes after selecting a hint before you are returned to normal mode.
@@ -472,15 +464,13 @@ class default_config {
      * Controls whether the page can focus elements for you via js
      *
      * Best used in conjunction with browser.autofocus in `about:config`
-     *
-     * Permitted values: `true`, or `false`.
      */
-    allowautofocus = "true"
+    allowautofocus: "true" | "false" = "true"
 
     /**
      * Whether to use Tridactyl's (bad) smooth scrolling.
      */
-    smoothscroll = "false" // "false" | "true"
+    smoothscroll: "true" | "false" = "false"
 
     /**
      * How viscous you want smooth scrolling to feel.
@@ -489,17 +479,13 @@ class default_config {
 
     /**
      * Where to open tabs opened with `tabopen` - to the right of the current tab, or at the end of the tabs.
-     *
-     * Permitted values: `next`, or `last`.
      */
-    tabopenpos = "next"
+    tabopenpos: "next" | "last" = "next"
 
     /**
      * Where to open tabs opened with hinting - as if it had been middle clicked, to the right of the current tab, or at the end of the tabs.
-     *
-     * Permitted values: `related, `next`, or `last`.
      */
-    relatedopenpos = "related"
+    relatedopenpos: "related" | "next" | "last" = "related"
     ttsvoice = "default" // chosen from the listvoices list or "default"
     ttsvolume = 1 // 0 to 1
     ttsrate = 1 // 0.1 to 10
@@ -509,22 +495,25 @@ class default_config {
      * If nextinput, <Tab> after gi brings selects the next input
      *
      * If firefox, <Tab> selects the next selectable element, e.g. a link
-     *
-     * Permitted values: "nextinput" or "firefox"
      */
-    gimode = "nextinput" // either "nextinput" or "firefox"
+    gimode: "nextinput" | "firefox" = "nextinput"
 
-    // either "beginning" or "end"
-    // Decides where to place the cursor when selecting non-empty input fields
-    cursorpos = "end"
+    /**
+     * Decides where to place the cursor when selecting non-empty input fields
+     */
+    cursorpos: "beginning" | "end" = "end"
 
     /**
      * The theme to use.
      *
      * Permitted values: run `:composite js tri.styling.THEMES | fillcmdline` to find out.
      */
-    theme = "default" // currently available: "default" "dark"
-    modeindicator = "true"
+    theme = "default"
+
+    /**
+     * Whether to display the mode indicator or not.
+     */
+    modeindicator: "true" | "false" = "true"
 
     /*
      * Milliseconds before registering a scroll in the jumplist
@@ -564,17 +553,15 @@ class default_config {
 
     /* 
      * Which clipboard to store items in. Requires the native messenger to be installed.
-     *
-     * Permitted values: `clipboard`, `selection`, or `both`.
      */
-    yankto = "clipboard"
+    yankto: "clipboard" | "selection" | "both" = "clipboard"
 
     /* 
      * Which clipboard to retrieve items from. Requires the native messenger to be installed.
      *
      * Permitted values: `clipboard`, or `selection`.
      */
-    putfrom = "clipboard"
+    putfrom: "clipboard" | "selection" = "clipboard"
 
     /* 
      * Clipboard command to try to get the selection from (e.g. `xsel` or `xclip`)
@@ -601,17 +588,17 @@ class default_config {
     /*
      * If enabled, tabopen opens a new tab in the currently active tab's container.
      */
-    tabopencontaineraware = "false"
+    tabopencontaineraware: "true" | "false" = "false"
 
     /*
      * If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
      */
-    containerindicator = "true"
+    containerindicator: "true" | "false" = "true"
 
     /*
      * Autocontain directives create a container if it doesn't exist already.
      */
-    auconcreatecontainer = "true"
+    auconcreatecontainer: "true" | "false" = "true"
 
     /*
      * Number of most recent results to ask Firefox for. We display the top 20 or so most frequently visited ones.
@@ -620,10 +607,8 @@ class default_config {
 
     /*
      * Change this to "clobber" to ruin the "Content Security Policy" of all sites a bit and make Tridactyl run a bit better on some of them, e.g. raw.github*
-     *
-     * Permitted values: `untouched`, or `clobber`.
      */
-    csp = "untouched"
+    csp: "untouched" | "clobber" = "untouched"
 }
 
 /** @hidden */

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,13 +43,13 @@ let USERCONFIG = o({})
  * You can change anything here using `set key1.key2.key3 value` or specific things any of the various helper commands such as `bind` or `command`.
  *
  */
-const default_config = {
+class default_config {
     /**
      * Internal version number Tridactyl uses to know whether it needs to update from old versions of the configuration.
      *
      * Changing this might do weird stuff.
      */
-    configversion: "0.0",
+    configversion = "0.0"
 
     // Note to developers: When creating new <modifier-letter> maps, make sure to make the modifier uppercase (e.g. <C-a> instead of <c-a>) otherwise some commands might not be able to find them (e.g. `bind <c-a>`)
 
@@ -58,20 +58,20 @@ const default_config = {
      *
      * They consist of key sequences mapped to ex commands.
      */
-    ignoremaps: {
+    ignoremaps = {
         "<S-Insert>": "mode normal",
         "<CA-Escape>": "mode normal",
         "<CA-`>": "mode normal",
         "<S-Escape>": "mode normal",
         I: "mode normal",
-    },
+    }
 
     /**
      * inputmaps contain all of the bindings for "input mode".
      *
      * They consist of key sequences mapped to ex commands.
      */
-    inputmaps: {
+    inputmaps = {
         "<Escape>": "composite unfocus | mode normal",
         "<C-[>": "composite unfocus | mode normal",
         "<C-i>": "editor",
@@ -80,14 +80,14 @@ const default_config = {
         "<CA-Escape>": "mode normal",
         "<CA-`>": "mode normal",
         "<C-^>": "buffer #",
-    },
+    }
 
     /**
      * imaps contain all of the bindings for "insert mode".
      *
      * They consist of key sequences mapped to ex commands.
      */
-    imaps: {
+    imaps = {
         "<Escape>": "composite unfocus | mode normal",
         "<C-[>": "composite unfocus | mode normal",
         "<C-i>": "editor",
@@ -96,14 +96,14 @@ const default_config = {
         "<C-6>": "buffer #",
         "<C-^>": "buffer #",
         "<S-Escape>": "mode ignore",
-    },
+    }
 
     /**
      * nmaps contain all of the bindings for "normal mode".
      *
      * They consist of key sequences mapped to ex commands.
      */
-    nmaps: {
+    nmaps = {
         "<A-p>": "pin",
         "<A-m>": "mute toggle",
         "<F1>": "help",
@@ -237,14 +237,14 @@ const default_config = {
         ".": "repeat",
         "<SA-ArrowUp><SA-ArrowUp><SA-ArrowDown><SA-ArrowDown><SA-ArrowLeft><SA-ArrowRight><SA-ArrowLeft><SA-ArrowRight>ba":
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
-    },
+    }
 
     /**
      * Autocommands that run when certain events happen, and other conditions are met.
      *
      * Related ex command: `autocmd`.
      */
-    autocmds: {
+    autocmds = {
         /**
          * Commands that will be run as soon as Tridactyl loads into a page.
          *
@@ -298,24 +298,24 @@ const default_config = {
             // Too bad :/
             // "emacs.org": "tabclose",
         },
-    },
+    }
 
     /**
      * Automatically place these sites in the named container.
      *
      * Each key corresponds to a URL fragment which, if contained within the page URL, the site will be opened in a container tab instead.
      */
-    autocontain: o({
+    autocontain = o({
         //"github.com": "microsoft",
         //"youtube.com": "google",
-    }),
+    })
 
     /**
      * Aliases for the commandline.
      *
      * You can make a new one with `command alias ex-command`.
      */
-    exaliases: {
+    exaliases = {
         alias: "command",
         au: "autocmd",
         aucon: "autocontain",
@@ -363,27 +363,27 @@ const default_config = {
         "!jsb":
             "fillcmdline_tmp 3000 !jsb is deprecated. Please use jsb instead",
         current_url: "composite get_current_url | fillcmdline_notrail ",
-    },
+    }
 
     /**
      * Used by `]]` and `[[` to look for links containing these words.
      *
      * Edit these if you want to add, e.g. other language support.
      */
-    followpagepatterns: {
+    followpagepatterns = {
         next: "^(next|newer\\b|»|>>|more",
         prev: "^(prev(ious?|older\\b|«|<<",
-    },
+    }
 
     /**
      * The default search engine used by `open search`
      */
-    searchengine: "google",
+    searchengine = "google"
 
     /**
      * Definitions of search engines for use via `open [keyword]`.
      */
-    searchurls: {
+    searchurls = {
         google: "https://www.google.com/search?q=",
         scholar: "https://scholar.google.com/scholar?q=",
         googleuk: "https://www.google.co.uk/search?q=",
@@ -407,66 +407,66 @@ const default_config = {
         gentoo_wiki:
             "https://wiki.gentoo.org/index.php?title=Special%3ASearch&profile=default&fulltext=Search&search=",
         qwant: "https://www.qwant.com/?q=",
-    },
+    }
 
     /**
      * URL the newtab will redirect to.
      *
      * All usual rules about things you can open with `open` apply, with the caveat that you'll get interesting results if you try to use something that needs `nativeopen`: so don't try `about:newtab`.
      */
-    newtab: "",
+    newtab = ""
 
     /**
      * Whether `:viewsource` will use our own page that you can use Tridactyl binds on, or Firefox's default viewer, which you cannot use Tridactyl on.
      *
      * Permitted values: `tridactyl` or `default`.
      */
-    viewsource: "tridactyl", // "tridactyl" or "default"
+    viewsource = "tridactyl" // "tridactyl" or "default"
 
     /**
      * Which storage to use. Sync storage will synchronise your settings via your Firefox Account.
      *
      * Permitted values: `sync` or `local`
      */
-    storageloc: "sync",
+    storageloc = "sync"
 
     /**
      * Pages opened with `gH`.
      */
-    homepages: [],
+    homepages = []
 
     /**
      * Characters to use in hint mode.
      *
      * They are used preferentially from left to right.
      */
-    hintchars: "hjklasdfgyuiopqwertnmzxcvb",
+    hintchars = "hjklasdfgyuiopqwertnmzxcvb"
 
     /**
      * The type of hinting to use. `vimperator` will allow you to filter links based on their names by typing non-hint chars. It is recommended that you use this in conjuction with the [[hintchars]] setting, which you should probably set to e.g, `5432167890`.
      *
      * Permitted values: `simple`, `vimperator`, or `vimperator-reflow`.
      */
-    hintfiltermode: "simple", // "simple", "vimperator", "vimperator-reflow"
+    hintfiltermode = "simple" // "simple", "vimperator" "vimperator-reflow"
 
     /**
      * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric`, overrides `hintchars` setting.
      *
      * Permitted values: `short` or `numeric`
      */
-    hintnames: "short",
+    hintnames = "short"
 
     /**
      * Whether to display the names for hints in uppercase.
      */
-    hintuppercase: "true",
+    hintuppercase = "true"
 
     /**
      * The delay in milliseconds in `vimperator` style hint modes after selecting a hint before you are returned to normal mode.
      *
      * The point of this is to prevent accidental execution of normal mode binds due to people typing more than is necessary to choose a hint.
      */
-    hintdelay: "300",
+    hintdelay = "300"
 
     /**
      * Controls whether the page can focus elements for you via js
@@ -475,35 +475,35 @@ const default_config = {
      *
      * Permitted values: `true`, or `false`.
      */
-    allowautofocus: "true",
+    allowautofocus = "true"
 
     /**
      * Whether to use Tridactyl's (bad) smooth scrolling.
      */
-    smoothscroll: "false", // "false" | "true"
+    smoothscroll = "false" // "false" | "true"
 
     /**
      * How viscous you want smooth scrolling to feel.
      */
-    scrollduration: 100, // number
+    scrollduration = 100 // number
 
     /**
      * Where to open tabs opened with `tabopen` - to the right of the current tab, or at the end of the tabs.
      *
      * Permitted values: `next`, or `last`.
      */
-    tabopenpos: "next",
+    tabopenpos = "next"
 
     /**
      * Where to open tabs opened with hinting - as if it had been middle clicked, to the right of the current tab, or at the end of the tabs.
      *
      * Permitted values: `related, `next`, or `last`.
      */
-    relatedopenpos: "related",
-    ttsvoice: "default", // chosen from the listvoices list, or "default"
-    ttsvolume: 1, // 0 to 1
-    ttsrate: 1, // 0.1 to 10
-    ttspitch: 1, // 0 to 2
+    relatedopenpos = "related"
+    ttsvoice = "default" // chosen from the listvoices list or "default"
+    ttsvolume = 1 // 0 to 1
+    ttsrate = 1 // 0.1 to 10
+    ttspitch = 1 // 0 to 2
 
     /**
      * If nextinput, <Tab> after gi brings selects the next input
@@ -512,31 +512,31 @@ const default_config = {
      *
      * Permitted values: "nextinput" or "firefox"
      */
-    gimode: "nextinput", // either "nextinput" or "firefox"
+    gimode = "nextinput" // either "nextinput" or "firefox"
 
     // either "beginning" or "end"
     // Decides where to place the cursor when selecting non-empty input fields
-    cursorpos: "end",
+    cursorpos = "end"
 
     /**
      * The theme to use.
      *
      * Permitted values: run `:composite js tri.styling.THEMES | fillcmdline` to find out.
      */
-    theme: "default", // currently available: "default", "dark"
-    modeindicator: "true",
+    theme = "default" // currently available: "default" "dark"
+    modeindicator = "true"
 
     /*
      * Milliseconds before registering a scroll in the jumplist
      */
-    jumpdelay: 3000,
+    jumpdelay = 3000
 
     /*
      * Default logging levels - 2 === WARNING
      * 
      * NB: these cannot be set directly with `set` - you must use magic words such as `WARNING` or `DEBUG`.
      */
-    logging: {
+    logging = {
         messaging: 2,
         cmdline: 2,
         controller: 2,
@@ -545,8 +545,8 @@ const default_config = {
         state: 2,
         excmd: 1,
         styling: 2,
-    },
-    noiframeon: [],
+    }
+    noiframeon = []
 
     /* 
      * Insert / input mode edit-in-$EDITOR command to run
@@ -555,81 +555,79 @@ const default_config = {
      * Please send your requests to have your favourite terminal moved further up the list to /dev/null.
      *          (but we are probably happy to add your terminal to the list if it isn't already there.)
      */
-    editorcmd: "auto",
+    editorcmd = "auto"
 
     /* 
      * The browser executable to look for in commands such as `restart`. Not as mad as it seems if you have multiple versions of Firefox...
      */
-    browser: "firefox",
+    browser = "firefox"
 
     /* 
      * Which clipboard to store items in. Requires the native messenger to be installed.
      *
      * Permitted values: `clipboard`, `selection`, or `both`.
      */
-    yankto: "clipboard",
+    yankto = "clipboard"
 
     /* 
      * Which clipboard to retrieve items from. Requires the native messenger to be installed.
      *
      * Permitted values: `clipboard`, or `selection`.
      */
-    putfrom: "clipboard",
+    putfrom = "clipboard"
 
     /* 
      * Clipboard command to try to get the selection from (e.g. `xsel` or `xclip`)
      */
-    externalclipboardcmd: "auto",
+    externalclipboardcmd = "auto"
 
     /* 
      * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger. 
      */
-    nativeinstallcmd:
-        "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash",
+    nativeinstallcmd: "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash"
 
     /* 
      * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger. 
      */
-    win_nativeinstallcmd:
-        "powershell -NoProfile -InputFormat None -Command \"Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))\"",
+    win_nativeinstallcmd: "powershell -NoProfile -InputFormat None -Command \"Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))\""
 
     /* 
      * Profile directory to use with native messenger with e.g, `guiset`.
      */
-    profiledir: "auto",
+    profiledir = "auto"
 
     // Container settings
 
     /*
      * If enabled, tabopen opens a new tab in the currently active tab's container.
      */
-    tabopencontaineraware: "false",
+    tabopencontaineraware = "false"
 
     /*
      * If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
      */
-    containerindicator: "true",
+    containerindicator = "true"
 
     /*
      * Autocontain directives create a container if it doesn't exist already.
      */
-    auconcreatecontainer: "true",
+    auconcreatecontainer = "true"
 
     /*
      * Number of most recent results to ask Firefox for. We display the top 20 or so most frequently visited ones.
      */
-    historyresults: "50",
+    historyresults = "50"
 
     /*
      * Change this to "clobber" to ruin the "Content Security Policy" of all sites a bit and make Tridactyl run a bit better on some of them, e.g. raw.github*
      *
      * Permitted values: `untouched`, or `clobber`.
      */
-    csp: "untouched",
+    csp = "untouched"
 }
 
 /** @hidden */
-const DEFAULTS = o(default_config)
+const DEFAULTS = o(new default_config())
 
 /** Given an object and a target, extract the target if it exists, else return undefined
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -475,7 +475,7 @@ class default_config {
     /**
      * How viscous you want smooth scrolling to feel.
      */
-    scrollduration = 100 // number
+    scrollduration = "100"
 
     /**
      * Where to open tabs opened with `tabopen` - to the right of the current tab, or at the end of the tabs.
@@ -518,7 +518,7 @@ class default_config {
     /*
      * Milliseconds before registering a scroll in the jumplist
      */
-    jumpdelay = 3000
+    jumpdelay = "3000"
 
     /*
      * Default logging levels - 2 === WARNING

--- a/src/config.ts
+++ b/src/config.ts
@@ -486,10 +486,22 @@ class default_config {
      * Where to open tabs opened with hinting - as if it had been middle clicked, to the right of the current tab, or at the end of the tabs.
      */
     relatedopenpos: "related" | "next" | "last" = "related"
+    /**
+     * The name of the voice to use for text-to-speech. You can get the list of installed voices by running the following snippet: `js alert(window.speechSynthesis.getVoices().reduce((a, b) => a + " " + b.name))`
+     */
     ttsvoice = "default" // chosen from the listvoices list or "default"
-    ttsvolume = 1 // 0 to 1
-    ttsrate = 1 // 0.1 to 10
-    ttspitch = 1 // 0 to 2
+    /**
+     * Controls text-to-speech volume. Has to be a number between 0 and 1.
+     */
+    ttsvolume = "1"
+    /**
+     * Controls text-to-speech speed. Has to be a number between 0.1 and 10.
+     */
+    ttsrate = "1"
+    /**
+     * Controls text-to-speech pitch. Has to be between 0 and 2.
+     */
+    ttspitch = "1"
 
     /**
      * If nextinput, <Tab> after gi brings selects the next input
@@ -515,14 +527,14 @@ class default_config {
      */
     modeindicator: "true" | "false" = "true"
 
-    /*
+    /**
      * Milliseconds before registering a scroll in the jumplist
      */
     jumpdelay = "3000"
 
-    /*
+    /**
      * Default logging levels - 2 === WARNING
-     * 
+     *
      * NB: these cannot be set directly with `set` - you must use magic words such as `WARNING` or `DEBUG`.
      */
     logging = {
@@ -535,9 +547,9 @@ class default_config {
         excmd: 1,
         styling: 2,
     }
-    noiframeon = []
+    noiframeon: string[] = []
 
-    /* 
+    /**
      * Insert / input mode edit-in-$EDITOR command to run
      * This has to be a command that stays in the foreground for the whole editing session
      * "auto" will attempt to find a sane editor in your path.
@@ -546,66 +558,66 @@ class default_config {
      */
     editorcmd = "auto"
 
-    /* 
+    /**
      * The browser executable to look for in commands such as `restart`. Not as mad as it seems if you have multiple versions of Firefox...
      */
     browser = "firefox"
 
-    /* 
+    /**
      * Which clipboard to store items in. Requires the native messenger to be installed.
      */
     yankto: "clipboard" | "selection" | "both" = "clipboard"
 
-    /* 
+    /**
      * Which clipboard to retrieve items from. Requires the native messenger to be installed.
      *
      * Permitted values: `clipboard`, or `selection`.
      */
     putfrom: "clipboard" | "selection" = "clipboard"
 
-    /* 
+    /**
      * Clipboard command to try to get the selection from (e.g. `xsel` or `xclip`)
      */
     externalclipboardcmd = "auto"
 
-    /* 
-     * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger. 
+    /**
+     * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger.
      */
     nativeinstallcmd: "curl -fsSl https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/install.sh | bash"
 
-    /* 
-     * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger. 
+    /**
+     * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger.
      */
     win_nativeinstallcmd: "powershell -NoProfile -InputFormat None -Command \"Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))\""
 
-    /* 
+    /**
      * Profile directory to use with native messenger with e.g, `guiset`.
      */
     profiledir = "auto"
 
     // Container settings
 
-    /*
+    /**
      * If enabled, tabopen opens a new tab in the currently active tab's container.
      */
     tabopencontaineraware: "true" | "false" = "false"
 
-    /*
+    /**
      * If moodeindicator is enabled, containerindicator will color the border of the mode indicator with the container color.
      */
     containerindicator: "true" | "false" = "true"
 
-    /*
+    /**
      * Autocontain directives create a container if it doesn't exist already.
      */
     auconcreatecontainer: "true" | "false" = "true"
 
-    /*
+    /**
      * Number of most recent results to ask Firefox for. We display the top 20 or so most frequently visited ones.
      */
     historyresults = "50"
 
-    /*
+    /**
      * Change this to "clobber" to ruin the "Content Security Policy" of all sites a bit and make Tridactyl run a bit better on some of them, e.g. raw.github*
      */
     csp: "untouched" | "clobber" = "untouched"

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,3 +1,45 @@
+export function fitsType(variable, type) {
+    switch (type.kind) {
+        case "function":
+            return variable instanceof Function
+        case "array":
+            return (
+                variable instanceof Array &&
+                !variable.find(e => !fitsType(e, type.type))
+            )
+        case "Promise":
+            return variable instanceof Promise
+        case "union":
+            for (let t of type.arguments) {
+                if (fitsType(variable, t)) return true
+            }
+            return false
+        case "LiteralType":
+            return variable == type.name
+        case "tuple":
+            if (variable.length != type.arguments.length) return false
+            for (let i = 0; i < variable.length; ++i) {
+                let v = variable[i]
+                let t = type.arguments[i]
+                if (!fitsType(v, t)) return false
+            }
+            return true
+        case "any":
+            return true
+        case "object":
+            return true
+        case "boolean":
+            return typeof variable == "number"
+        case "number":
+            return typeof variable == "number"
+        case "string":
+            return typeof variable == "string"
+        case "void":
+            return !variable
+    }
+    throw new Error("Unhandled type!")
+}
+
 // Gets the type sitting inside a promise
 function unwrapPromise(type) {
     while (type.kind == "Promise") type = type.arguments[0]

--- a/src/scrolling.ts
+++ b/src/scrolling.ts
@@ -17,14 +17,14 @@ async function getSmooth() {
 async function getDuration() {
     if (opts.duration === null)
         opts.duration = await config.getAsync("scrollduration")
-    return opts.duration
+    return Number.parseInt(opts.duration)
 }
 browser.storage.onChanged.addListener(changes => {
     if ("userconfig" in changes) {
         if ("smoothscroll" in changes.userconfig.newValue)
             opts.smooth = changes.userconfig.newValue["smoothscroll"]
         if ("scrollduration" in changes.userconfig.newValue)
-            opts.duration = changes.userconfig.newValue["scrollduration"]
+            opts.duration = Number.parseInt(changes.userconfig.newValue["scrollduration"])
     }
 })
 

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -227,13 +227,16 @@ a.url:hover {
     width: 20%;
 }
 
-.SettingsCompletionOption td.title {
-    padding-left: 0.5em;
-    width: 20%;
-}
-.ExcmdCompletionOption td.type {
-    width: 30%;
-}
 .ExcmdCompletionOption td.documentation {
     width: 100%;
+}
+
+.SettingsCompletionOption td.title {
+    padding-left: 0.5em;
+}
+
+#completions .SettingsCompletionOption td.title,
+#completions .SettingsCompletionOption td.content,
+#completions .SettingsCompletionOption td.type {
+    width: 15%;
 }

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -239,4 +239,5 @@ a.url:hover {
 #completions .SettingsCompletionOption td.content,
 #completions .SettingsCompletionOption td.type {
     width: 15%;
+    text-overflow: ellipsis;
 }

--- a/src/text_to_speech.ts
+++ b/src/text_to_speech.ts
@@ -27,10 +27,10 @@ export function readText(text: string): void {
 
     let utterance = new SpeechSynthesisUtterance(text)
 
-    let pitch = Config.get("ttspitch")
+    let pitch = Number.parseFloat(Config.get("ttspitch"))
     let voice = Config.get("ttsvoice")
-    let volume = Config.get("ttsvolume")
-    let rate = Config.get("ttsrate")
+    let volume = Number.parseFloat(Config.get("ttsvolume"))
+    let rate = Number.parseFloat(Config.get("ttsrate"))
 
     if (pitch >= 0 && pitch < 2) utterance.pitch = pitch
 


### PR DESCRIPTION
This PR makes config-related stuff nicer by:
- Turning config into a class, which improves the TypeDoc layout
- Adding type info to metadata, which enables adding type info and documentation to completions
- Using type info to typecheck settings when the `:set` command is used