### PR TITLE
Option to disable javascript hinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tags
 compiler/*.js
 compiler/**/*.js
 src/.metadata.generated.ts
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ tags
 compiler/*.js
 compiler/**/*.js
 src/.metadata.generated.ts
-*.swp

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -559,9 +559,10 @@ export function pipe(
     selectors = DOM.HINTTAGS_selectors,
     action: HintSelectedCallback = _ => _,
     rapid = false,
+    jshints = true,
 ): Promise<[Element, number]> {
     return new Promise((resolve, reject) => {
-        hintPage(hintables(selectors, true), action, resolve, reject, rapid)
+        hintPage(hintables(selectors, jshints), action, resolve, reject, rapid)
     })
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3495,6 +3495,11 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
         option = "-" + option.slice(2)
         rapid = true
     }
+    let jshints = true
+    if (option.startsWith("-j")) {
+        option = "-" + option.slice(2)
+        jshints = false
+    }
 
     let selectHints = new Promise(r => r())
     let hintTabOpen = async (href, active = !rapid) => {
@@ -3528,6 +3533,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                     return link
                 },
                 rapid,
+                jshints,
             )
             break
 
@@ -3541,6 +3547,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                     return elem
                 },
                 rapid,
+                jshints,
             )
             break
 
@@ -3598,6 +3605,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                     return elem
                 },
                 rapid,
+                jshints,
             )
             break
 
@@ -3610,6 +3618,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                     return elem
                 },
                 rapid,
+                jshints,
             )
             break
 
@@ -3618,6 +3627,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                 selectors,
                 elem => elem[rest.join(" ")],
                 rapid,
+                jshints,
             )
             break
 
@@ -3737,6 +3747,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                     return elem
                 },
                 rapid,
+                jshints,
             )
     }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3457,7 +3457,7 @@ import * as hinting from "@src/content/hinting"
         - `-pipe selector key` e.g, `-pipe a href` returns the key. Only makes sense with `composite`, e.g, `composite hint -pipe * textContent | yank`. If you don't select a hint (i.e. press <Esc>), will return an empty string.
         - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos.
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
-        - -j* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
+        - -J* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
         - -br deprecated, use `-qb` instead
 
     Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.
@@ -3492,14 +3492,20 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
     if (option == "-br") option = "-qb"
 
     let rapid = false
+    let jshints = true
+
     if (option.startsWith("-q")) {
         option = "-" + option.slice(2)
         rapid = true
     }
-    let jshints = true
-    if (option.startsWith("-j")) {
+
+    if (option.startsWith("-J")) {
         option = "-" + option.slice(2)
         jshints = false
+        if (option.startsWith("-q")) {
+            option = "-" + option.slice(2)
+            rapid = true
+        }
     }
 
     let selectHints = new Promise(r => r())

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3458,6 +3458,7 @@ import * as hinting from "@src/content/hinting"
         - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos.
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
         - -J* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
+          - For example, use `bind ;gg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
         - -br deprecated, use `-qb` instead
 
     Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3458,7 +3458,7 @@ import * as hinting from "@src/content/hinting"
         - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos.
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
         - -J* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
-          - For example, use `bind ;gg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
+          - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
         - -br deprecated, use `-qb` instead
 
     Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3457,6 +3457,7 @@ import * as hinting from "@src/content/hinting"
         - `-pipe selector key` e.g, `-pipe a href` returns the key. Only makes sense with `composite`, e.g, `composite hint -pipe * textContent | yank`. If you don't select a hint (i.e. press <Esc>), will return an empty string.
         - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos.
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
+        - -j* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
         - -br deprecated, use `-qb` instead
 
     Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.


### PR DESCRIPTION
Allowing use of `-j` option that disables hints for javascript elements. This option can be combined with other options. This is particularly useful when one is using the `-c` option to generate hints only for specified elements. 

Should solve #1299 