### PR TITLE
commandline_frame.ts: Make sure activeCompletions is defined

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -186,7 +186,9 @@ export function prev_completion() {
  */
 export function insert_completion() {
     const command = getCompletion()
-    activeCompletions.forEach(comp => (comp.completion = undefined))
+    if (activeCompletions) {
+        activeCompletions.forEach(comp => (comp.completion = undefined))
+    }
     if (command) {
         clInput.value = command + " "
         clInput.dispatchEvent(new Event("input")) // dirty hack for completions
@@ -199,7 +201,9 @@ export function insert_completion() {
  */
 export function insert_space_or_completion() {
     const command = getCompletion()
-    activeCompletions.forEach(comp => (comp.completion = undefined))
+    if (activeCompletions) {
+        activeCompletions.forEach(comp => (comp.completion = undefined))
+    }
     if (command) {
         clInput.value = command + " "
     } else {


### PR DESCRIPTION
This is a temporary fix for
https://github.com/tridactyl/tridactyl/issues/1167 . I couldn't find
where this issue might come from and since there are no reproduction
steps this will have to do.

I plan on modeling Tridactyl in TLA+ when I have time in order to find
out where our hard-to-reproduce bugs come from. Hopefully this bug will
be among them.

Closes #1167.