### PR TITLE
Fix "tab" alias breaking completions

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -92,16 +92,22 @@ function getCompletion() {
 export function enableCompletions() {
     if (!activeCompletions) {
         activeCompletions = [
-            new BmarkCompletionSource(completionsDiv),
-            new TabAllCompletionSource(completionsDiv),
-            new BufferCompletionSource(completionsDiv),
-            new ExcmdCompletionSource(completionsDiv),
-            new FileSystemCompletionSource(completionsDiv),
-            new HelpCompletionSource(completionsDiv),
-            new HistoryCompletionSource(completionsDiv),
-            new PreferenceCompletionSource(completionsDiv),
-            new SettingsCompletionSource(completionsDiv),
+            BmarkCompletionSource,
+            TabAllCompletionSource,
+            BufferCompletionSource,
+            ExcmdCompletionSource,
+            FileSystemCompletionSource,
+            HelpCompletionSource,
+            HistoryCompletionSource,
+            PreferenceCompletionSource,
+            SettingsCompletionSource,
         ]
+            .map(constructorr => {
+                try {
+                    return new constructorr(completionsDiv)
+                } catch (e) {}
+            })
+            .filter(c => c)
 
         const fragment = document.createDocumentFragment()
         activeCompletions.forEach(comp => fragment.appendChild(comp.node))

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1078,6 +1078,10 @@ export async function update() {
             )
             set("configversion", "1.5")
         },
+        "1.5": () => {
+            unset("exaliases", "tab")
+            set("configversion", "1.6")
+        },
     }
     if (!get("configversion")) set("configversion", "0.0")
     const updatetest = v => {


### PR DESCRIPTION
PR#1183 broke completions for users that had a tab -> buffer alias. This
is because having such an alias created a loop, which made
BufferCompletionSource throw errors when being instanciated, which
resulted in the activeCompletions array not being created.

This is fixed in two ways: first, a config updater is created in order
to remove the alias. Second, completions are instantiated in
try/catchs, which should hopefully prevent a faulty completion source
constructor from breaking every completion source.