### PR TITLE
Move glacambre/typedoc-default-themes to tridactyl/typedoc-default-theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ts-jest": "^23.10.4",
     "ts-node": "^7.0.1",
     "typedoc": "^0.13.0",
-    "typedoc-default-themes": "git://github.com/glacambre/typedoc-default-themes.git#fix_weird_member_names_bin",
+    "typedoc-default-themes": "git://github.com/tridactyl/typedoc-default-themes.git#fix_weird_member_names_bin",
     "typescript": "^3.1.5",
     "uglify-es": "^3.3.9",
     "uglifyjs-webpack-plugin": "^2.0.1",


### PR DESCRIPTION
I transfered ownership of my typedoc-default-themes repo to the Tridactyl organization. This way I won't be the only one able to sneak bitcoin-stealing code into the build system.