### PR TITLE
config.ts: Fix followpagepatterns

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -371,8 +371,8 @@ class default_config {
      * Edit these if you want to add, e.g. other language support.
      */
     followpagepatterns = {
-        next: "^(next|newer\\b|»|>>|more",
-        prev: "^(prev(ious?|older\\b|«|<<",
+        next: "^(next|newer)\\b|»|>>|more",
+        prev: "^(prev(ious)?|older)\\b|«|<<",
     }
 
     /**


### PR DESCRIPTION
14d7acc5 accidentally broke the regexes used by followpage. This commit
fixes them.

Closes https://github.com/tridactyl/tridactyl/issues/971.