### PR TITLE
scripts: Use different flags for sed and base64 on Mac

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -76,7 +76,12 @@ else
 fi
 
 if [ -e "$TRIDACTYL_LOGO" ] ; then
-	sed "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 --wrap 0 "$TRIDACTYL_LOGO")@" -i build/static/themes/default/default.css
+    # sed and base64 take different arguments on Mac
+    if [[ $OSTYPE == darwin* ]]; then
+	    sed -i "" "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO")@" build/static/themes/default/default.css
+    else
+	    sed "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 --wrap 0 "$TRIDACTYL_LOGO")@" -i build/static/themes/default/default.css
+    fi
 else
 	echo "Couldn't find Tridactyl logo ($TRIDACTYL_LOGO)"
 fi


### PR DESCRIPTION
sed and base64 have different flags on darwin (and possibly other
BSDs). Alternatively we could encourage the user to install coreutils and use
gsed and gbase64.