### PR TITLE
Turn `:bmarks` into a proper excmd

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -43,7 +43,8 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
 
     public async filter(exstr: string) {
         this.lastExstr = exstr
-        const [prefix, query] = this.splitOnPrefix(exstr)
+        let [prefix, query] = this.splitOnPrefix(exstr)
+        let option = ""
 
         // Hide self and stop if prefixes don't match
         if (prefix) {
@@ -56,9 +57,14 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
             return
         }
 
+        if (query.startsWith("-t ")) {
+            option = "-t "
+            query = query.slice(3)
+        }
+
         this.completion = undefined
         this.options = (await this.scoreOptions(query, 10)).map(
-            page => new BmarkCompletionOption(page.url, page),
+            page => new BmarkCompletionOption(option + page.url, page),
         )
 
         this.updateChain()
@@ -92,7 +98,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
 
     select(option: Completions.CompletionOption) {
         if (this.lastExstr !== undefined && option !== undefined) {
-            this.completion = "open " + option.value
+            this.completion = "bmarks " + option.value
             option.state = "focused"
             this.lastFocused = option
         } else {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1360,6 +1360,18 @@ export async function open(...urlarr: string[]) {
 }
 
 /**
+ * Works exactly like [[open]], but only suggests bookmarks.
+ *
+ * @param opt Optional. Has to be `-t` in order to make bmarks open your bookmarks in a new tab.
+ * @param urlarr any argument accepted by [[open]], or [[tabopen]] if opt is "-t"
+ */
+//#background
+export async function bmarks(opt: string, ...urlarr: string[]) {
+    if (opt == "-t") return tabopen(...urlarr)
+    else return open(opt, ...urlarr)
+}
+
+/**
  * Like [[open]] but doesn't make a new entry in history.
  */
 //#content


### PR DESCRIPTION
Turn `:bmarks` into a proper excmd

Turning `:bmarks` into a proper excmd has several advantages: it will
show up in the `:help` pages, be available for excmd completions and
enbales adding specific arguments (such as "-t") in order to open
bookmarks in other tabs.

This time I'm directly messaging the background script in order to
trigger a tabopen rather than trying to bring tabopen to the content
script.

Closes https://github.com/tridactyl/tridactyl/issues/902.