### PR TITLE
commandline_frame.ts: Catch exception in input handler

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -221,7 +221,12 @@ clInput.addEventListener("input", async () => {
     let myInputId = onInputId + 1
     onInputId = myInputId
 
-    await onInputPromise
+    try {
+        await onInputPromise
+    } catch (e) {
+        // we don't actually care because this is the previous computation, which we will throw away
+        logger.warning(e)
+    }
 
     if (onInputId != myInputId) return
     onInputPromise = new Promise(resolve => {


### PR DESCRIPTION
Because of the await in the input handler, exceptions that are thrown
for previous computations will be thrown for the current one too, even
if there's no reason for it to go wrong. We fix this by surrounding the
await keyword with a try/catch and simply logging the error.