### PR TITLE
scrolling.ts: default scroll values to 0

### DIFF
--- a/src/scrolling.ts
+++ b/src/scrolling.ts
@@ -110,8 +110,8 @@ class ScrollingData {
  *  last duration milliseconds
  */
 export async function scroll(
-    x: number,
-    y: number,
+    x: number = 0,
+    y: number = 0,
     e: HTMLElement,
     duration: number = undefined,
 ) {


### PR DESCRIPTION
If x or y are undefined, the page could be scrolled back to its very top
under certain circumstances. This commit fixes that.

Closes https://github.com/tridactyl/tridactyl/issues/753 .