### PR TITLE
Update metadata names

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,7 +41,7 @@ fi
   && node compiler/gen_metadata.js \
           --out src/.metadata.generated.ts \
           --themeDir src/static/themes \
-          src/excmds.ts src/config.ts
+          src/excmds.ts src/lib/config.ts
 
 scripts/newtab.md.sh
 scripts/make_tutorial.sh

--- a/src/completions/Settings.ts
+++ b/src/completions/Settings.ts
@@ -63,7 +63,7 @@ export class SettingsCompletionSource extends Completions.CompletionSourceFuse {
         options += options ? " " : ""
 
         let configmd =
-            metadata.everything["src/config.ts"].classes.default_config
+            metadata.everything["src/lib/config.ts"].classes.default_config
         let settings = config.get()
         this.options = Object.keys(settings)
             .filter(x => x.startsWith(query))

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3042,7 +3042,7 @@ function validateSetArgs(key: string, values: string[]) {
         throw "Unsupported setting type!"
     }
 
-    let md = Metadata.everything["src/config.ts"].classes.default_config[last]
+    let md = Metadata.everything["src/lib/config.ts"].classes.default_config[last]
     if (md) {
         if (md.type && !fitsType(value, md.type)) throw `Given type does not match expected type (given: ${value}, expected: ${typeToString(md.type)})`
     }


### PR DESCRIPTION
3ec27fd broke the commandline by moving config.ts while
metadata-generation/using code relied on its path. This commit updates
the path. A proper fix is to stop using paths and use names instead.