### PR TITLE
Readline excmds

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -663,6 +663,11 @@ class default_config {
      * Change this to "clobber" to ruin the "Content Security Policy" of all sites a bit and make Tridactyl run a bit better on some of them, e.g. raw.github*
      */
     csp: "untouched" | "clobber" = "untouched"
+
+    /**
+     * JavaScript RegExp used to recognize words in im_* functions (e.g. im_transpose_words). Should match any character belonging to a word.
+     */
+    wordpattern = "[^\\s]+"
 }
 
 /** @hidden */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -374,6 +374,65 @@ export function im_transpose_words() {
     elem.selectionStart = elem.selectionEnd = pos
 }
 
+/** @hidden
+ * Returns true if POSITION is in a word in text, false otherwise.
+ */
+//#content_helper
+function inWord(text: string, position: number) {
+    return !!text[0].match(new RegExp(config.get("wordpattern"), "g"))
+}
+
+/** @hidden
+ * Applies a function to the word the cursor is in, or to the next word if the cursor is not in a word, or to the previous word if the current word is empty.
+ */
+//#content_helper
+function applyWord(fn: (string) => string) {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_upcase_word: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    // If the cursor is at the end of the text, move it just before the last character
+    if (pos >= text.length) {
+        pos = text.length - 1
+    }
+
+    if (!inWord(text, pos)) {
+        let newPos = wordAfterPos(text, pos)
+        if (newPos > -1) pos = newPos
+    }
+    let boundaries = getWordBoundaries(text, pos)
+    let beginning = text.substring(0, boundaries[0]) + fn(text.substring(boundaries[0], boundaries[1]))
+    fillinput(DOM.getSelector(elem), beginning + text.substring(boundaries[1]))
+    elem.selectionStart = elem.selectionEnd = beginning.length + 1
+}
+
+/**
+ * Behaves like readline's [upcase_word](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_upcase_word() {
+    applyWord(word => word.toUpperCase())
+}
+
+/**
+ * Behaves like readline's [downcase_word](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_downcase_word() {
+    applyWord(word => word.toLowerCase())
+}
+
+/**
+ * Behaves like readline's [capitalize_word](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_capitalize_word() {
+    applyWord(word => word[0].toUpperCase() + word.substring(1))
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -457,6 +457,32 @@ export function im_kill_line() {
     elem.selectionStart = elem.selectionEnd = pos
 }
 
+/**
+ * Behaves like readline's [backward_kill_line](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC15).
+ **/
+//#content
+export function im_backward_kill_line() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_backward_kill_line: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    // If the cursor is at the beginning of a line, join the lines
+    if (text[pos - 1] == "\n") {
+        fillinput(DOM.getSelector(elem), text.substring(0, pos - 1) + text.substring(pos))
+        elem.selectionStart = elem.selectionEnd = pos - 1
+    } else {
+        let newLine
+        // Find the closest newline
+        for (newLine = pos; newLine > 0 && text[newLine - 1] != "\n"; --newLine) {}
+        // Remove everything between the newline and the cursor
+        fillinput(DOM.getSelector(elem), text.substring(0, newLine) + text.substring(pos))
+        elem.selectionStart = elem.selectionEnd = newLine
+    }
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -603,6 +603,38 @@ export function im_end_of_line() {
     elem.selectionStart = elem.selectionEnd = pos
 }
 
