### PR TITLE
Add setpref excmd

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -567,7 +567,6 @@ export async function getConfElsePrefElseDefault(
 export async function writePref(name: string, value: any) {
     if (cached_prefs) cached_prefs[name] = value
 
-    if (typeof value == "string") value = `"${value}"`
     const file = (await getProfileDir()) + "/user.js"
     // No need to check the return code because read returns "" when failing to
     // read a file

--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -2,6 +2,7 @@
  * Background functions for the native messenger interface
  */
 
+import * as Messaging from "@src/lib/messaging"
 import * as semverCompare from "semver-compare"
 import * as config from "@src/lib/config"
 import { browserBg } from "@src/lib/webext"
@@ -581,3 +582,6 @@ export async function writePref(name: string, value: any) {
         write(file, text.replace(substr, `pref("${name}", ${value})`))
     }
 }
+
+import * as SELF from "@src/background/native_background"
+Messaging.addListener("native_background", Messaging.attributeCaller(SELF))

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -10,6 +10,7 @@ import { BmarkCompletionSource } from "@src/completions/Bmark"
 import { ExcmdCompletionSource } from "@src/completions/Excmd"
 import { HelpCompletionSource } from "@src/completions/Help"
 import { HistoryCompletionSource } from "@src/completions/History"
+import { PreferenceCompletionSource } from "@src/completions/Preferences"
 import { SettingsCompletionSource } from "@src/completions/Settings"
 import * as Messaging from "@src/lib/messaging"
 import * as Config from "@src/lib/config"
@@ -68,6 +69,7 @@ function enableCompletions() {
             new ExcmdCompletionSource(completionsDiv),
             new HelpCompletionSource(completionsDiv),
             new HistoryCompletionSource(completionsDiv),
+            new PreferenceCompletionSource(completionsDiv),
             new SettingsCompletionSource(completionsDiv),
         ]
 

--- a/src/completions/Preferences.ts
+++ b/src/completions/Preferences.ts
@@ -1,0 +1,57 @@
+import * as Completions from "@src/completions"
+import * as Messaging from "@src/lib/messaging"
+
+class PreferenceCompletionOption extends Completions.CompletionOptionHTML
+    implements Completions.CompletionOptionFuse {
+    public fuseKeys = []
+
+    constructor(
+        public value: string,
+        public prefvalue: string
+    ) {
+        super()
+        this.fuseKeys.push(value)
+        this.html = html`<tr class="PreferenceCompletionOption option">
+            <td class="name">${value}</td>
+            <td class="value">${prefvalue}</td>
+        </tr>`
+    }
+}
+
+export class PreferenceCompletionSource extends Completions.CompletionSourceFuse {
+    public options: PreferenceCompletionOption[]
+
+    constructor(private _parent) {
+        super(
+            ["setpref"],
+            "PreferenceCompletionSource",
+            "Preference",
+        )
+
+        this._parent.appendChild(this.node)
+    }
+
+    public onInput(exstr: string) {
+        return this.filter(exstr)
+    }
+
+    public async filter(exstr: string) {
+        if (!exstr) {
+            this.state = "hidden"
+            return
+        }
+        let [cmd, pref] = this.splitOnPrefix(exstr)
+        if (pref === undefined) {
+            this.state = "hidden"
+            return
+        }
+        this.lastExstr = exstr
+        let preferences = await Messaging.message("native_background", "getPrefs", [])
+        this.options = Object.keys(preferences)
+            .filter(key => key.startsWith(pref))
+            .map(key => new PreferenceCompletionOption(key, preferences[key]))
+        if (this.options.length > 0)
+            this.state = "normal"
+        this.updateChain()
+    }
+}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -794,12 +794,28 @@ export async function colourscheme(themename: string) {
 }
 
 /**
+ * Write a setting to your user.js file.
+ *
+ * @param key The key that should be set. Must not be quoted. Must not contain spaces.
+ * @param value The value the key should take. Quoted if a string, unquoted otherwise.
+ *
+ * Note that not all of the keys Firefox uses are suggested by Tridactyl.
+ *
+ * e.g.: `setpref general.warnOnAboutConfig false`
+ * `setpref extensions.webextensions.restricterDomains ""`
+ */
+//#background
+export async function setpref(key: string, value: string) {
+    await Native.writePref(key, value)
+}
+
+/**
  * Like [[fixamo]] but quieter.
  */
 //#background
 export async function fixamo_quiet() {
-    await Native.writePref("privacy.resistFingerprinting.block_mozAddonManager", true)
-    await Native.writePref("extensions.webextensions.restrictedDomains", "")
+    await setpref("privacy.resistFingerprinting.block_mozAddonManager", "true")
+    return setpref("extensions.webextensions.restrictedDomains", '""')
 }
 
 /**

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -11,6 +11,7 @@ export type NonTabMessageType =
     | "commandline_background"
     | "controller_background"
     | "browser_proxy_background"
+    | "native_background"
     | "download_background"
     | "performance_background"
 export type MessageType = TabMessageType | NonTabMessageType


### PR DESCRIPTION
This PR adds a setpref excmd with completions. Unfortunately this completion source is far from exhaustive, but I'm not sure what we could do about that short of adding the list of all preferences (which vary on a per version/language/OS/distro/whatever else basis) to Tridactyl's source code.

Closes https://github.com/tridactyl/tridactyl/issues/940 .