### PR TITLE
completions: Use browserBg instead of messaging background

### DIFF
--- a/src/background/commandline_background.ts
+++ b/src/background/commandline_background.ts
@@ -25,29 +25,9 @@ function recvExStr(exstr: string) {
     }
 }
 
-/** Helpers for completions */
-async function currentWindowTabs(): Promise<browser.tabs.Tab[]> {
-    return await browser.tabs.query({ currentWindow: true })
-}
-
-async function history(): Promise<browser.history.HistoryItem[]> {
-    return await browser.history.search({
-        text: "",
-        maxResults: 50,
-        startTime: 0,
-    })
-}
-
-async function allWindowTabs(): Promise<browser.tabs.Tab[]> {
-    return browser.tabs.query({})
-}
-
 Messaging.addListener(
     "commandline_background",
     Messaging.attributeCaller({
-        allWindowTabs,
-        currentWindowTabs,
-        history,
         recvExStr,
     }),
 )

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -1,4 +1,5 @@
 import * as Perf from "@src/perf"
+import { browserBg } from "@src/lib/webext.ts"
 import { enumerate } from "@src/lib/itertools"
 import * as Containers from "@src/lib/containers"
 import * as Messaging from "@src/lib/messaging"
@@ -78,11 +79,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         )
 
         /* console.log('updateOptions', this.optionContainer) */
-        const tabs: browser.tabs.Tab[] = await Messaging.message(
-            "commandline_background",
-            "currentWindowTabs",
-        )
-
+        const tabs: browser.tabs.Tab[] = await browserBg.tabs.query({ currentWindow: true })
         const options = []
 
         // Get alternative tab, defined as last accessed tab.

--- a/src/completions/TabAll.ts
+++ b/src/completions/TabAll.ts
@@ -65,10 +65,7 @@ export class TabAllCompletionSource extends Completions.CompletionSourceFuse {
 
     @Perf.measuredAsync
     private async updateOptions(exstr?: string) {
-        const tabsPromise = Messaging.message(
-            "commandline_background",
-            "allWindowTabs",
-        )
+        const tabsPromise = browserBg.tabs.query({})
         const windowsPromise = this.getWindows()
         const [tabs, windows] = await Promise.all([tabsPromise, windowsPromise])
 


### PR DESCRIPTION
commandline_background.ts:history() isn't used anywhere and is wrong (it
doesn't respect the historyresults setting) so this commit removes it.
Also, currentWindowTabs and allWindowTabs are both used in a single
place (respectively Tab and TabAll completions) and do not perform anything
complicated, thus it's better to have completions juste use browserBg
instead of manually messaging the background process.