### PR TITLE
Move fillcmdline to content

### DIFF
--- a/src/background/commandline_background.ts
+++ b/src/background/commandline_background.ts
@@ -42,14 +42,6 @@ async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
     return browser.tabs.query({})
 }
 
-export async function show(focus = true) {
-    Messaging.messageActiveTab("commandline_content", "show")
-    if (focus) {
-        Messaging.messageActiveTab("commandline_content", "focus")
-        Messaging.messageActiveTab("commandline_frame", "focus")
-    }
-}
-
 export async function hide(tabid?) {
     if (!tabid) tabid = await activeTabId()
     Messaging.messageTab(tabid, "commandline_content", "hide")
@@ -63,7 +55,6 @@ Messaging.addListener(
         currentWindowTabs,
         history,
         recvExStr,
-        show,
         hide,
     }),
 )

--- a/src/background/commandline_background.ts
+++ b/src/background/commandline_background.ts
@@ -42,12 +42,6 @@ async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
     return browser.tabs.query({})
 }
 
-export async function hide(tabid?) {
-    if (!tabid) tabid = await activeTabId()
-    Messaging.messageTab(tabid, "commandline_content", "hide")
-    Messaging.messageTab(tabid, "commandline_content", "blur")
-}
-
 Messaging.addListener(
     "commandline_background",
     Messaging.attributeCaller({
@@ -55,6 +49,5 @@ Messaging.addListener(
         currentWindowTabs,
         history,
         recvExStr,
-        hide,
     }),
 )

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -106,6 +106,11 @@ export function blur() {
     }
 }
 
+export function hide_and_blur() {
+    hide()
+    blur()
+}
+
 export function executeWithoutCommandLine(fn) {
     let parent
     if (cmdline_iframe) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2407,41 +2407,39 @@ export function hidecmdline() {
 }
 
 /** Set the current value of the commandline to string *with* a trailing space */
-//#background
+//#content
 export function fillcmdline(...strarr: string[]) {
     let str = strarr.join(" ")
     showcmdline()
-    messageActiveTab("commandline_frame", "fillcmdline", [str])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str])
 }
 
 /** Set the current value of the commandline to string *without* a trailing space */
-//#background
+//#content
 export function fillcmdline_notrail(...strarr: string[]) {
     let str = strarr.join(" ")
-    let trailspace = false
     showcmdline()
-    messageActiveTab("commandline_frame", "fillcmdline", [str, trailspace])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false])
 }
 
 /** Show and fill the command line without focusing it */
-//#background
+//#content
 export function fillcmdline_nofocus(...strarr: string[]) {
     showcmdline(false)
-    return messageActiveTab("commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
 }
 
 /** Shows str in the command line for ms milliseconds. Recommended duration: 3000ms. */
-//#background
+//#content
 export async function fillcmdline_tmp(ms: number, ...strarr: string[]) {
     let str = strarr.join(" ")
-    let tabId = await activeTabId()
     showcmdline(false)
-    messageTab(tabId, "commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
+    Messaging.messageOwnTab("commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
     return new Promise(resolve =>
         setTimeout(async () => {
-            if ((await messageTab(tabId, "commandline_frame", "getContent", [])) == str) {
-                await messageTab(tabId, "commandline_content", "hide_and_blur")
-                await messageTab(tabId, "commandline_frame", "clear", [true])
+            if ((await Messaging.messageOwnTab("commandline_frame", "getContent", [])) == str) {
+                CommandLineContent.hide_and_blur()
+                resolve(Messaging.messageOwnTab("commandline_frame", "clear", [true]))
             }
             resolve()
         }, ms),

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -94,7 +94,7 @@ import "@src/lib/number.clamp"
 import * as SELF from "@src/.excmds_content.generated"
 Messaging.addListener("excmd_content", Messaging.attributeCaller(SELF))
 import * as DOM from "@src/lib/dom"
-import { executeWithoutCommandLine } from "@src/content/commandline_content"
+import * as CommandLineContent from "@src/content/commandline_content"
 import * as scrolling from "@src/content/scrolling"
 // }
 
@@ -1063,7 +1063,7 @@ export function viewsource(url = "") {
         return
     }
     if (!sourceElement) {
-        sourceElement = executeWithoutCommandLine(() => {
+        sourceElement = CommandLineContent.executeWithoutCommandLine(() => {
             let pre = document.createElement("pre")
             pre.id = "TridactylViewsourceElement"
             pre.className = "cleanslate " + config.get("theme")
@@ -2389,9 +2389,15 @@ export async function sleep(time_ms: number) {
 }
 
 /** @hidden */
-//#background
-function showcmdline(focus = true) {
-    CommandLineBackground.show(focus)
+//#content
+export function showcmdline(focus = true) {
+    CommandLineContent.show()
+    let done = Promise.resolve()
+    if (focus) {
+        CommandLineContent.focus()
+        done = Messaging.messageOwnTab("commandline_frame", "focus")
+    }
+    return done
 }
 
 /** @hidden */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2401,9 +2401,9 @@ export function showcmdline(focus = true) {
 }
 
 /** @hidden */
-//#background
+//#content
 export function hidecmdline() {
-    CommandLineBackground.hide()
+    CommandLineContent.hide_and_blur()
 }
 
 /** Set the current value of the commandline to string *with* a trailing space */
@@ -2440,7 +2440,7 @@ export async function fillcmdline_tmp(ms: number, ...strarr: string[]) {
     return new Promise(resolve =>
         setTimeout(async () => {
             if ((await messageTab(tabId, "commandline_frame", "getContent", [])) == str) {
-                CommandLineBackground.hide(tabId)
+                await messageTab(tabId, "commandline_content", "hide_and_blur")
                 await messageTab(tabId, "commandline_frame", "clear", [true])
             }
             resolve()


### PR DESCRIPTION
It doesn't make sense for fillcmdline* functions to live in the background script since we now have separate commandline states in each tab. This PR moves these functions to the content script. Nothing changes as far as cmdline behavior is concerned (except it should be theorically faster since there's no need to message the content twice to hide and blur the commandline anymore).