### PR TITLE
completions/Help.ts: Fix completions not being properly deselected

### DIFF
--- a/src/completions/Help.ts
+++ b/src/completions/Help.ts
@@ -30,6 +30,7 @@ export class HelpCompletionSource extends Completions.CompletionSourceFuse {
 
     public async filter(exstr: string) {
         this.lastExstr = exstr
+        this.completion = undefined
         let [prefix, query] = this.splitOnPrefix(exstr)
         let options = ""
 


### PR DESCRIPTION
Before this commit, the following steps caused a completion option to be
wrongly inserted in the command line: `:h -e<Tab><Backspace>a<Space>`.
This commit fixes that by making sure that the completion source forgets
the selected completion option on changes.