### PR TITLE
native_background.ts: Fix terminator not working as editorcmd

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -122,8 +122,8 @@ export async function getBestEditor(): Promise<string> {
             "urxvt -e",
             "alacritty -e", // alacritty is nice but takes ages to start and doesn't support class
             // Terminator and termite require  -e commands to be in quotes
-            'terminator -e "%f"',
-            'termite --class tridactyl_editor -e "%f"',
+            'terminator -u -e "%c"',
+            'termite --class tridactyl_editor -e "%c"',
             "sakura --class tridactyl_editor -e",
             "lilyterm -e",
             "mlterm -e",
@@ -146,7 +146,7 @@ export async function getBestEditor(): Promise<string> {
         ]
     }
 
-    tui_editors = ["vim", "nvim", "nano", "emacs -nw"]
+    tui_editors = ["vim %f", "nvim %f", "nano %f", "emacs -nw %f"]
 
     // Consider GUI editors
     let cmd = await firstinpath(gui_candidates)
@@ -157,7 +157,11 @@ export async function getBestEditor(): Promise<string> {
         if (cmd !== undefined) {
             // and a text editor
             let tuicmd = await firstinpath(tui_editors)
-            cmd = cmd + " " + tuicmd
+            if (cmd.includes("%c")) {
+                cmd = cmd.replace("%c", tuicmd)
+            } else {
+                cmd = cmd + " " + tuicmd
+            }
         } else {
             // or fall back to some really stupid stuff
             cmd = await firstinpath(last_resorts)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -255,7 +255,7 @@ export function removeTridactylEditorClass(selector: string) {
  *
  * The editorcmd needs to accept a filename, stay in the foreground while it's edited, save the file and exit. By default the filename is added to the end of editorcmd, if you require control over the position of that argument, the first occurrence of %f in editorcmd is replaced with the filename:
  * ```
- * set editorcmd 'terminator -e "%f"'
+ * set editorcmd 'terminator -u -e "vim %f"'
  * ```
  *
  * You're probably better off using the default insert mode bind of `<C-i>` (Ctrl-i) to access this.


### PR DESCRIPTION
There were two problems: first, the format string used by terminator and
termite was wrong: tuicmd was appended after "%f", which resulted in
tridactyl telling the emulator to execute the file rather than the
tuicmd.
The second issue was that, as mentionned in
https://github.com/tridactyl/tridactyl/issues/1346, `-u` was missing
from terminator's options.