### PR TITLE
Metadata Types: Use a single type instance where it makes sense

### DIFF
--- a/compiler/types/AnyType.ts
+++ b/compiler/types/AnyType.ts
@@ -1,12 +1,13 @@
 import { Type } from "./Type"
 
 export class AnyType implements Type {
+    static instance = new AnyType()
     kind = "any"
 
     constructor() {}
 
     toConstructor() {
-        return "new AnyType()"
+        return "AnyType.instance"
     }
 
     toString() {

--- a/compiler/types/BooleanType.ts
+++ b/compiler/types/BooleanType.ts
@@ -1,12 +1,13 @@
 import { Type } from "./Type"
 
 export class BooleanType implements Type {
+    static instance = new BooleanType()
     kind = "boolean"
 
     constructor() {}
 
     toConstructor() {
-        return "new BooleanType()"
+        return "BooleanType.instance"
     }
 
     toString() {

--- a/compiler/types/NumberType.ts
+++ b/compiler/types/NumberType.ts
@@ -1,12 +1,13 @@
 import { Type } from "./Type"
 
 export class NumberType implements Type {
+    static instance = new NumberType()
     kind = "number"
 
     constructor() {}
 
     toConstructor() {
-        return "new NumberType()"
+        return "NumberType.instance"
     }
 
     toString() {

--- a/compiler/types/StringType.ts
+++ b/compiler/types/StringType.ts
@@ -1,12 +1,13 @@
 import { Type } from "./Type"
 
 export class StringType implements Type {
+    static instance = new StringType()
     kind = "string"
 
     constructor() {}
 
     toConstructor() {
-        return "new StringType()"
+        return "StringType.instance"
     }
 
     toString() {

--- a/compiler/types/VoidType.ts
+++ b/compiler/types/VoidType.ts
@@ -1,12 +1,13 @@
 import { Type } from "./Type"
 
 export class VoidType implements Type {
+    static instance = new VoidType()
     kind = "void"
 
     constructor() {}
 
     toConstructor() {
-        return "new VoidType()"
+        return "VoidType.instance"
     }
 
     toString() {


### PR DESCRIPTION
One of the possible problems of #1184 (firefox freezing periodically
with Tridactyl enabled) is that Tridactyl uses too much RAM, which could
cause Firefox to attempt to GC it from time to time.
One easy optimisation to try to reduce this problem is to use singletons
for metadata when possible (VoidType, AnyType...).
According to my measurements, this saves the allocation of 933 objects,
which amounted to ~0.03MB. Multiply this by 40 tabs and you get about
1.20MB saved, the space of a whole 1980-era floppy disk.