### PR TITLE
commandline_frame.ts: Fix compile-time error

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -250,7 +250,10 @@ export function refresh_completions(exstr) {
     if (!activeCompletions) enableCompletions()
     return Promise.all(
         activeCompletions.map(comp => comp.filter(exstr).then(resizeArea)),
-    ).catch(err => console.error(err)) // We can't use the regular logging mechanism because the user is using the command line.
+    ).catch(err => {
+        console.error(err)
+        return []
+    }) // We can't use the regular logging mechanism because the user is using the command line.
 }
 
 /** @hidden **/
@@ -260,14 +263,8 @@ clInput.addEventListener("input", () => {
     const exstr = clInput.value
     // Schedule completion computation. We do not start computing immediately because this would incur a slow down on quickly repeated input events (e.g. maintaining <Backspace> pressed)
     setTimeout(async () => {
-        try {
-            // Make sure the previous computation has ended
-            await onInputPromise
-        } catch (e) {
-            // we don't actually care because this is the previous computation, which we will throw away
-            logger.warning(e)
-        }
-
+        // Make sure the previous computation has ended
+        await onInputPromise
         // If we're not the current completion computation anymore, stop
         if (exstr != clInput.value) return
 


### PR DESCRIPTION
10cb692d726126255dd63cd412152f91c78720ae broke the build bot by
introducing type incompatibilites. This is fixed by making sure .catch()
returns an array.
This enables removing the try/catch in the input event handler since
the await won't throw anymore.