### PR TITLE
excmds.ts: Fix setpref breaking user.js when value contains spaces

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -805,8 +805,8 @@ export async function colourscheme(themename: string) {
  * `setpref extensions.webextensions.restricterDomains ""`
  */
 //#background
-export async function setpref(key: string, value: string) {
-    await Native.writePref(key, value)
+export async function setpref(key: string, ...value: string[]) {
+    await Native.writePref(key, value.join(" "))
 }
 
 /**


### PR DESCRIPTION
Before this commit, `:setpref my_pref "my value"` broke user.js by only
writing '"my' to the file. This created a syntax error and prevented
firefox from reading the rest of the file. This commit fixes that.