### PR TITLE
Minor code cleanups

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -51,7 +51,7 @@ async function sendNativeMsg(
         return resp as MessageResp
     } catch (e) {
         if (!quiet) {
-            throw e
+            throw new Error("Failed to send message to native messenger. If it is correctly installed (run `:native`), please report this bug on https://github.com/tridactyl/tridactyl/issues .")
         }
     }
 }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -385,6 +385,7 @@ function applyWithTmpTextArea(fn) {
 
 /** @hidden **/
 export async function setClipboard(content: string) {
+    await Messaging.messageOwnTab("commandline_content", "focus")
     applyWithTmpTextArea(scratchpad => {
         scratchpad.value = content
         scratchpad.select()
@@ -394,20 +395,21 @@ export async function setClipboard(content: string) {
         } else throw "Failed to copy!"
     })
     // Return focus to the document
-    Messaging.messageOwnTab("commandline_content", "hide")
-    Messaging.messageOwnTab("commandline_content", "blur")
+    await Messaging.messageOwnTab("commandline_content", "hide")
+    return Messaging.messageOwnTab("commandline_content", "blur")
 }
 
 /** @hidden **/
-export function getClipboard() {
+export async function getClipboard() {
+    await Messaging.messageOwnTab("commandline_content", "focus")
     const result = applyWithTmpTextArea(scratchpad => {
         scratchpad.focus()
         document.execCommand("Paste")
         return scratchpad.textContent
     })
     // Return focus to the document
-    Messaging.messageOwnTab("commandline_content", "hide")
-    Messaging.messageOwnTab("commandline_content", "blur")
+    await Messaging.messageOwnTab("commandline_content", "hide")
+    await Messaging.messageOwnTab("commandline_content", "blur")
     return result
 }
 


### PR DESCRIPTION
This commit makes error messages when the native messenger is
unavailable easier to read. Since they're easier to read, there's no
need for custom errors in setclip/getclip anymore, provided that the
errors they throw are correctly logged. In order to make sure of that,
we remove the try/catch in excmds.ts:clipboard(), which should let
errors bubble up as needed.

I also noticed that while {set,get}Clipboard relied on the command line
being focused in order to work, they didn't do that themselves and
instead expected their callers to have set things up. This didn't make
sense to me so I moved the focusing code inside of {set,get}Clipboard.

This was all done while chasing the elusive #1135 but probably doesn't
change anything about it.