### PR TITLE
Turn `:bmarks` into a proper excmd

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -43,7 +43,8 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
 
     public async filter(exstr: string) {
         this.lastExstr = exstr
-        const [prefix, query] = this.splitOnPrefix(exstr)
+        let [prefix, query] = this.splitOnPrefix(exstr)
+        let option = ""
 
         // Hide self and stop if prefixes don't match
         if (prefix) {
@@ -56,9 +57,14 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
             return
         }
 
+        if (query.startsWith("-t ")) {
+            option = "-t "
+            query = query.slice(3)
+        }
+
         this.completion = undefined
         this.options = (await this.scoreOptions(query, 10)).map(
-            page => new BmarkCompletionOption(page.url, page),
+            page => new BmarkCompletionOption(option + page.url, page),
         )
 
         this.updateChain()
@@ -92,7 +98,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
 
     select(option: Completions.CompletionOption) {
         if (this.lastExstr !== undefined && option !== undefined) {
-            this.completion = "open " + option.value
+            this.completion = "bmarks " + option.value
             option.state = "focused"
             this.lastFocused = option
         } else {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1331,6 +1331,18 @@ export async function open(...urlarr: string[]) {
 }
 
 /**
+ * Works exactly like [[open]], but only suggests bookmarks.
+ *
+ * @param opt Optional. Has to be `-t` in order to make bmarks open your bookmarks in a new tab.
+ * @param urlarr any argument accepted by [[open]], or [[tabopen]] if opt is "-t"
+ */
+//#content
+export async function bmarks(opt: string, ...urlarr: string[]) {
+    if (opt == "-t") return tabopen(...urlarr)
+    else return open(opt, ...urlarr)
+}
+
+/**
  * Like [[open]] but doesn't make a new entry in history.
  */
 //#content
@@ -2022,7 +2034,7 @@ export async function tablast() {
     Hinting is controlled by `relatedopenpos`
 
 */
-//#background
+//#content
 export async function tabopen(...addressarr: string[]) {
     let active
     let container
@@ -2035,7 +2047,7 @@ export async function tabopen(...addressarr: string[]) {
             argParse(args)
         } else if (args[0] === "-c") {
             // Ignore the -c flag if incognito as containers are disabled.
-            let win = await browser.windows.getCurrent()
+            let win = await browserBg.windows.getCurrent()
             if (!win["incognito"]) container = await Container.fuzzyMatch(args[1])
             else logger.error("[tabopen] can't open a container in a private browsing window.")
 
@@ -2051,11 +2063,12 @@ export async function tabopen(...addressarr: string[]) {
 
     if (address == "") address = config.get("newtab")
     if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
-        if ((await browser.runtime.getPlatformInfo()).os === "mac" && (await browser.windows.getCurrent()).incognito) {
+        if ((await browserBg.runtime.getPlatformInfo()).os === "mac" && (await browserBg.windows.getCurrent()).incognito) {
             fillcmdline_notrail("# nativeopen isn't supported in private mode on OSX. Consider installing Linux or Windows :).")
             return
         } else {
-            nativeopen(address)
+            Messaging.message("commandline_background", "recvExStr", ["nativeopen " + address])
+            // nativeopen(address)
             return
         }
     } else if (address != "") url = forceURI(address)
@@ -2619,9 +2632,13 @@ export async function sleep(time_ms: number) {
 }
 
 /** @hidden */
-//#background
+//#content
 function showcmdline(focus = true) {
-    CommandLineBackground.show(focus)
+    Messaging.messageOwnTab("commandline_content", "show")
+    if (focus) {
+        Messaging.messageOwnTab("commandline_content", "focus")
+        Messaging.messageOwnTab("commandline_frame", "focus")
+    }
 }
 
 /** @hidden */
@@ -2631,20 +2648,20 @@ export function hidecmdline() {
 }
 
 /** Set the current value of the commandline to string *with* a trailing space */
-//#background
+//#content
 export function fillcmdline(...strarr: string[]) {
     let str = strarr.join(" ")
     showcmdline()
-    messageActiveTab("commandline_frame", "fillcmdline", [str])
+    Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str])
 }
 
 /** Set the current value of the commandline to string *without* a trailing space */
-//#background
+//#content
 export function fillcmdline_notrail(...strarr: string[]) {
     let str = strarr.join(" ")
     let trailspace = false
     showcmdline()
-    messageActiveTab("commandline_frame", "fillcmdline", [str, trailspace])
+    Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, trailspace])
 }
 
 /** Show and fill the command line without focusing it */
@@ -2698,11 +2715,12 @@ async function setclip(str) {
     // Functions to avoid retyping everything everywhere
 
     // Note: We're using fillcmdline here because exceptions are somehow not caught. We're rethrowing because otherwise the error message will be overwritten with the "yank successful" message.
-    let s = () => Native.clipboard("set", str).catch(e => {
-        let msg = "# Failed to set X selection. Is the native messenger installed and is it >=v.0.1.7?"
-        fillcmdline(msg)
-        throw msg
-    })
+    let s = () =>
+        Native.clipboard("set", str).catch(e => {
+            let msg = "# Failed to set X selection. Is the native messenger installed and is it >=v.0.1.7?"
+            fillcmdline(msg)
+            throw msg
+        })
     let c = async () => {
         await messageActiveTab("commandline_content", "focus")
         await messageActiveTab("commandline_frame", "setClipboard", [str])


### PR DESCRIPTION
Turning `:bmarks` into a proper excmd has several advantages: it will
show up in the `:help` pages, be available for excmd completions and
enbales adding specific arguments (such as "-t") in order to open
bookmarks in other tabs.

Doing this required moving tabopen and some of its dependencies to the
content script.

Closes https://github.com/tridactyl/tridactyl/issues/902.