### PR TITLE
Warn when adding a binding that is shadowed by other bind (#1309)

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2931,11 +2931,12 @@ export function bind(...args: string[]) {
     let args_obj = parse_bind_args(...args)
     let p = Promise.resolve()
     if (args_obj.excmd != "") {
-        for (let i = 0; i < args_obj.key.length; i++) {  // Check if any initial subsequence of the key exists and will shadow the new binding
-            let key_sub = args_obj.key.slice(0, i);
+        for (let i = 0; i < args_obj.key.length; i++) {
+            // Check if any initial subsequence of the key exists and will shadow the new binding
+            let key_sub = args_obj.key.slice(0, i)
             if (config.get(args_obj.configName, key_sub)) {
-                fillcmdline_notrail("# Warning: bind `"+key_sub+"` exists and will shadow `" + args_obj.key + "`. Try running `:unbind "+key_sub+"` first");
-                break;
+                fillcmdline_notrail("# Warning: bind `" + key_sub + "` exists and will shadow `" + args_obj.key + "`. Try running `:unbind --mode=" + args_obj.mode + " " + key_sub + "`")
+                break
             }
         }
         p = config.set(args_obj.configName, args_obj.key, args_obj.excmd)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2931,6 +2931,13 @@ export function bind(...args: string[]) {
     let args_obj = parse_bind_args(...args)
     let p = Promise.resolve()
     if (args_obj.excmd != "") {
+        for (let i = 0; i < args_obj.key.length; i++) {  // Check if any initial subsequence of the key exists and will shadow the new binding
+            let key_sub = args_obj.key.slice(0, i);
+            if (config.get(args_obj.configName, key_sub)) {
+                fillcmdline_notrail("# Warning: bind `"+key_sub+"` exists and will shadow `" + args_obj.key + "`. Try running `:unbind "+key_sub+"` first");
+                break;
+            }
+        }
         p = config.set(args_obj.configName, args_obj.key, args_obj.excmd)
     } else if (args_obj.key.length) {
         // Display the existing bind


### PR DESCRIPTION
Fixes #1309 by iteratively checking for already existing keybindings that might shadow the binding that is being added. 