### PR TITLE
nativeopen: detect profile, enable space in URLs

### DIFF
--- a/src/background/native_background.ts
+++ b/src/background/native_background.ts
@@ -479,6 +479,10 @@ export async function getProfileDir() {
     }
 }
 
+export function getProfile() {
+    return getProfileDir().then(p => p.split("/").slice(-1))
+}
+
 export async function parsePrefs(prefFileContent: string) {
     //  This RegExp currently only deals with " but for correctness it should
     //  also deal with ' and `


### PR DESCRIPTION
This commit does two things:
- If the user didn't specify any arguments, try to detect what profile
  is currently being used and specify it in the command passed to
  firefox. This makes sure tabs opened with `:nativeopen` are opened
  with the right profile if multiple firefox profiles are running.
- Quote url argument to enable adding spaces and quotes to the URL
  (closes #555)