### PR TITLE
webext.ts: Fix openInTab() leaving a space in search queries

### DIFF
--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -184,7 +184,8 @@ export async function openInTab(tab, opts = {}, strarr: string[]) {
         }
     }
 
-    const rest = address.substr(firstWord.length)
+    // `+ 1` because we want to get rid of the space
+    const rest = address.substr(firstWord.length + 1)
     const searchurls = config.get("searchurls")
     if (searchurls[firstWord]) {
         let url = UrlUtil.interpolateSearchItem(


### PR DESCRIPTION
Before this commit, `rest` contained a space, which was not a problem
when performing regular queries but was one when constructing urls.