### PR TITLE
Implement ownTab{,Id,Container}, use them to set modeindicator color

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -130,7 +130,10 @@ config.getAsync("modeindicator").then(mode => {
     // Dynamically sets the border container color.
     if (containerIndicator === "true") {
         webext
-            .activeTabContainer()
+            .ownTabContainer()
+            .then(ownTab =>
+                webext.browserBg.contextualIdentities.get(ownTab.cookieStoreId),
+            )
             .then(container => {
                 statusIndicator.setAttribute(
                     "style",

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -57,6 +57,24 @@ export async function activeTabContainerId() {
     return (await activeTab()).cookieStoreId
 }
 
+//#content_helper
+export async function ownTab() {
+    // Warning: this relies on the owntab_background listener being set in messaging.ts in order to work
+    return await browser.runtime.sendMessage({ type: "owntab_background" })
+}
+
+//#content_helper
+export async function ownTabId() {
+    return (await ownTab()).id
+}
+
+//#content_helper
+export async function ownTabContainer() {
+    return await browserBg.contextualIdentities.get(
+        (await ownTab()).cookieStoreId,
+    )
+}
+
 //#background_helper
 export async function activeTabContainer() {
     let containerId = await activeTabContainerId()
@@ -114,7 +132,9 @@ export async function openInNewTab(
             break
         case "last":
             // Infinity can't be serialised, apparently.
-            options.index = (await browserBg.tabs.query({currentWindow: true})).length
+            options.index = (await browserBg.tabs.query({
+                currentWindow: true,
+            })).length
             break
         case "related":
             if (await firefoxVersionAtLeast(57)) {


### PR DESCRIPTION
Firefox used to give the same color to all modeindicators on startup
with browser.sessionstore.restore_on_demand set to true in about:config,
This was caused by the use of `activeTabContainer` when setting the
modeindicator in content.ts. This call is replaced by a call to
`ownTabContainer`, which fixes this bug.

Closes https://github.com/tridactyl/tridactyl/issues/816 .