+/**
+ * Behaves like readline's [forward_char](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_forward_char() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_forward_char: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0) return
+    elem.selectionStart = elem.selectionEnd = pos + 1
+}
+
+/**
+ * Behaves like readline's [backward_char](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_backward_char() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_backward_char: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0) return
+    elem.selectionStart = elem.selectionEnd = pos - 1
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -282,6 +282,26 @@ export function im_tab_insert() {
     elem.selectionStart = elem.selectionEnd = pos + 1
 }
 
+/**
+ * Behaves like readline's [transpose_chars](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_transpose_chars() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_transpose_chars: elem doesn't have a selectionStart")
+        return
+    }
+    // When at the beginning of the text, transpose the first and second characters
+    if (pos == 0) pos = 1
+    let text = getInput(elem)
+    // When at the end of the text, transpose the last and second-to-last characters
+    if (pos >= text.length) pos = text.length - 1
+    fillinput(DOM.getSelector(elem), text.substring(0, pos - 1) + text.substring(pos, pos + 1) + text.substring(pos - 1, pos) + text.substring(pos + 1))
+    elem.selectionStart = elem.selectionEnd = pos + 1
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -163,15 +163,20 @@ export async function fillinput(selector: string, ...content: string[]) {
 }
 
 /** @hidden */
