### PR TITLE
native_main.py: Add ".txt" suffix to temporary file names

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -477,7 +477,7 @@ def handleMessage(message):
             prefix = ""
         prefix = "tmp_{}_".format(sanitizeFilename(prefix))
 
-        (handle, filepath) = tempfile.mkstemp(prefix=prefix)
+        (handle, filepath) = tempfile.mkstemp(prefix=prefix, suffix=".txt")
         with os.fdopen(handle, "w") as file:
             file.write(message["content"])
         reply["content"] = filepath


### PR DESCRIPTION
Reasons explained in https://github.com/tridactyl/tridactyl/issues/1204

Closes #1204