### PR TITLE
commandline_frame.ts: Simplify completion-updating mechanism

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -242,16 +242,12 @@ export function refresh_completions(exstr) {
 }
 
 /** @hidden **/
-let timeoutId: any = 0
-/** @hidden **/
 let onInputPromise: Promise<any> = Promise.resolve()
 /** @hidden **/
 clInput.addEventListener("input", () => {
     const exstr = clInput.value
-    // Prevent starting previous completion computation if possible
-    clearTimeout(timeoutId)
     // Schedule completion computation. We do not start computing immediately because this would incur a slow down on quickly repeated input events (e.g. maintaining <Backspace> pressed)
-    let myTimeoutId = setTimeout(async () => {
+    setTimeout(async () => {
         try {
             // Make sure the previous computation has ended
             await onInputPromise
@@ -261,12 +257,10 @@ clInput.addEventListener("input", () => {
         }
 
         // If we're not the current completion computation anymore, stop
-        if (timeoutId != myTimeoutId) return
+        if (exstr != clInput.value) return
 
         onInputPromise = refresh_completions(exstr)
-    }, 100)
-    // Declare self as current completion computation
-    timeoutId = myTimeoutId
+    }, 1)
 })
 
 /** @hidden **/


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/issues/1295 reports that
sometimes, completions won't be offered for excmds even though they
should. This happened because of the following steps:

- A letter is pressed, triggering an "input" event which schedules
  completion computation
- <Space> is pressed, which doesn't trigger an "input" event since it's
  bound to an excmd. However, the excmd itself refreshes completions.
- The computation scheduled by the "input" event is run with the
  previous exstr, even though it isn't up to date anymore.

This is fixed by replacing all the complicated timeoutId checking with
exstr checking, which makes a lot more sense, is simpler and all around
better.

Closes #1295.