### PR TITLE
Possible temporary fix for #1016

### DIFF
--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -14,6 +14,7 @@ class HistoryCompletionOption extends Completions.CompletionOptionHTML
 
         // Push properties we want to fuzmatch on
         this.fuseKeys.push(page.title, page.url) // weight by page.visitCount
+        
         // Create HTMLElement
         // need to download favicon
         const favIconUrl = Completions.DEFAULT_FAVICON


### PR DESCRIPTION
This fix should allow one to `set historyresults 0`.  Instead of history results, it should just keep showing top sites.