### PR TITLE
Config api

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -79,13 +79,11 @@ function removeCSPListener() {
 
 config.getAsync("csp").then(csp => csp === "clobber" && addCSPListener())
 
-browser.storage.onChanged.addListener((changes, areaname) => {
-    if ("userconfig" in changes) {
-        if (changes.userconfig.newValue.csp === "clobber") {
-            addCSPListener()
-        } else {
-            removeCSPListener()
-        }
+config.addChangeListener("csp", (old, cur) => {
+    if (cur === "clobber") {
+        addCSPListener()
+    } else {
+        removeCSPListener()
     }
 })
 

--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -14,14 +14,9 @@ async function getDuration() {
         opts.duration = await config.getAsync("scrollduration")
     return opts.duration
 }
-browser.storage.onChanged.addListener(changes => {
-    if ("userconfig" in changes) {
-        if ("smoothscroll" in changes.userconfig.newValue)
-            opts.smooth = changes.userconfig.newValue["smoothscroll"]
-        if ("scrollduration" in changes.userconfig.newValue)
-            opts.duration = changes.userconfig.newValue["scrollduration"]
-    }
-})
+
+config.addChangeListener("smoothscroll", (prev, cur) => opts.smooth = cur)
+config.addChangeListener("scrollduration", (prev, cur) => opts.duration = cur)
 
 class ScrollingData {
     // time at which the scrolling animation started

--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -80,12 +80,7 @@ function retheme() {
     })
 }
 
-// Hacky listener
-browser.storage.onChanged.addListener((changes, areaname) => {
-    if ("userconfig" in changes) {
-        retheme()
-    }
-})
+config.addChangeListener("theme", retheme)
 
 // Sometimes pages will overwrite class names of elements. We use a MutationObserver to make sure that the HTML element always has a TridactylTheme class
 // We can't just call theme() because it would first try to remove class names from the element, which would trigger the MutationObserver before we had a chance to add the theme class and thus cause infinite recursion

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -794,6 +794,9 @@ function setDeepProperty(obj, value, target) {
     }
 }
 
+/** @hidden
+ * Merges two objects and any child objects they may have
+ */
 export function mergeDeep(o1, o2) {
     let r = Array.isArray(o1) ? o1.slice() : Object.create(o1)
     Object.assign(r, o1, o2)
@@ -804,7 +807,11 @@ export function mergeDeep(o1, o2) {
     return r
 }
 
-export function getURL(url, target) {
+/** @hidden
+ * Gets a site-specific setting.
+ */
+
+export function getURL(url: string, target: string[]) {
     if (!USERCONFIG.subconfigs) return undefined
     let key =
         // For each key
@@ -1069,7 +1076,13 @@ async function init() {
     }
 }
 
+/** @hidden */
 const changeListeners = new Map()
+
+/** @hidden
+ * @param name The name of a "toplevel" config setting (i.e. "nmaps", not "nmaps.j")
+ * @param listener A function to call when the value of $name is modified in the config. Takes the previous and new value as parameters.
+ */
 export function addChangeListener<P extends keyof default_config>(
     name: P,
     listener: (old: default_config[P], neww: default_config[P]) => void,
@@ -1082,6 +1095,9 @@ export function addChangeListener<P extends keyof default_config>(
     arr.push(listener)
 }
 
+/** @hidden
+ * Removes event listeners set with addChangeListener
+ */
 export function removeChangeListener<P extends keyof default_config>(
     name: P,
     listener: (old: default_config[P], neww: default_config[P]) => void,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1104,12 +1104,18 @@ browser.storage.onChanged.addListener(async (changes, areaname) => {
             let unsetKeys = Object.keys(USERCONFIG).filter(
                 k =>
                     changes[CONFIGNAME].newValue[k] === undefined &&
-                    USERCONFIG[k] != defaultConf[k],
+                    JSON.stringify(USERCONFIG[k]) !=
+                        JSON.stringify(defaultConf[k]),
             )
 
-            // A key has changed if its value in `changes` is different from the one in USERCONFIG
+            // A key has changed if it is defined in USERCONFIG and its value in USERCONFIG is different from the one in `changes` or if the value in defaultConf is different from the one in `changes`
             let changedKeys = Object.keys(changes[CONFIGNAME].newValue).filter(
-                k => USERCONFIG[k] != changes[CONFIGNAME].newValue[k],
+                k =>
+                    JSON.stringify(
+                        USERCONFIG[k] !== undefined
+                            ? USERCONFIG[k]
+                            : defaultConf[k],
+                    ) != JSON.stringify(changes[CONFIGNAME].newValue[k]),
             )
 
             let old = USERCONFIG


### PR DESCRIPTION
This implements the API suggested in https://github.com/tridactyl/tridactyl/issues/1180 and thus closes #1180. Note that this API only lets you add listeners to "top-level" config settings (e.g. `nmaps`, not `nmaps.j`) because I wanted to use fancy types for `addChangeListener` and `removeChangeListener`, but also because it is simpler and adding listeners to non-toplevel config settings is not something we've needed for now.

Implementing this further convinced me that a good solution to https://github.com/tridactyl/tridactyl/issues/303 and https://github.com/tridactyl/tridactyl/issues/1169 could be the to flatten our config settings (e.g. `{"nmaps" : {"j": "someexcmd"}}` would become `{"nmaps.j": "someexcmd"}`), as I already mentioned in https://github.com/tridactyl/tridactyl/issues/774.  