### PR TITLE
Extend zoom excmd keybindings and improve documentation.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1797,10 +1797,28 @@ export function geturlsforlinks(reltype = "rel", rel: string) {
     return []
 }
 
+/** Sets the current page's zoom level anywhere between 30% and 300%.
+ *
+ * If you overshoot the level while using relative adjustments i.e. level > 300% or level < 30%
+ * the zoom level will be set to it's maximum or minimum position.
+ *
+ * @param level - The zoom level to set.
+ * Expects percentages when changing the absolute zoom value and percentage points when making relative adjustments..
+ * @param rel - Set the zoom adjustment to be relative to current zoom level.
+ */
 //#background
 export async function zoom(level = 0, rel = "false") {
     level = level > 3 ? level / 100 : level
-    if (rel == "true") level += await browser.tabs.getZoom()
+    if (rel === "false") {
+        if (level > 3 || level < 0.3) throw new Error(`[zoom] level out of range: ${level}`)
+    }
+    if (rel === "true") {
+        level += await browser.tabs.getZoom()
+
+        // Handle overshooting of zoom level.
+        if (level > 3) level = 3
+        if (level < 0.3) level = 0.3
+    }
     browser.tabs.setZoom(level)
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1803,7 +1803,7 @@ export function geturlsforlinks(reltype = "rel", rel: string) {
  * the zoom level will be set to it's maximum or minimum position.
  *
  * @param level - The zoom level to set.
- * Expects percentages when changing the absolute zoom value and percentage points when making relative adjustments..
+ * Expects percentages when changing the absolute zoom value and percentage points when making relative adjustments.
  * @param rel - Set the zoom adjustment to be relative to current zoom level.
  */
 //#background

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -250,7 +250,11 @@ class default_config {
         A: "bmark",
         zi: "zoom 0.1 true",
         zo: "zoom -0.1 true",
+        zM: "zoom 0.5 true",
+        zR: "zoom -0.5 true",
         zz: "zoom 1",
+        zI: "zoom 3",
+        zO: "zoom 0.3",
         ".": "repeat",
         "<SA-ArrowUp><SA-ArrowUp><SA-ArrowDown><SA-ArrowDown><SA-ArrowLeft><SA-ArrowRight><SA-ArrowLeft><SA-ArrowRight>ba":
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
@@ -405,6 +409,7 @@ class default_config {
             "fillcmdline_tmp 3000 !jsb is deprecated. Please use jsb instead",
         current_url: "composite get_current_url | fillcmdline_notrail ",
         stop: "js window.stop()",
+        zo: "zoom",
     }
 
     /**


### PR DESCRIPTION
This patch improves upon the existing zoom excmd and adds some features present
in Vimperator and Pentadactyl. `zI` and `zO` are now bound to the maximum and
minimum zoom levels respectively. `zM` (read zoom more) zooms in on increments
of 50pp and `zR` (read zoom reduce) zooms out on increments of 50pp.

In addition, overshooting the zoom level while using relative adjustments is now
handled by setting the level to it's max/min zoom level.

An error is thrown if an absolute value is given that is out of bounds of the
allowed zoom range.