### PR TITLE
commandline_content.ts: Don't instantiate multiple command lines

### DIFF
--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -17,23 +17,23 @@ const cmdline_logger = new Logger("cmdline")
 
 // inject the commandline iframe into a content page
 
-let cmdline_iframe: HTMLIFrameElement = undefined
+let cmdline_iframe = window.document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    "iframe",
+) as HTMLIFrameElement
+cmdline_iframe.className = "cleanslate"
+cmdline_iframe.setAttribute(
+    "src",
+    browser.extension.getURL("static/commandline.html"),
+)
+cmdline_iframe.setAttribute("id", "cmdline_iframe")
+
 let enabled = false
 
 /** Initialise the cmdline_iframe element unless the window location is included in a value of config/noiframe */
 async function init() {
     let noiframe = await config.getAsync("noiframe")
     if (noiframe == "false" && !enabled && cmdline_iframe === undefined) {
-        cmdline_iframe = window.document.createElementNS(
-            "http://www.w3.org/1999/xhtml",
-            "iframe",
-        ) as HTMLIFrameElement
-        cmdline_iframe.className = "cleanslate"
-        cmdline_iframe.setAttribute(
-            "src",
-            browser.extension.getURL("static/commandline.html"),
-        )
-        cmdline_iframe.setAttribute("id", "cmdline_iframe")
         hide()
         document.documentElement.appendChild(cmdline_iframe)
         enabled = true


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/issues/1237 is caused by multiple
command lines being instantiated in the tab. All command lines receive
the "fillcmdline tabopen" message, only one receives the key events
generated by typing stuff in the command line and then they all receive
the "ex.accept_line" message.

There can be two causes ; either Firefox loads multiple Tridactyls
(unlikely) or we load multiple commandlines (more likely). Moving
command line creation out of init() should fix this as the worst that
can happen now when init() is called twice is that the command line is
re-inserted in the document (before that we created multiple command
lines).

We'll have to try removing the update-disabling stuff we did if this does
nothing to make #1237 disappear and if that does nothing either we'll
probably need to ask Mozilla to look into our problem.