### PR TITLE
Add Fullscreen{Change,Enter,Left} autocommand events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5046,12 +5046,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5066,17 +5068,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5193,7 +5198,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5205,6 +5211,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5219,6 +5226,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5226,12 +5234,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5250,6 +5260,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5330,7 +5341,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5342,6 +5354,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5463,6 +5476,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1923,6 +1923,7 @@ export async function reader() {
 loadaucmds("DocStart")
 window.addEventListener("pagehide", () => loadaucmds("DocEnd"))
 window.addEventListener("DOMContentLoaded", () => loadaucmds("DocLoad"))
+/** @hidden */
 const fullscreenhandler = () => {
     loadaucmds("FullscreenChange")
     if (document.fullscreenElement || (document as any).mozFullScreenElement) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1932,10 +1932,10 @@ const fullscreenhandler = () => {
     }
 }
 
-const prefixed = "mozFullScreenEnabled" in document
+const fullscreenApiIsPrefixed = "mozFullScreenEnabled" in document
 
 // Until firefox removes vendor prefix for this api (in FF64), we must also use mozfullscreenchange
-if (prefixed) {
+if (fullscreenApiIsPrefixed) {
     document.addEventListener("mozfullscreenchange", fullscreenhandler)
 } else if ("fullscreenEnabled" in document) {
     document.addEventListener("fullscreenchange", fullscreenhandler)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1923,11 +1923,28 @@ export async function reader() {
 loadaucmds("DocStart")
 window.addEventListener("pagehide", () => loadaucmds("DocEnd"))
 window.addEventListener("DOMContentLoaded", () => loadaucmds("DocLoad"))
+const fullscreenhandler = () => {
+    loadaucmds("FullscreenChange")
+    if (document.fullscreenElement || (document as any).mozFullScreenElement) {
+        loadaucmds("FullscreenEnter")
+    } else {
+        loadaucmds("FullscreenLeft")
+    }
+}
+
+const prefixed = "mozFullScreenEnabled" in document
+
+// Until firefox removes vendor prefix for this api (in FF64), we must also use mozfullscreenchange
+if (prefixed) {
+    document.addEventListener("mozfullscreenchange", fullscreenhandler)
+} else if ("fullscreenEnabled" in document) {
+    document.addEventListener("fullscreenchange", fullscreenhandler)
+}
 // }
 
 /** @hidden */
 //#content
-export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "TabEnter" | "TabLeft") {
+export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "TabEnter" | "TabLeft" | "FullscreenEnter" | "FullscreenLeft" | "FullscreenChange") {
     let aucmds = await config.getAsync("autocmds", cmdType)
     const ausites = Object.keys(aucmds)
     const aukeyarr = ausites.filter(e => window.document.location.href.search(e) >= 0)
@@ -3268,10 +3285,10 @@ export function set(key: string, ...values: string[]) {
 
 /** @hidden */
 //#background_helper
-let AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft"]
+let AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft", "FullscreenChange", "FullscreenEnter", "FullscreenLeft"]
 /** Set autocmds to run when certain events happen.
 
- @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter' and 'TabLeft' are supported.
+ @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
 
  @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
 
@@ -3313,7 +3330,7 @@ export function autocontain(domain: string, container: string) {
 }
 
 /** Remove autocmds
- @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter' and 'TabLeft' are supported.
+ @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
 
  @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
 */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -316,6 +316,21 @@ class default_config {
             // Too bad :/
             // "emacs.org": "tabclose",
         },
+
+        /**
+         * Commands that will be run when fullscreen state changes.
+         */
+        FullscreenChange: {},
+
+        /**
+         * Commands that will be run when fullscreen state is entered.
+         */
+        FullscreenEnter: {},
+
+        /**
+         * Commands that will be run when fullscreen state is left.
+         */
+        FullscreenLeft: {},
     }
 
     /**


### PR DESCRIPTION
Adds autocommand hooks for the [fullscreenchange](https://developer.mozilla.org/en-US/docs/Web/Events/fullscreenchange) event. 

Because the fullscreen api is still vendor prefixed, and will be until FF64, the code is designed to be forward compatible for when FF64 lands and the prefix is removed (we detect if the prefix exists at runtime and attach the handler to the correct event).

Three autocommands were added:
+ FullscreenChange - called whenever fullscreen state is changed
+ FullscreenEnter - called whenever fullscreen state is changed and fullscreen mode has been entered
+ FullscreenLeft - called whenever fullscreen state is changed and fullscreen mode has been left

Closes #1003