### PR TITLE
Add new config variable 'newtabfocus'.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -511,6 +511,11 @@ class default_config {
     allowautofocus: "true" | "false" = "true"
 
     /**
+     * Controls whether the newtab focuses on tridactyl or the firefox urlbar.
+     */
+    allownewtabfocus: "true" | "false" = "true"
+
+    /**
      * Whether to use Tridactyl's (bad) smooth scrolling.
      */
     smoothscroll: "true" | "false" = "false"

--- a/src/config.ts
+++ b/src/config.ts
@@ -511,9 +511,11 @@ class default_config {
     allowautofocus: "true" | "false" = "true"
 
     /**
-     * Controls whether the newtab focuses on tridactyl or the firefox urlbar.
+     * Controls whether the newtab focuses on tridactyl's newtab page or the firefox urlbar.
+     *
+     * To get FF default behaviour, use "urlbar".
      */
-    allownewtabfocus: "true" | "false" = "true"
+    newtabfocus: "page" | "urlbar" = "page"
 
     /**
      * Whether to use Tridactyl's (bad) smooth scrolling.

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -36,8 +36,8 @@ window.addEventListener("load", _ => {
         return
     }
     spoilerbutton.addEventListener("click", readChangelog)
-    config.getAsync("allownewtabfocus").then(f => {
-        if (f === "true") {
+    config.getAsync("newtabfocus").then(f => {
+        if (f === "page") {
             window.focus()
         }
     })

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -1,5 +1,7 @@
 // This file is only included in newtab.html, after content.js has been loaded
 
+import * as config from "./config"
+
 // These functions work with the elements created by tridactyl/scripts/newtab.md.sh
 function getChangelogDiv() {
     const changelogDiv = document.getElementById("changelog")
@@ -34,5 +36,9 @@ window.addEventListener("load", _ => {
         return
     }
     spoilerbutton.addEventListener("click", readChangelog)
-    window.focus()
+    config.getAsync("allownewtabfocus").then(f => {
+        if (f === "true") {
+            window.focus()
+        }
+    })
 })


### PR DESCRIPTION
Allows switching between having the newtab site grab focus or letting
the urlbar keep it with the former being default.