### PR TITLE
Add searchengine support

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1036,15 +1036,17 @@ export async function reloadhard(n = 1) {
 /** @hidden */
 export const ABOUT_WHITELIST = ["about:license", "about:logo", "about:rights", "about:blank"]
 
-/** Open a new page in the current tab.
+/**
+ * Open a new page in the current tab.
  *
- *   @param urlarr
- *   - if first word looks like it has a schema, treat as a URI
- *   - else if the first word contains a dot, treat as a domain name
- *   - else if the first word is a key of [[SEARCH_URLS]], treat all following terms as search parameters for that provider
- *   - else treat as search parameters for [[searchengine]]
+ * @param urlarr
  *
- *   Related settings: [[searchengine]], [[historyresults]]
+ * - if first word looks like it has a schema, treat as a URI
+ * - else if the first word contains a dot, treat as a domain name
+ * - else if the first word is a key of [[SEARCH_URLS]], treat all following terms as search parameters for that provider
+ * - else treat as search parameters for [[searchengine]]
+ *
+ * Related settings: [[searchengine]], [[historyresults]]
  *
  * Can only open about:* or file:* URLs if you have the native messenger installed, and on OSX you must set `browser` to something that will open Firefox from a terminal pass it commmand line options.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2256,7 +2256,6 @@ export async function winopen(...args: string[]) {
         address = args.slice(1, args.length).join(" ")
         firefoxArgs = "--private-window"
     } else address = args.join(" ")
-    createData["url"] = address != "" ? forceURI(address) : forceURI(config.get("newtab"))
     if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
         if ((await browser.runtime.getPlatformInfo()).os === "mac") {
             fillcmdline_notrail("# nativeopen isn't supported for winopen on OSX. Consider installing Linux or Windows :).")
@@ -2266,7 +2265,7 @@ export async function winopen(...args: string[]) {
             return
         }
     }
-    browser.windows.create(createData)
+    return browser.windows.create(createData).then(win => openInTab(win.tabs[0], address.split(" ")))
 }
 
 //#background

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2248,23 +2248,19 @@ export async function mute(...muteArgs: string[]): Promise<void> {
 /** Like [[tabopen]], but in a new window. `winopen -private [...]` will open the result in a private window (and won't store the command in your ex-history ;) )*/
 //#background
 export async function winopen(...args: string[]) {
-    let address: string
+    let address = args.join(" ")
     const createData = {}
     let firefoxArgs = "--new-window"
     if (args[0] === "-private") {
         createData["incognito"] = true
         address = args.slice(1, args.length).join(" ")
         firefoxArgs = "--private-window"
-    } else address = args.join(" ")
-    if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
-        if ((await browser.runtime.getPlatformInfo()).os === "mac") {
-            fillcmdline_notrail("# nativeopen isn't supported for winopen on OSX. Consider installing Linux or Windows :).")
-            return
-        } else {
-            nativeopen(address, firefoxArgs)
-            return
-        }
     }
+
+    if (!ABOUT_WHITELIST.includes(address) && address.match(/^(about|file):.*/)) {
+        return nativeopen(address, firefoxArgs)
+    }
+
     return browser.windows.create(createData).then(win => openInTab(win.tabs[0], address.split(" ")))
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1837,7 +1837,7 @@ export async function tabopen(...addressarr: string[]) {
         } else if (containerId && config.get("tabopencontaineraware") === "true") {
             args.cookieStoreId = containerId
         }
-        return openInNewTab(null, args).then(tab => openInTab(tab, {}, query))
+        return openInNewTab(null, args).then(tab => openInTab(tab, { loadReplace: true }, query))
     })
 }
 
@@ -2199,7 +2199,7 @@ export async function winopen(...args: string[]) {
         return nativeopen(address, firefoxArgs)
     }
 
-    return browser.windows.create(createData).then(win => openInTab(win.tabs[0], {}, address.split(" ")))
+    return browser.windows.create(createData).then(win => openInTab(win.tabs[0], { loadReplace: true }, address.split(" ")))
 }
 
 //#background

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2876,6 +2876,14 @@ export function keymap(source: string, target: string) {
 }
 
 /**
+ * @hidden
+ */
+//#background
+export function searchsetkeyword() {
+    throw ":searchsetkeyword has been deprecated. Use `set searchurls.KEYWORD URL` instead."
+}
+
+/**
  * Validates arguments for set/seturl
  * @hidden
  */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -472,7 +472,7 @@ class default_config {
     }
 
     /**
-     * The default search engine used by `open search`. If empty string, your browser's default search engine will be used. If set to something, Tridactyl will first look at your [[searchurls]] and then at your .
+     * The default search engine used by `open search`. If empty string, your browser's default search engine will be used. If set to something, Tridactyl will first look at your [[searchurls]] and then at the search engines for which you have defined a keyword on `about:preferences#search`.
      */
     searchengine = ""
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -472,9 +472,9 @@ class default_config {
     }
 
     /**
-     * The default search engine used by `open search`. Has to be one of your [[searchurls]].
+     * The default search engine used by `open search`. If empty string, your browser's default search engine will be used. If set to something, Tridactyl will first look at your [[searchurls]] and then at your .
      */
