### PR TITLE
Kill the gnome

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -119,7 +119,9 @@ export async function getBestEditor(): Promise<string> {
             // Terminator and termite require  -e commands to be in quotes
             'terminator -e "%f"',
             'termite --class tridactyl_editor -e "%f"',
-            "dbus-launch gnome-terminal --",
+            // Gnome-terminal doesn't work consistently, see issue #1035
+            // "dbus-launch gnome-terminal --",
+
             // I wanted to put hyper.js here as a joke but you can't start it running a command,
             // which is a far better joke: a terminal emulator that you can't send commands to.
             // You win this time, web artisans.


### PR DESCRIPTION
Gnome terminal doesn't work consistently: it doesn't block but some
distros add wrappers that will make it block when given the right
arguments. Closes https://github.com/tridactyl/tridactyl/issues/1035.