### PR TITLE
excmds: Allow selector for all non-element hints

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3357,7 +3357,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         case "-b":
             // Open in background
             selectHints = hinting.pipe(
-                DOM.HINTTAGS_selectors,
+                selectors || DOM.HINTTAGS_selectors,
                 async link => {
                     link.focus()
                     if (link.href) {
@@ -3374,7 +3374,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         case "-y":
             // Yank link
             selectHints = hinting.pipe(
-                DOM.HINTTAGS_selectors,
+                selectors || DOM.HINTTAGS_selectors,
                 elem => {
                     // /!\ Warning: This is racy! This can easily be fixed by adding an await but do we want this? yank can be pretty slow, especially with yankto=selection
                     run_exstr("yank " + elem["href"])
@@ -3443,7 +3443,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
 
         case "-W":
             selectHints = hinting.pipe(
-                DOM.HINTTAGS_selectors,
+                selectors || DOM.HINTTAGS_selectors,
                 elem => {
                     // /!\ RACY RACY RACY!
                     run_exstr(selectors + " " + rest.join(" ") + " " + elem)
@@ -3571,7 +3571,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
 
         default:
             selectHints = hinting.pipe(
-                DOM.HINTTAGS_selectors,
+                selectors || DOM.HINTTAGS_selectors,
                 elem => {
                     DOM.simulateClick(elem as HTMLElement)
                     return elem


### PR DESCRIPTION
I wanted to support something like `hint -qbc selector`. I noticed we can
instead deprecate the `-c` flag and just let any hint command take a selector.

I am unsure if this is the correct approach, so this is just a minor change to
get what I want working. After feedback I'll make a more "correct" change
(including documentation updates).