### PR TITLE
commandline_frame.ts: Catch errors in refresh_completions

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -250,7 +250,7 @@ export function refresh_completions(exstr) {
     if (!activeCompletions) enableCompletions()
     return Promise.all(
         activeCompletions.map(comp => comp.filter(exstr).then(resizeArea)),
-    )
+    ).catch(err => console.error(err)) // We can't use the regular logging mechanism because the user is using the command line.
 }
 
 /** @hidden **/


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/issues/1345 describes a problem
where completion computation fails and fills the command line with an
error message.
This commit doesn't make the underlying problem disappear but prevents
Tridactyl from spamming the command line.