### PR TITLE
hinting.ts: Give higher z-index to <a> hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -270,6 +270,7 @@ class Hint {
         if (config.get("hintuppercase") == "true") {
             this.flag.classList.add("TridactylHintUppercase")
         }
+        this.flag.classList.add("TridactylHint" + target.tagName)
         /* this.flag.style.cssText = ` */
         /*     top: ${rect.top}px; */
         /*     left: ${rect.left}px; */

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -11,6 +11,10 @@ span.TridactylHint {
     border-style: var(--tridactyl-hintspan-border-style) !important;
     padding: 0 1pt !important;
     text-align: center !important;
+    z-index: 2147483646 !important;
+}
+
+span.TridactylHintA {
     z-index: 2147483647 !important;
 }
 


### PR DESCRIPTION
Closes #1215.
Not sure about #506 and #367, do we want to find a way to never add useless hints (which is probably impossible) or is just giving lower priority to js hints enough?