### PR TITLE
Reapply PR #1150 "Only cycle through visible tabs"

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1704,7 +1704,7 @@ export async function tabprev(increment = 1) {
     // Proper way:
     // return tabIndexSetActive((await activeTab()).index - increment + 1)
     // Kludge until https://bugzilla.mozilla.org/show_bug.cgi?id=1504775 is fixed:
-    return browser.tabs.query({ currentWindow: true }).then(tabs => {
+    return browser.tabs.query({ currentWindow: true, hidden: false }).then(tabs => {
         tabs = tabs.sort((t1, t2) => t1.index - t2.index)
         let prevTab = (tabs.findIndex(t => t.active) - increment + tabs.length) % tabs.length
         return browser.tabs.update(tabs[prevTab].id, { active: true })


### PR DESCRIPTION
It seems the actual change in PR #1150 (a09a771) has been lost in its merge (6562699).

This should now actually fix Issue #1084 and ignore hidden tabs when cycling through tabs.