### PR TITLE
Fix binding space

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -968,6 +968,23 @@ export async function save(storage: "local" | "sync" = get("storageloc")) {
     @hidden
 */
 export async function update() {
+    // Updates a value both in the main config and in sub (=site specific) configs
+    let updateAll = (setting: any[], fn: (any) => any) => {
+        let val = getDeepProperty(USERCONFIG, setting)
+        if (val) {
+            set(...setting, fn(val))
+        }
+        let subconfigs = getDeepProperty(USERCONFIG, ["subconfigs"])
+        if (subconfigs) {
+            Object.keys(subconfigs)
+                .map(pattern => [pattern, getURL(pattern, setting)])
+                .filter(([pattern, value]) => value)
+                .forEach(([pattern, value]) =>
+                    setURL(pattern, ...setting, fn(value)),
+                )
+        }
+    }
+
     let updaters = {
         "0.0": async () => {
             try {
@@ -1042,22 +1059,6 @@ export async function update() {
             set("configversion", "1.3")
         },
         "1.3": () => {
-            // Updates a value both in the main config and in sub (=site specific) configs
-            let updateAll = (setting: any[], fn: (any) => any) => {
-                let val = getDeepProperty(USERCONFIG, setting)
-                if (val) {
-                    set(...setting, fn(val))
-                }
-                let subconfigs = getDeepProperty(USERCONFIG, ["subconfigs"])
-                if (subconfigs) {
-                    Object.keys(subconfigs)
-                        .map(pattern => [pattern, getURL(pattern, setting)])
-                        .filter(([pattern, value]) => value)
-                        .forEach(([pattern, value]) =>
-                            setURL(pattern, ...setting, fn(value)),
-                        )
-                }
-            }
             ;[
                 "priority",
                 "hintdelay",
@@ -1081,6 +1082,38 @@ export async function update() {
         "1.5": () => {
             unset("exaliases", "tab")
             set("configversion", "1.6")
+        },
+        "1.6": () => {
+            let updateSetting = mapObj => {
+                if (!mapObj) return mapObj
+                if (mapObj[" "] != undefined) {
+                    mapObj["<Space>"] = mapObj[" "]
+                    delete mapObj[" "]
+                }
+                ;[
+                    "<A- >",
+                    "<C- >",
+                    "<M- >",
+                    "<S- >",
+                    "<AC- >",
+                    "<AM- >",
+                    "<AS- >",
+                    "<CM- >",
+                    "<CS- >",
+                    "<MS- >",
+                ].forEach(binding => {
+                    if (mapObj[binding] != undefined) {
+                        let key = binding.replace(" ", "Space")
+                        mapObj[key] = mapObj[binding]
+                        delete mapObj[binding]
+                    }
+                })
+                return mapObj
+            }
+            ;["nmaps", "exmaps", "imaps", "inputmaps", "ignoremaps"].forEach(
+                settingName => updateAll([settingName], updateSetting),
+            )
+            set("configversion", "1.7")
         },
     }
     if (!get("configversion")) set("configversion", "0.0")

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -79,8 +79,14 @@ export class MinimalKey {
             str += "-"
         }
 
+        let key = this.key
+        if (key == " ") {
+            key = "Space"
+            needsBrackets = true
+        }
+
         // Format the rest
-        str += this.key
+        str += key
         if (needsBrackets) {
             str = "<" + str + ">"
         }
@@ -349,15 +355,12 @@ export function translateKeysUsingKeyTranslateMap(
             // through, so we just swap the key event out for a new
             // MinimalKey with the right key and modifiers copied from
             // the original.
-            keyEvents[index] = new MinimalKey(
-                newkey,
-                {
-                    altKey: keyEvent.altKey,
-                    ctrlKey: keyEvent.ctrlKey,
-                    metaKey: keyEvent.metaKey,
-                    shiftKey: keyEvent.shiftKey,
-                }
-            )
+            keyEvents[index] = new MinimalKey(newkey, {
+                altKey: keyEvent.altKey,
+                ctrlKey: keyEvent.ctrlKey,
+                metaKey: keyEvent.metaKey,
+                shiftKey: keyEvent.shiftKey,
+            })
         }
     }
 }


### PR DESCRIPTION
Before storing bindings in the config, bindings are first converted to
their canonical representation by using toMapstr. The problem is that
toMapstr returns " " instead of "<Space>" when asked to convert a
minimalkey representing a space.
This was a problem while trying to bind/unbind keys that were already
bound in the config (e.g. `unbind --mode=ex <Space>` to disable
inserting completions).
This commit fixes that. It also comes with a config updater in order to
make sure that we do not break `<Space>` bindings for users who might
have created some.