### PR TITLE
Add `:saveas` ex command

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -14,7 +14,7 @@ import time
 import unicodedata
 
 DEBUG = False
-VERSION = "0.1.8"
+VERSION = "0.1.9"
 
 
 class NoConnectionError(Exception):
@@ -449,6 +449,17 @@ def handleMessage(message):
         )
         reply["content"] = ""
         reply["code"] = 0
+
+    elif cmd == "move":
+        dest = os.path.expanduser(message["to"])
+        if (os.path.isfile(dest)):
+            reply["code"] = 1
+        else:
+            try:
+                shutil.move(os.path.expanduser(message["from"]), dest)
+                reply["code"] = 0
+            except:
+                reply["code"] = 2
 
     elif cmd == "write":
         with open(message["file"], "w") as file:

--- a/src/download_background.ts
+++ b/src/download_background.ts
@@ -3,6 +3,7 @@
  */
 
 import { getDownloadFilenameForUrl } from "./url_util"
+import * as Native from "./native_background"
 
 /** Construct an object URL string from a given data URL
  *
@@ -69,6 +70,83 @@ export async function downloadUrl(url: string, saveAs: boolean) {
     await downloadPromise
 }
 
+/** Dowload a given URL to disk
+ *
+ * This behaves mostly like downloadUrl, except that this function will use the native messenger in order to move the file to `saveAs`.
+ *
+ * Note: this requires a native messenger >=0.1.9. Make sure to nativegate for this.
+ *
+ * @param url the URL to download
+ * @param saveAs If beginning with a slash, this is the absolute path the document should be moved to. If the first character of the string is a tilda, it will be expanded to an absolute path to the user's home directory. If saveAs begins with any other character, it will be considered a path relative to where the native messenger binary is located (e.g. "$HOME/.local/share/tridactyl" on linux).
+ * If saveAs points to a directory, the name of the document will be inferred from the URL and the document will be placed inside the directory. If saveAs points to an already existing file, the document will be saved in the downloads directory but wont be moved to where it should be ; an error will be thrown. If any of the directories referred to in saveAs do not exist, the file will be kept in the downloads directory but won't be moved to where it should be.
+ */
+export async function downloadUrlAs(url: string, saveAs: string) {
+    if (!(await Native.nativegate("0.1.9", true))) return
+    const urlToSave = new URL(url)
+
+    let urlToDownload
+
+    if (urlToSave.protocol === "data:") {
+        urlToDownload = objectUrlFromDataUrl(urlToSave)
+    } else {
+        urlToDownload = urlToSave.href
+    }
+
+    let fileName = getDownloadFilenameForUrl(urlToSave)
+
+    let downloadId = await browser.downloads.download({
+        conflictAction: "uniquify",
+        url: urlToDownload,
+        filename: fileName,
+    })
+
+    // We want to return a promise that will resolve once the file has been moved somewhere else
+    return new Promise((resolve, reject) => {
+        let onDownloadComplete = async downloadDelta => {
+            if (downloadDelta.id != downloadId) {
+                return
+            }
+            // Note: this might be a little too drastic. For example, files that encounter a problem while being downloaded and the download of which is restarted by a user won't be moved
+            // This seems acceptable for now as taking all states into account seems quite difficult
+            if (
+                downloadDelta.state &&
+                downloadDelta.state.current != "in_progress"
+            ) {
+                browser.downloads.onChanged.removeListener(onDownloadComplete)
+                let downloadItem = (await browser.downloads.search({
+                    id: downloadId,
+                }))[0]
+                if (downloadDelta.state.current == "complete") {
+                    let operation = await Native.move(
+                        downloadItem.filename,
+                        saveAs,
+                    )
+                    if (operation.code != 0) {
+                        reject(
+                            new Error(
+                                `'${
+                                    downloadItem.filename
+                                }' could not be moved to '${saveAs}'. Make sure it doesn't already exist and that all directories of the path exist.`,
+                            ),
+                        )
+                    } else {
+                        resolve(operation)
+                    }
+                } else {
+                    reject(
+                        new Error(
+                            `'${
+                                downloadItem.filename
+                            }' state not in_progress anymore but not complete either (would have been moved to '${saveAs}')`,
+                        ),
+                    )
+                }
+            }
+        }
+        browser.downloads.onChanged.addListener(onDownloadComplete)
+    })
+}
+
 import * as Messaging from "./messaging"
 
 // Get messages from content
@@ -76,5 +154,6 @@ Messaging.addListener(
     "download_background",
     Messaging.attributeCaller({
         downloadUrl,
+        downloadUrlAs,
     }),
 )

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -497,6 +497,25 @@ export async function restart() {
     }
 }
 
+/** Download the current document.
+ *
+ * If you have the native messenger v>=0.1.9 installed, the function accepts one optional argument, filename, which can be:
+ * - An absolute path
+ * - A path starting with ~, which will be expanded to your home directory
+ * - A relative path, relative to the native messenger executable (e.g. ~/.local/share/tridactyl on linux).
+ * If filename is not given, a download dialog will be opened. If filename is a directory, the file will be saved inside of it, its name being inferred from the URL. If the directories mentionned in the path do not exist or if a file already exists at this path, the file will be kept in your downloads folder and an error message will be given.
+ *
+ * @param filename The name the file should be saved as.
+ */
+//#content
+export async function saveas(...filename: string[]) {
+    if (filename.length > 0) {
+        return Messaging.message("download_background", "downloadUrlAs", [window.location.href, filename.join(" ")])
+    } else {
+        return Messaging.message("download_background", "downloadUrl", [window.location.href, true])
+    }
+}
+
 // }}}
 
 /** @hidden */

--- a/src/native_background.ts
+++ b/src/native_background.ts
@@ -17,6 +17,7 @@ type MessageCommand =
     | "write"
     | "temp"
     | "mkdir"
+    | "move"
     | "eval"
     | "getconfig"
     | "env"
@@ -208,7 +209,7 @@ export async function firstinpath(cmdarray) {
     let ind = 0
     let cmd = cmdarray[ind]
     // Try to find a text editor
-    while (!await inpath(cmd.split(" ")[0])) {
+    while (!(await inpath(cmd.split(" ")[0]))) {
         ind++
         cmd = cmdarray[ind]
         if (cmd === undefined) break
@@ -246,13 +247,17 @@ export async function temp(content: string, prefix: string) {
     return sendNativeMsg("temp", { content, prefix })
 }
 
+export async function move(from: string, to: string) {
+    return sendNativeMsg("move", { from, to })
+}
+
 export async function winFirefoxRestart(
     profiledir: string,
     browsercmd: string,
 ) {
     let required_version = "0.1.6"
 
-    if (!await nativegate(required_version, false)) {
+    if (!(await nativegate(required_version, false))) {
         throw `'restart' on Windows needs native messenger version >= ${required_version}.`
     }
 
@@ -275,7 +280,7 @@ export async function pyeval(command: string): Promise<MessageResp> {
 export async function getenv(variable: string) {
     let required_version = "0.1.2"
 
-    if (!await nativegate(required_version, false)) {
+    if (!(await nativegate(required_version, false))) {
         throw `'getenv' needs native messenger version >= ${required_version}.`
     }
 


### PR DESCRIPTION
This commit adds a `:saveas` ex command that behaves mostly like
pentadactyl's `saveas`. This requires adding a new `move` primitive to
the native messenger which behaves like `cp` (but isn't actually a call
to `cp` in order to stay compatible with windows). Then
native_background.ts uses that in order to move files when their
download is complete.