### PR TITLE
Parallelize async in browserBg.allWindowTabs + BufferAll completion

### DIFF
--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -37,15 +37,9 @@ async function history(): Promise<browser.history.HistoryItem[]> {
         startTime: 0,
     })
 }
+
 async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
-    const windows: browser.windows.Window[] = await browser.windows.getAll()
-    const queries: Promise<browser.tabs.Tab[]>[] = windows.map(
-        window =>
-            browser.tabs.query({ windowId: window.id })
-    )
-    const windowTabs: browser.tabs.Tab[][] = await Promise.all(queries)
-    const allTabs: browser.tabs.Tab[] = Array.prototype.concat(...windowTabs)
-    return allTabs
+    return browser.tabs.query({})
 }
 
 export async function show(focus = true) {

--- a/src/commandline_background.ts
+++ b/src/commandline_background.ts
@@ -38,19 +38,21 @@ async function history(): Promise<browser.history.HistoryItem[]> {
     })
 }
 async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
-    let allTabs: browser.tabs.Tab[] = []
-    for (const window of await browser.windows.getAll()) {
-        const tabs = await browser.tabs.query({ windowId: window.id })
-        allTabs = allTabs.concat(tabs)
-    }
+    const windows: browser.windows.Window[] = await browser.windows.getAll()
+    const queries: Promise<browser.tabs.Tab[]>[] = windows.map(
+        window =>
+            browser.tabs.query({ windowId: window.id })
+    )
+    const windowTabs: browser.tabs.Tab[][] = await Promise.all(queries)
+    const allTabs: browser.tabs.Tab[] = Array.prototype.concat(...windowTabs)
     return allTabs
 }
 
 export async function show(focus = true) {
     Messaging.messageActiveTab("commandline_content", "show")
     if (focus) {
-        await Messaging.messageActiveTab("commandline_content", "focus")
-        await Messaging.messageActiveTab("commandline_frame", "focus")
+        Messaging.messageActiveTab("commandline_content", "focus")
+        Messaging.messageActiveTab("commandline_frame", "focus")
     }
 }
 

--- a/src/completions/BufferAll.ts
+++ b/src/completions/BufferAll.ts
@@ -53,17 +53,19 @@ export class BufferAllCompletionSource extends Completions.CompletionSourceFuse 
     }
 
     private async updateOptions(exstr?: string) {
-        const tabs: browser.tabs.Tab[] = await Messaging.message(
+        const tabsPromise: Promise<browser.tabs.Tab[]> = Messaging.message(
             "commandline_background",
             "allWindowTabs",
         )
-        const windows = (await browserBg.windows.getAll()).reduce(
-            (acc, win) => {
+        const windowsPromise: Promise<{
+            [tabId: number]: browser.windows.Window
+        }> = browserBg.windows.getAll().then(windows =>
+            windows.reduce((acc, win) => {
                 acc[win.id] = win
                 return acc
-            },
-            {},
+            }, {}),
         )
+        const [tabs, windows] = await Promise.all([tabsPromise, windowsPromise])
 
         const options = []
 

--- a/src/completions/BufferAll.ts
+++ b/src/completions/BufferAll.ts
@@ -52,19 +52,22 @@ export class BufferAllCompletionSource extends Completions.CompletionSourceFuse 
         await this.updateOptions()
     }
 
+    /**
+     * Map all windows into a {[windowId]: window} object
+     */
+    private async getWindows() {
+        const windows = await browserBg.windows.getAll()
+        const response: {[windowId: number]: browser.windows.Window} = {}
+        windows.forEach(win => response[win.id] = win)
+        return response
+    }
+
     private async updateOptions(exstr?: string) {
-        const tabsPromise: Promise<browser.tabs.Tab[]> = Messaging.message(
+        const tabsPromise = Messaging.message(
             "commandline_background",
             "allWindowTabs",
         )
-        const windowsPromise: Promise<{
-            [tabId: number]: browser.windows.Window
-        }> = browserBg.windows.getAll().then(windows =>
-            windows.reduce((acc, win) => {
-                acc[win.id] = win
-                return acc
-            }, {}),
-        )
+        const windowsPromise = this.getWindows()
         const [tabs, windows] = await Promise.all([tabsPromise, windowsPromise])
 
         const options = []


### PR DESCRIPTION
Didn't bring the average down too much, but I probably killed a long-tail. I'll have to do more extensive profiling.

Before:
```
78                  #####
117.78571428571429  ###############################
157.57142857142858  #######################################
197.35714285714286  ############################################################
237.14285714285714  ####################################
276.92857142857144  ##
316.7142857142857   #####
356.5               #######
396.2857142857143
436.07142857142856  #####
475.85714285714283  #####
515.6428571428571   ##
555.4285714285714   #####
595.2142857142857   ##
635                 #####
```
After:
```
74                  ###
101.85714285714286  #########################################
129.71428571428572  ######
157.57142857142858  ###########
185.42857142857142  ############################################################
213.28571428571428  ##########
241.14285714285714  ##################
269                 ################
296.85714285714283  ##########
324.7142857142857   ########
352.57142857142856  ######
380.42857142857144  ######
408.2857142857143   ###
436.14285714285717  ######
464                 #####
```