### PR TITLE
Make followpagepatterns case-insensitive, don't force it in excmds

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1564,7 +1564,7 @@ export function followpage(rel: "next" | "prev" = "next") {
         return
     }
 
-    const anchor = <HTMLAnchorElement>selectLast(`a[rel~=${rel}][href]`) || findRelLink(new RegExp(config.get("followpagepatterns", rel), "i"))
+    const anchor = <HTMLAnchorElement>selectLast(`a[rel~=${rel}][href]`) || findRelLink(new RegExp(config.get("followpagepatterns", rel)))
 
     if (anchor) {
         DOM.mouseEvent(anchor, "click")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -414,8 +414,8 @@ class default_config {
      * Edit these if you want to add, e.g. other language support.
      */
     followpagepatterns = {
-        next: "^(next|newer)\\b|»|>>|more",
-        prev: "^(prev(ious)?|older)\\b|«|<<",
+        next: "/^(next|newer)\\b|»|>>|more/i",
+        prev: "/^(prev(ious)?|older)\\b|«|<</i",
     }
 
     /**


### PR DESCRIPTION
This commit makes followpagepatterns.{next,prev} case insensitive by
adding "/i" to them and removes the "i" parameter from the followpage
excmd, which means that user can now control whether they want their
pattern to be case-sensitive or not.

This fixes https://github.com/tridactyl/tridactyl/issues/943 for reasons
I do not quite understand.