### PR TITLE
Allow control over filename position in editorcmd

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -106,10 +106,9 @@ export async function getBestEditor(): Promise<string> {
             "urxvt -e",
             "alacritty -e", // alacritty is nice but takes ages to start and doesn't support class
             "cool-retro-term -e",
-            // Terminator and termite require  -e commands to be in quotes, hence the extra quote at the end.
-            // The closing quote is implemented in the editor function.
-            'terminator -e "',
-            'termite --class tridactyl_editor -e "',
+            // Terminator and termite require  -e commands to be in quotes
+            'terminator -e "{}"',
+            'termite --class tridactyl_editor -e "{}"',
             "dbus-launch gnome-terminal --",
             // I wanted to put hyper.js here as a joke but you can't start it running a command,
             // which is a far better joke: a terminal emulator that you can't send commands to.
@@ -223,11 +222,11 @@ export async function editor(file: string, content?: string) {
         config.get("editorcmd") == "auto"
             ? await getBestEditor()
             : config.get("editorcmd")
-    // Dirty hacks for termite and terminator support part 2.
-    const e = editorcmd.split(" ")[0]
-    if (e === "termite" || e === "terminator") {
-        await run(editorcmd + " " + file + '"')
-    } else await run(editorcmd + " " + file)
+    if (editorcmd.indexOf("{}") != -1) {
+        await run(editorcmd.replace(/{}/, file))
+    } else {
+        await run(editorcmd + " " + file)
+    }
     return await read(file)
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -192,7 +192,10 @@ export async function getInputSelector() {
  *
  * Uses the `editorcmd` config option, default = `auto` looks through a list defined in native_background.ts try find a sensible combination. If it's a bit slow, or chooses the wrong editor, or gives up completely, set editorcmd to something you want. The command must stay in the foreground until the editor exits.
  *
- * The editorcmd needs to accept a filename, stay in the foreground while it's edited, save the file and exit.
+ * The editorcmd needs to accept a filename, stay in the foreground while it's edited, save the file and exit. By default the filename is added to the end of editorcmd, if you require control over the position of that argument, the first occurrence of {} in editorcmd is replaced with the filename:
+ * ```
+ * set editorcmd 'terminator -e "{}"'
+ * ```
  *
  * You're probably better off using the default insert mode bind of `<C-i>` (Ctrl-i) to access this.
  *


### PR DESCRIPTION
I'm running on windows and I prefer using vim from within the WSL shell to have access to a proper terminal while I'm editing so my editorcmd ends up being a bit hairier to properly escape filenames:
```
set editorcmd start /wait C:\Windows\Sysnative\wsl.exe vim "$(wslpath -u '{}')"
```
As a bonus also gets rid of the terminator and termite hacks