### PR TITLE
Prevent webpack from minifying source code

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const CopyWebPackPlugin = require("copy-webpack-plugin")
 // const WebpackShellPlugin = require('webpack-shell-plugin')
 
 module.exports = {
+    mode: "development",
     entry: {
         background: "./src/background.ts",
         content: "./src/content.ts",


### PR DESCRIPTION
a0ac1a2 upgraded Tridactyl's dependencies and webpack suddenly started
minifying the files it builds. This makes debugging much harder and thus
needs to be prevented. This is done by setting "mode" to "development"
in the module.exports object in webpack.config.js.