### PR TITLE
config.ts: Add leavegithubalone setting to config.ts

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -295,6 +295,11 @@ class default_config {
     }
 
     /**
+     * Whether to allow pages (not necessarily github) to override `/`, which is a default Firefox binding.
+     */
+    leavegithubalone: "true" | "false" = "false"
+
+    /**
      * Autocommands that run when certain events happen, and other conditions are met.
      *
      * Related ex command: `autocmd`.


### PR DESCRIPTION
leavegthubalone is used in content.ts but wasn't defined in config.ts.
This didn't cause any bugs but prevented leavegithubalone from being
shown in command line completions. This commit fixes that.