### PR TITLE
Implement winclose and winclose completions

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -33,6 +33,7 @@ import { PreferenceCompletionSource } from "@src/completions/Preferences"
 import { RssCompletionSource } from "@src/completions/Rss"
 import { SessionsCompletionSource } from "@src/completions/Sessions"
 import { SettingsCompletionSource } from "@src/completions/Settings"
+import { WindowCompletionSource } from "@src/completions/Window"
 import * as Messaging from "@src/lib/messaging"
 import * as Config from "@src/lib/config"
 import "@src/lib/number.clamp"
@@ -107,6 +108,7 @@ export function enableCompletions() {
             RssCompletionSource,
             SessionsCompletionSource,
             SettingsCompletionSource,
+            WindowCompletionSource,
         ]
             .map(constructorr => {
                 try {

--- a/src/completions/Window.ts
+++ b/src/completions/Window.ts
@@ -1,0 +1,53 @@
+import { browserBg } from "@src/lib/webext.ts"
+import * as Completions from "@src/completions"
+
+class WindowCompletionOption extends Completions.CompletionOptionHTML
+    implements Completions.CompletionOptionFuse {
+    public fuseKeys = []
+
+    constructor(win) {
+        super()
+        this.value = win.id
+        this.fuseKeys.push(`${win.title}`)
+        this.fuseKeys.push(`${win.id}`)
+
+        // Create HTMLElement
+        this.html = html`<tr class="WindowCompletionOption option ${win.incognito ? "incognito" : ""}">
+            <td class="privatewindow"></td>
+            <td class="id">${win.id}</td>
+            <td class="title">${win.title}</td>
+            <td class="tabcount">${win.tabs.length} tab${win.tabs.length != 1 ? "s" : ""}</td>
+        </tr>`
+    }
+}
+
+export class WindowCompletionSource extends Completions.CompletionSourceFuse {
+    public options: WindowCompletionOption[]
+
+    constructor(private _parent) {
+        super(
+            ["winclose"],
+            "WindowCompletionSource",
+            "Windows",
+        )
+
+        this.updateOptions()
+        this._parent.appendChild(this.node)
+    }
+
+    private async updateOptions(exstr = "") {
+        const [prefix, query] = this.splitOnPrefix(exstr)
+        if (!prefix)
+            return
+        this.options = (await browserBg.windows.getAll({populate: true}))
+            .map(win => new WindowCompletionOption(win))
+        return this.updateChain()
+    }
+
+    async onInput(exstr) {
+        // Schedule an update, if you like. Not very useful for windows, but
+        // will be for other things.
+        this.updateOptions(exstr)
+    }
+
+}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2275,9 +2275,19 @@ export async function winopen(...args: string[]) {
     browser.windows.create(createData)
 }
 
+/** 
+ * Close a tab.
+ *
+ * @param id - The window id. Defaults to the id of the current window.
+ *
+ * Example: `winclose 
+ */
 //#background
-export async function winclose() {
-    browser.windows.remove((await browser.windows.getCurrent()).id)
+export async function winclose(...ids: string[]) {
+    if (ids.length == 0) {
+        ids.push(`${(await browser.windows.getCurrent()).id}`)
+    }
+    return Promise.all(ids.map(id => browser.windows.remove(parseInt(id))))
 }
 
 /** Close all windows */

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -255,3 +255,9 @@ a.url:hover {
     padding: 0px 3pt;
     text-align: right;
 }
+
+#completions .WindowCompletionOption td.id {
+    width: 4ch !important;
+    text-align: right;
+    padding: 0px 3pt;
+}


### PR DESCRIPTION
Winclose was already there but was much less useful (could only close
the current window). This commit enables closing other windows and
provides completions for it.

Related issue: https://github.com/tridactyl/tridactyl/issues/794.