### PR TITLE
Implement mergedeep function

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -739,6 +739,17 @@ function setDeepProperty(obj, value, target) {
     }
 }
 
+export function mergeDeep(o1, o2) {
+    let r = Array.isArray(o1) ? o1.slice() : Object.create(o1)
+    Object.assign(r, o1, o2)
+    if (o2 === undefined)
+        return r
+    Object.keys(o1)
+        .filter(key => typeof o1[key] == "object" && typeof o2[key] == "object")
+        .forEach(key => Object.assign(r[key], mergeDeep(o1[key], o2[key])))
+    return r
+}
+
 export function getURL(url, target) {
     if (!USERCONFIG.subconfigs) return undefined
     let key =
@@ -774,8 +785,8 @@ export function get(...target) {
     const defult = getDeepProperty(DEFAULTS, target)
 
     // Merge results if there's a default value and it's not an Array or primitive.
-    if (defult && (!Array.isArray(defult) && typeof defult === "object")) {
-        return Object.assign(Object.assign(o({}), defult, user), site)
+    if (typeof defult === "object") {
+        return mergeDeep(mergeDeep(defult, user), site)
     } else {
         if (site !== undefined) {
             return site


### PR DESCRIPTION
Previously, running `config.get()` would result in only top level
objects being merged and returned. This means that if you ran
`config.get()`, the `nmaps` object would be the default one if no custom
bindings were defined, but it would not contain the default bindings if
custom bindings were defined.

This commit fixes that by implementing a mergeDeep function that makes
sure that children of the returned are merged with the default config.

Closes https://github.com/tridactyl/tridactyl/issues/390.