### PR TITLE
config.ts: bind ;t to `hint -W tabopen` by default

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -248,6 +248,7 @@ class default_config {
         ";#": "hint -#",
         ";v": "hint -W exclaim_quiet mpv",
         ";w": "hint -w",
+        ";t": "hint -W tabopen",
         ";O": "hint -W fillcmdline_notrail open ",
         ";W": "hint -W fillcmdline_notrail winopen ",
         ";T": "hint -W fillcmdline_notrail tabopen ",


### PR DESCRIPTION
This binding was asked for at least twice on IRC and it also makes sense
to have it when looking at https://github.com/tridactyl/tridactyl/issues/1279 .

Closes #1279.