### PR TITLE
Cycle the hint focus through the available hints

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ You can bind your own shortcuts in normal mode with the `:bind` command. For exa
 
 -   How can I change the colors or theme used by Tridactyl?
 
-    Use `:colors dark` (authored by @fugerf), `:colors shydactyl` (authored by @atrnh) or `:colors greenmat` (authored by @caputchinefrobles). Tridactyl can also load themes from disk, which would let you use one of the themes authored by @bezmi ([#1012](https://github.com/tridactyl/tridactyl/pull/1012)), see `:help colors` for more information.
+    Use `:colors dark` (authored by @furgerf), `:colors shydactyl` (authored by @atrnh) or `:colors greenmat` (authored by @caputchinefrobles). Tridactyl can also load themes from disk, which would let you use one of the themes authored by @bezmi ([#1012](https://github.com/tridactyl/tridactyl/pull/1012)), see `:help colors` for more information.
 
 -   How to remap keybindings? or How can I bind keys using the control/alt key modifiers (eg: `ctrl+^`)?
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -532,7 +532,7 @@ class default_config {
     hintchars = "hjklasdfgyuiopqwertnmzxcvb"
 
     /**
-     * The type of hinting to use. `vimperator` will allow you to filter links based on their names by typing non-hint chars. It is recommended that you use this in conjuction with the [[hintchars]] setting, which you should probably set to e.g, `5432167890`.
+     * The type of hinting to use. `vimperator` will allow you to filter links based on their names by typing non-hint chars. It is recommended that you use this in conjuction with the [[hintchars]] setting, which you should probably set to e.g, `5432167890`. ´vimperator-reflow´ additionally updates the hint labels after filtering.
      */
     hintfiltermode: "simple" | "vimperator" | "vimperator-reflow" = "simple"
 


### PR DESCRIPTION
Hi guys, I had some time to catch up with all the awesome changes to tridactyl - great job and thanks a lot for your effort! :+1: 

I was really looking forward to the vimperator-style hint filtering, great that we can do that now! However, I couldn't find out what the difference between `vimperator` and `vimperator-reflow` are. I saw that this has been asked before, so I added that to the documentation (at least I _hope_ I did).

Additionally, back when using vimperator, I would often filter links until just a few remain, then cycle through them with `<Tab>` and `<S-Tab>`. So, I had a look at `src/content/hinting.ts` and took a shot at implementing that. What's missing is the opposite direction - the `key` in the parser function doesn't seem to be a [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent), so I can't check `key.shiftKey`.

I hope this is something you'll find useful and maybe you can help with the shift-thing. Thanks in advance :)