### PR TITLE
scrolling.ts: Fix sticky scrolling

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -808,13 +808,13 @@ export function scrollto(a: number | string, b: number | "x" | "y" = "y") {
         if (top == elem.getClientRects()[0].top && (percentage == 0 || percentage == 100)) {
             // scrollTo failed, if the user wants to go to the top/bottom of
             // the page try scrolling.recursiveScroll instead
-            scrolling.recursiveScroll(window.scrollX, 1073741824 * (percentage == 0 ? -1 : 1), [document.documentElement])
+            scrolling.recursiveScroll(window.scrollX, 1073741824 * (percentage == 0 ? -1 : 1), document.documentElement)
         }
     } else if (b === "x") {
         let left = elem.getClientRects()[0].left
         window.scrollTo((percentage * elem.scrollWidth) / 100, window.scrollY)
         if (left == elem.getClientRects()[0].left && (percentage == 0 || percentage == 100)) {
-            scrolling.recursiveScroll(1073741824 * (percentage == 0 ? -1 : 1), window.scrollX, [document.documentElement])
+            scrolling.recursiveScroll(1073741824 * (percentage == 0 ? -1 : 1), window.scrollX, document.documentElement)
         }
     } else {
         window.scrollTo(a, Number(b)) // a,b numbers


### PR DESCRIPTION
Before this commit, Tridactyl used to "stick" at a page's edge. This was
caused by some values (namely lastX and lastY) that should have been
cached not being cached, resulting in Tridactyl trying to start
scrolling from the wrong element.

While testing this fix, I noticed that scrolling could be extremely slow
on large pages (e.g. https://stripe.com/docs/api). I attempted to fix
that by switching from a dumb parent/childNode traversal to a
TreeWalker-based traversal. While this helps a lot, scrolling can still
be slow on such pages.

Should close https://github.com/tridactyl/tridactyl/issues/777 .