### PR TITLE
Replace `return await promise` with `return promise`

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -249,7 +249,7 @@ export async function editor(file: string, content?: string) {
     } else {
         await run(editorcmd + " " + file)
     }
-    return await read(file)
+    return read(file)
 }
 
 export async function read(file: string) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1838,7 +1838,7 @@ async function idFromIndex(index?: number | "%" | "#" | string): Promise<number>
             index: index - 1,
         }))[0].id
     } else {
-        return await activeTabId()
+        return activeTabId()
     }
 }
 
@@ -2500,9 +2500,9 @@ for (let fn in cmdframe_fns) {
 /**
  * Returns the current URL. For use with [[composite]].
  */
-//#background
+//#content
 export async function get_current_url() {
-    return (await activeTab()).url
+    return window.location.href
 }
 
 /**
@@ -3382,13 +3382,13 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
     let hintTabOpen = async (href, active = !rapid) => {
         let containerId = await activeTabContainerId()
         if (containerId) {
-            return await openInNewTab(href, {
+            return openInNewTab(href, {
                 active,
                 related: true,
                 cookieStoreId: containerId,
             })
         } else {
-            return await openInNewTab(href, {
+            return openInNewTab(href, {
                 active,
                 related: true,
             })

--- a/src/lib/autocontainers.ts
+++ b/src/lib/autocontainers.ts
@@ -183,7 +183,7 @@ export class AutoContain implements IAutoContain {
                     )
                 }
             }
-            return await Container.getId(aucons[aukeyarr[0]])
+            return Container.getId(aucons[aukeyarr[0]])
         }
     }
 }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -174,7 +174,7 @@ export function fromString(
  *  @returns An array representation of all containers.
  */
 export async function getAll(): Promise<any[]> {
-    return await browser.contextualIdentities.query({})
+    return browser.contextualIdentities.query({})
 }
 
 /** Fetches the cookieStoreId of a given container

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -60,7 +60,7 @@ export async function activeTabContainerId() {
 //#content_helper
 export async function ownTab() {
     // Warning: this relies on the owntab_background listener being set in messaging.ts in order to work
-    return await browser.runtime.sendMessage({ type: "owntab_background" })
+    return browser.runtime.sendMessage({ type: "owntab_background" })
 }
 
 //#content_helper
@@ -79,7 +79,7 @@ export async function ownTabContainer() {
 export async function activeTabContainer() {
     let containerId = await activeTabContainerId()
     if (containerId !== "firefox-default")
-        return await browserBg.contextualIdentities.get(containerId)
+        return browserBg.contextualIdentities.get(containerId)
     else
         throw new Error(
             "firefox-default is not a valid contextualIdentity (activeTabContainer)",


### PR DESCRIPTION
Awaiting a promise before returning it doesn't make sense if the await
isn't in a try/catch as awaiting forces a function to be async and thus
turns its return value and any error it might throw into a promise.
Worse than that, it can result in an unnecessary context switch which
could be bad for performance.