### PR TITLE
Fix build scripts on paths with spaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,7 @@ If you want to install a local copy of the add-on into your developer or nightly
 # Build tridactyl if you haven't done that yet
 npm run build
 # Package for a browser
-$(npm bin)/web-ext build -s build
+"$(npm bin)/web-ext" build -s build
 ```
 
 If you want to build a signed copy (e.g. for the non-developer release), you can do that with `web-ext sign`. You'll need some keys for AMO and to edit the application id in `src/manifest.json`. There's a helper script in `scripts/sign` that's used by our build bot and for manual releases.

--- a/scripts/amo_text_to_clipboard.sh
+++ b/scripts/amo_text_to_clipboard.sh
@@ -3,4 +3,4 @@
 # Put the AMO flavour text in your clipboard for easy pasting. 
 # AMO doesn't support all HTML in markdown so we strip it out.
 
-$(npm bin)/marked doc/amo.md | sed -r "s/<.?p>//g" | sed -r "s/<.?h.*>//g" | xclip -selection "clipboard"
+"$(npm bin)/marked" doc/amo.md | sed -r "s/<.?p>//g" | sed -r "s/<.?h.*>//g" | xclip -selection "clipboard"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,7 +47,7 @@ scripts/newtab.md.sh
 scripts/make_tutorial.sh
 scripts/make_docs.sh &
 
-$(npm bin)/nearleyc src/grammars/bracketexpr.ne \
+"$(npm bin)/nearleyc" src/grammars/bracketexpr.ne \
   > src/grammars/.bracketexpr.generated.ts
 
 if [ "$(isWindowsMinGW)" = "True" ]; then

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 dest=generated/static/docs
-$(npm bin)/typedoc --theme src/static/typedoc/ --out $dest src --ignoreCompilerErrors
+"$(npm bin)/typedoc" --theme src/static/typedoc/ --out $dest src --ignoreCompilerErrors
 cp -r $dest build/static/

--- a/scripts/make_tutorial.sh
+++ b/scripts/make_tutorial.sh
@@ -11,6 +11,6 @@ for page in $pages
 do
     fileroot=$(echo $page | cut -d'.' -f-1)
     sed "/REPLACETHIS/,$ d" tutor.template.html > "$dest$fileroot.html"
-    $(npm bin)/marked $page >> "$dest$fileroot.html"
+    "$(npm bin)/marked" $page >> "$dest$fileroot.html"
     sed "1,/REPLACETHIS/ d" tutor.template.html >> "$dest$fileroot.html"
 done

--- a/scripts/newtab.md.sh
+++ b/scripts/newtab.md.sh
@@ -8,7 +8,7 @@ newtab="../../generated/static/newtab.html"
 newtabtemp="../../generated/static/newtab.temp.html"
 
 sed "/REPLACETHIS/,$ d" newtab.template.html > "$newtabtemp"
-$(npm bin)/marked newtab.md >> "$newtabtemp"
+"$(npm bin)/marked" newtab.md >> "$newtabtemp"
 sed "1,/REPLACETHIS/ d" newtab.template.html >> "$newtabtemp"
 
 # Why think when you can pattern match?
@@ -20,7 +20,7 @@ echo """
 <label for="spoilerbutton" onclick=""><div id="nagbar-changelog">New features!</div>Changelog</label>
 <div id="changelog" class="spoiler">
 """ >> "$newtab"
-$(npm bin)/marked ../../CHANGELOG.md >> "$newtab"
+"$(npm bin)/marked" ../../CHANGELOG.md >> "$newtab"
 echo """
 </div>
 """ >> "$newtab"


### PR DESCRIPTION
Fix build scripts broken if you clone the repo to a directory that has spaces anywhere along it's path like:
`~/workspace/some folder name with spaces/firefox/tridactyl`