### PR TITLE
Fix commandline failing to insert spaces in middle of words

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2433,6 +2433,7 @@ const cmdframe_fns: { [key: string]: [string, any[]] } = {
     next_completion: ["next_completion", []],
     prev_completion: ["prev_completion", []],
     insert_completion: ["insert_completion", []],
+    insert_space_or_completion: ["insert_space_or_completion", []],
     complete: ["complete", []],
     hide_and_clear: ["hide_and_clear", []],
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -86,7 +86,7 @@ class default_config {
         "<C-f>": "ex.complete",
         "<Tab>": "ex.next_completion",
         "<S-Tab>": "ex.prev_completion",
-        "<Space>": "ex.insert_completion",
+        "<Space>": "ex.insert_space_or_completion",
     }
 
     /**


### PR DESCRIPTION
Before this commit, it was impossible to insert a space in the middle of
a word in the command line ; the space would always be inserted at its
end.