-//#content
-export async function getinput() {
+//#content_helper
+export function getInput(e: HTMLElement) {
     // this should probably be subsumed by the focusinput code
-    let input = DOM.getLastUsedInput()
-    if ("value" in input) {
-        return (input as HTMLInputElement).value
+    if ("value" in e) {
+        return (e as HTMLInputElement).value
     } else {
-        return input.textContent
+        return e.textContent
     }
+}
+
+/** @hidden */
+//#content
+export function getinput() {
+    return getInput(DOM.getLastUsedInput())
 }
 
 /** @hidden */
@@ -209,6 +214,29 @@ export async function editor() {
     Messaging.messageTab(tab.id, "excmd_content", "fillinput", [selector, content])
     // TODO: add annoying "This message was written with [Tridactyl](https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/)" to everything written using editor
     return [file, content]
+}
+
+/**
+ * Behaves like readline's [delete_char](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_delete_char() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    // Abort if we can't find out where the cursor is
+    if (pos === undefined || pos === null) {
+        logger.warning("im_delete_char: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (pos != elem.selectionEnd) {
+        // If the user selected text, then we need to delete that instead of a single char
+        text = text.substring(0, pos) + text.substring(elem.selectionEnd)
+    } else {
+        text = text.substring(0, pos) + text.substring(pos + 1)
+    }
+    fillinput(DOM.getSelector(elem), text)
+    elem.selectionStart = elem.selectionEnd = pos
 }
 
 //#background_helper

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -433,6 +433,30 @@ export function im_capitalize_word() {
     applyWord(word => word[0].toUpperCase() + word.substring(1))
 }
 
+/**
+ * Behaves like readline's [kill_line](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC15).
+ **/
+//#content
+export function im_kill_line() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_kill_line: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    let newLine = text.substring(pos).search("\n")
+    if (newLine != -1) {
+        // If the cursor is right before the newline, kill the newline
+        if (newLine == 0) newLine = 1
+        text = text.substring(0, pos) + text.substring(pos + newLine)
+    } else {
+        text = text.substring(0, pos)
+    }
+    fillinput(DOM.getSelector(elem), text)
+    elem.selectionStart = elem.selectionEnd = pos
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -239,6 +239,28 @@ export function im_delete_char() {
     elem.selectionStart = elem.selectionEnd = pos
 }
 
+/**
+ * Behaves like readline's [delete_backward_char](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_delete_backward_char() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    // Abort if we can't find out where the cursor is or if it is at the beginning of the text
+    if (!pos) {
+        logger.warning("im_delete_backward_char: elem doesn't have a selectionStart or cursor is at beginning of line.")
+        return
+    }
+    let text = getInput(elem)
+    if (pos != elem.selectionEnd) {
+        text = text.substring(0, pos) + text.substring(elem.selectionEnd)
+    } else {
+        text = text.substring(0, pos - 1) + text.substring(pos)
+    }
+    fillinput(DOM.getSelector(elem), text)
+    elem.selectionStart = elem.selectionEnd = pos - 1
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -483,6 +483,28 @@ export function im_backward_kill_line() {
     }
 }
 
+/**
+ * Behaves like readline's [kill_whole_line](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC15).
+ **/
+//#content
+export function im_kill_whole_line() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_kill_whole_line: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    let firstNewLine, secondNewLine
+    // Find the newline before the cursor
+    for (firstNewLine = pos; firstNewLine > 0 && text[firstNewLine - 1] != "\n"; --firstNewLine) {}
+    // Find the newline after the cursor
+    for (secondNewLine = pos; secondNewLine < text.length && text[secondNewLine - 1] != "\n"; ++secondNewLine) {}
+    // Remove everything between the newline and the cursor
+    fillinput(DOM.getSelector(elem), text.substring(0, firstNewLine) + text.substring(secondNewLine))
+    elem.selectionStart = elem.selectionEnd = firstNewLine
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -635,6 +635,42 @@ export function im_backward_char() {
     elem.selectionStart = elem.selectionEnd = pos - 1
 }
 
+/**
+ * Behaves like readline's [forward_word](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_forward_word() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_forward_word: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0) return
+    let boundaries = getWordBoundaries(text, pos, false)
+    if (pos >= boundaries[0] && pos < boundaries[1]) boundaries = getWordBoundaries(text, boundaries[1], false)
+    elem.selectionStart = elem.selectionEnd = boundaries[0]
+}
+
+/**
+ * Behaves like readline's [backward_word](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_backward_word() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_backward_word: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0 || pos == 0) return
+    let boundaries = getWordBoundaries(text, pos, true)
+    if (pos >= boundaries[0] && pos < boundaries[1]) boundaries = getWordBoundaries(text, boundaries[0] - 1, true)
+    elem.selectionStart = elem.selectionEnd = boundaries[0]
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -261,6 +261,27 @@ export function im_delete_backward_char() {
     elem.selectionStart = elem.selectionEnd = pos - 1
 }
 
+/**
+ * Behaves like readline's [tab_insert](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC14).
+ **/
+//#content
+export function im_tab_insert() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_tab_insert: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (pos != elem.selectionEnd) {
+        text = text.substring(0, pos) + "\t" + text.substring(elem.selectionEnd)
+    } else {
+        text = text.substring(0, pos) + "\t" + text.substring(pos)
+    }
+    fillinput(DOM.getSelector(elem), text)
+    elem.selectionStart = elem.selectionEnd = pos + 1
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -586,6 +586,23 @@ export function im_beginning_of_line() {
     elem.selectionStart = elem.selectionEnd = pos
 }
 
+/**
+ * Behaves like readline's [end_of_line](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_end_of_line() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_end_of_line: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0) return
+    while (text[pos] != undefined && text[pos] != "\n") pos += 1
+    elem.selectionStart = elem.selectionEnd = pos
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -569,6 +569,23 @@ export function im_backward_kill_word() {
     elem.selectionStart = elem.selectionEnd = boundaries[0]
 }
 
+/**
+ * Behaves like readline's [beginning_of_line](http://web.mit.edu/gnu/doc/html/rlman_1.html#SEC12).
+ **/
+//#content
+export function im_beginning_of_line() {
+    let elem = DOM.getLastUsedInput() as HTMLInputElement
+    let pos = elem.selectionStart
+    if (pos === undefined || pos === null) {
+        logger.warning("im_beginning_of_line: elem doesn't have a selectionStart")
+        return
+    }
+    let text = getInput(elem)
+    if (text.length == 0) return
+    while (text[pos - 1] != undefined && text[pos - 1] != "\n") pos -= 1
+    elem.selectionStart = elem.selectionEnd = pos
+}
+
 //#background_helper
 import * as css_util from "./css_util"
 


### PR DESCRIPTION
This implements a bunch of excmds that behave like readline's functions. I did this mostly for my personal use so if you feel this shouldn't be in Tridactyl that's absolutely fine, I'll just convert everything to javascript and add it to my tridactylrc.

I didn't bind anything by default because some of readline's keybindings clash with what users might expect (e.g. `<C-a>`) or with firefox's bindings (e.g. `<C-w>`).