### PR TITLE
[RFC] Add rudimentary version checker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3709,8 +3709,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "errno": {
       "version": "0.1.7",
@@ -9851,6 +9850,15 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss-parser": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.5.4.tgz",
+      "integrity": "sha512-dC7wHtz/p8QWQnsGgCB+HEYE01Dk8/AHMzSk0ZvoV3S0mhBqQNO/yi3H2fPh3qV2NNLNNEBg+8ZDSipKxjR5tQ==",
+      "requires": {
+        "entities": "^1.1.1",
+        "xml2js": "^0.4.19"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -10294,8 +10302,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "0.4.7",
@@ -14655,7 +14662,6 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -14664,8 +14670,7 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldom": {
       "version": "0.1.27",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "css": "^2.2.4",
     "fuse.js": "^3.3.0",
     "mark.js": "^8.11.1",
+    "rss-parser": "^3.5.4",
     "semver-compare": "^1.0.0"
   },
   "devDependencies": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -112,6 +112,12 @@ browser.runtime.onStartup.addListener(_ => {
     })
 })
 
+// Nag people about updates.
+// Hope that they're on a tab we can access.
+config.getAsync("updatenag").then(nag => {
+    if (nag === true) excmds.updatecheck(true)
+})
+
 // }}}
 
 // {{{ AUTOCOMMANDS

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -85,6 +85,8 @@ import * as CSS from "css"
 import * as Perf from "@src/perf"
 import * as Metadata from "@src/.metadata.generated"
 
+const TRI_VERSION = "REPLACE_ME_WITH_THE_VERSION_USING_SED"
+
 //#content_helper
 // {
 import "@src/lib/number.clamp"
@@ -2250,7 +2252,7 @@ export function suppress(preventDefault?: boolean, stopPropagation?: boolean) {
 
 //#background
 export function version() {
-    fillcmdline_notrail("REPLACE_ME_WITH_THE_VERSION_USING_SED")
+    fillcmdline_notrail(TRI_VERSION)
 }
 
 /** Example:
@@ -2455,7 +2457,7 @@ for (let fn in cmdframe_fns) {
 // {
 for (let editorfn in tri_editor) {
     let name = "text." + editorfn
-    cmd_params.set(name, new Map([['arr', 'string[]']]))
+    cmd_params.set(name, new Map([["arr", "string[]"]]))
     BGSELF[name] = (...args) => messageActiveTab("excmd_content", name, args)
 }
 for (let fn in cmdframe_fns) {
@@ -2901,8 +2903,7 @@ export function set(key: string, ...values: string[]) {
     if (key == "noiframeon") {
         let noiframes = config.get("noiframeon")
         // unset previous settings
-        if (noiframes)
-            noiframes.forEach(url => seturl(url, "noiframe", "false"))
+        if (noiframes) noiframes.forEach(url => seturl(url, "noiframe", "false"))
         // store new settings
         values.forEach(url => seturl(url, "noiframe", "true"))
         // save as deprecated setting for compatibility
@@ -3870,6 +3871,27 @@ export async function jsb(...str: string[]) {
     } else {
         return eval(str.join(" "))
     }
+}
+
+//#background_helper
+import * as Parser from "rss-parser"
+import * as semverCompare from "semver-compare"
+
+//#background
+export async function checkupdate() {
+    let parser = new Parser()
+    let feed = await parser.parseURL("https://github.com/tridactyl/tridactyl/tags.atom")
+
+    try {
+        // If any monster any makes a novelty tag this will break.
+        // So let's just ignore any errors.
+        // let latest = feed.items[0].title
+        let latest = feed.items[0].title
+        let current = TRI_VERSION.replace(/-.*/, "")
+        if (semverCompare(latest, current) > 0) {
+            fillcmdline_notrail("A new version of Tridactyl is available.")
+        }
+    } catch (e) {}
 }
 
 /**  Open a welcome page on first install.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3896,12 +3896,13 @@ export async function updatecheck(polite = false) {
         const latest = feed.items[0].title
         const current = TRI_VERSION.replace(/-.*/, "")
         if (semverCompare(latest, current) > 0) {
-            const releasedate = new Date(feed.items[0].pubDate) // e.g. 2018-12-04T15:24:43.000Z
+            const releasedate = new Date(feed.items[3].pubDate) // e.g. 2018-12-04T15:24:43.000Z
             const today = new Date()
             // any here are to shut up TS - it doesn't think Dates have subtraction defined :S
             const days_since = ((today as any) - (releasedate as any)) / (1000 * 60 * 60 * 24)
-            if (polite == false || days_since > config.get("updatenagwait")) {
-                fillcmdline_tmp(10000, "Tridactyl " + latest + " is available. Visit about:addons, right click Tridactyl, click 'Find Updates'. Restart Firefox once it has downloaded.")
+            if (polite == false || (days_since > config.get("updatenagwait") && semverCompare(latest, config.get("updatenaglastversion")) > 0)) {
+                config.set("updatenaglastversion", latest)
+                fillcmdline_tmp(30000, "Tridactyl " + latest + " is available. Visit about:addons, right click Tridactyl, click 'Find Updates'. Restart Firefox once it has downloaded.")
             }
         }
     } catch (e) {}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -696,6 +696,16 @@ class default_config {
     win_nativeinstallcmd = `powershell -NoProfile -InputFormat None -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))"`
 
     /**
+     * Whether Tridactyl should check for available updates at startup.
+     */
+    updatenag = true
+
+    /**
+     * How many days to wait after an update is first available until telling people.
+     */
+    updatenagwait = 7
+
+    /**
      * Profile directory to use with native messenger with e.g, `guiset`.
      */
     profiledir = "auto"
@@ -1056,11 +1066,13 @@ export async function update() {
             set("configversion", "1.4")
         },
         "1.4": () => {
-            (getDeepProperty(USERCONFIG, ["noiframeon"]) || []).forEach(site => {
-                setURL(site, "noiframe", "true")
-            })
+            ;(getDeepProperty(USERCONFIG, ["noiframeon"]) || []).forEach(
+                site => {
+                    setURL(site, "noiframe", "true")
+                },
+            )
             set("configversion", "1.5")
-        }
+        },
     }
     if (!get("configversion")) set("configversion", "0.0")
     const updatetest = v => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -706,6 +706,11 @@ class default_config {
     updatenagwait = 7
 
     /**
+     * The version we last nagged you about. We only nag you once per version.
+     */
+    updatenaglastversion = "1.14.0"
+
+    /**
      * Profile directory to use with native messenger with e.g, `guiset`.
      */
     profiledir = "auto"


### PR DESCRIPTION
I thought I might as well do #708 in the most fragile way possible. Might as well add a runtime dep in while we're at it.

Todo:
- [x] make sure nothing bad happens if the URL is unreachable.
- [ ] show on the newtab page
- [ ] perhaps, if the version difference is big enough, do `fillcmdline_nofocus` and then set a config `last_nagged_version` and compare to that rather than the actual current version.

Fixes #708.