### PR TITLE
newtab.ts: Focus newtab page when opening it

### DIFF
--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -34,4 +34,5 @@ window.addEventListener("load", _ => {
         return
     }
     spoilerbutton.addEventListener("click", readChangelog)
+    window.focus()
 })


### PR DESCRIPTION
Re-reading https://github.com/tridactyl/tridactyl/issues/1021#issuecomment-423734337 made me realize that I had tried `document.focus()` but not `window.focus()`, which works.

Fixes https://github.com/tridactyl/tridactyl/issues/1021 on my computer.