### PR TITLE
styling.ts: Fix style not being loaded when opening tabs in bg

### DIFF
--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -1,7 +1,7 @@
 import { staticThemes } from "@src/.metadata.generated"
 import * as config from "@src/lib/config"
 import * as Logging from "@src/lib/logging"
-import { browserBg } from "@src/lib/webext"
+import { browserBg, ownTabId } from "@src/lib/webext"
 
 const logger = new Logging.Logger("styling")
 
@@ -34,7 +34,7 @@ export async function theme(element) {
     if (insertedCSS) {
         // Typescript doesn't seem to be aware than remove/insertCSS's tabid
         // argument is optional
-        await (browserBg.tabs.removeCSS as any)(customCss)
+        await browserBg.tabs.removeCSS(await ownTabId(), customCss)
         insertedCSS = false
     }
 
@@ -49,7 +49,7 @@ export async function theme(element) {
     if (newTheme !== "default" && !THEMES.includes(newTheme)) {
         customCss.code = await config.getAsync("customthemes", newTheme)
         if (customCss.code) {
-            await (browserBg.tabs.insertCSS as any)(customCss)
+            await browserBg.tabs.insertCSS(await ownTabId(), customCss)
             insertedCSS = true
         } else {
             logger.error("Theme " + newTheme + " couldn't be found.")


### PR DESCRIPTION
By default, insertCSS and removeCSS operate in the active tab. This is a
problem when opening tabs in the background (e.g. with `hint -b`)
because the transformations will be applied to the current tab instead
of the newly opened one.
This commit fixes that.