### PR TITLE
Respect the tabs.move/tabs.create API

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -338,7 +338,7 @@ export async function nativeopen(url: string, ...firefoxArgs: string[]) {
         let index = (await activeTab()).index + 1
         switch (pos) {
             case "last":
-                index = 99999
+                index = -1
                 break
             case "related":
                 // How do we simulate that?

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -114,7 +114,7 @@ export async function openInNewTab(
             break
         case "last":
             // Infinity can't be serialised, apparently.
-            options.index = 99999
+            options.index = (await browserBg.tabs.query({currentWindow: true})).length
             break
         case "related":
             if (await firefoxVersionAtLeast(57)) {


### PR DESCRIPTION
According to MDN[1], when you create a tab that should be placed at the
end of a window, you should use the number of tabs of the window as
index.
But if you use tabs.move(), you should use an index value of -1[2].

Probably fixes https://github.com/tridactyl/tridactyl/issues/990 .

1: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#Parameters
2: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/move#Parameters