### PR TITLE
config.ts: Remove sleep from 'D' bind

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -192,7 +192,7 @@ class default_config {
         "<C-o>": "jumpprev",
         "<C-i>": "jumpnext",
         d: "tabclose",
-        D: "composite tabprev; sleep 100; tabclose #",
+        D: "composite tabprev; tabclose #",
         gx0: "tabclosealltoleft",
         gx$: "tabclosealltoright",
         "<<": "tabmove -1",


### PR DESCRIPTION
The `sleep` command was added a long time ago to avoid race conditions
because tabprev didn't return a promise. Since tabprev now always
returns a promise which is resolved once a new tab is selected, it is
safe to remove the `sleep` call. This makes `D` feel smoother.

Tested on both a fast and a slow computer with high load.