-    searchengine = "google"
+    searchengine = ""
 
     /**
      * Definitions of search engines for use via `open [keyword]`.

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -153,7 +153,7 @@ export async function openInNewWindow(createData = {}) {
     browserBg.windows.create(createData)
 }
 
-export async function openInTab(tab, strarr: string[]) {
+export async function openInTab(tab, opts = {}, strarr: string[]) {
     let address = strarr.join(" ")
 
     if (address == "") {
@@ -166,13 +166,19 @@ export async function openInTab(tab, strarr: string[]) {
 
     if (firstWord == "") {
         // No query, no newtab set, the user is asking for Tridactyl's newtab page
-        return browserBg.tabs.update(tab.id, { url: "/static/newtab.html" })
+        return browserBg.tabs.update(
+            tab.id,
+            Object.assign({ url: "/static/newtab.html" }, opts),
+        )
     }
 
     // Perhaps the user typed a URL?
     if (/^[a-zA-Z0-9+.-]+:[^\s:]/.test(address)) {
         try {
-            return browserBg.tabs.update(tab.id, { url: new URL(address).href })
+            return browserBg.tabs.update(
+                tab.id,
+                Object.assign({ url: new URL(address).href }, opts),
+            )
         } catch (e) {
             // Not a problem, we'll treat address as a regular search query
         }
@@ -186,7 +192,10 @@ export async function openInTab(tab, strarr: string[]) {
             rest,
         )
         // firstWord is a searchurl, so let's use that
-        return browserBg.tabs.update(tab.id, { url: url.href })
+        return browserBg.tabs.update(
+            tab.id,
+            Object.assign({ url: url.href }, opts),
+        )
     }
 
     const searchEngines = await browserBg.search.get()
@@ -205,7 +214,10 @@ export async function openInTab(tab, strarr: string[]) {
         const url = new URL("http://" + address)
         // Ignore unlikely domains
         if (url.hostname.includes(".") || url.port || url.password) {
-            return browserBg.tabs.update(tab.id, { url: url.href })
+            return browserBg.tabs.update(
+                tab.id,
+                Object.assign({ url: url.href }, opts),
+            )
         }
     } catch (e) {}
 
@@ -226,7 +238,10 @@ export async function openInTab(tab, strarr: string[]) {
                 new URL(searchurls[enginename]),
                 queryString,
             )
-            return browserBg.tabs.update(tab.id, { url: url.href })
+            return browserBg.tabs.update(
+                tab.id,
+                Object.assign({ url: url.href }, opts),
+            )
         }
 
         if (

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -200,6 +200,17 @@ export async function openInTab(tab, strarr: string[]) {
         })
     }
 
+    // Maybe it's a domain without protocol
+    try {
+        const url = new URL("http://" + address)
+        // Ignore unlikely domains
+        if (url.hostname.includes(".") || url.port || url.password) {
+            return browserBg.tabs.update(tab.id, { url: url.href })
+        }
+    } catch (e) {}
+
+    // Let's default to the user's search engine then
+
     // if firstWord is "search", remove it from the query.
     // This allows users to search for a URL or a word they defined as searchurl
     let queryString = address

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -50,6 +50,7 @@
         "downloads",
         "find",
         "history",
+        "search",
         "sessions",
         "storage",
         "tabs",

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -97,6 +97,11 @@ declare namespace browser.webRequest {
     function filterResponseData(requestId: string): any
 }
 
+declare namespace browser.search {
+    function search(searchProperties: {query: string, engine?: string, tabId?: number}): never
+    function get(): {name: string, isDefault: boolean, alias?: string, faviconURL?: string}[]
+}
+
 // Stop typedoc complaining about toBeAll.
 declare namespace jest {
     interface Matchers<R> {


### PR DESCRIPTION
This commit adds firefox search engine support to tridactyl. Avoiding code
duplication between open and tabopen required changing the way tabopen
works: first, it opens a new tab pointing to Tridactyl's newtab page and
only after that does it actually navigate to where the user wants.

I couldn't find a cleaner architecture, let me know if you have ideas.

Should close https://github.com/tridactyl/tridactyl/issues/792 , https://github.com/tridactyl/tridactyl/issues/333 and https://github.com/tridactyl/tridactyl/issues/60 and probably https://github.com/tridactyl/tridactyl/issues/961 .