### PR TITLE
feat/minor: add hint that scrolls element to the top of a page

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3497,6 +3497,7 @@ import * as hinting from "@src/content/hinting"
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
         - -w open in new window
         - -wp open in new private window
+        - -z scroll an element to the top of the viewport
         - `-pipe selector key` e.g, `-pipe a href` returns the key. Only makes sense with `composite`, e.g, `composite hint -pipe * textContent | yank`. If you don't select a hint (i.e. press <Esc>), will return an empty string.
         - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W exclaim mpv` to open YouTube videos.
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
@@ -3779,12 +3780,23 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
             )
             break
 
-        case "-wp":
+       case "-wp":
             selectHints = hinting.pipe_elements(
                 hinting.hintables(),
                 elem => {
                     elem.focus()
                     if (elem.href) return openInNewWindow({ url: elem.href, incognito: true })
+                },
+                rapid,
+            )
+            break
+
+        case "-z":
+            selectHints = hinting.pipe_elements(
+                DOM.elementsWithText(),
+                elem => {
+                    elem.scrollIntoView(true)
+                    return elem
                 },
                 rapid,
             )

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -252,6 +252,7 @@ class default_config {
         ";O": "hint -W fillcmdline_notrail open ",
         ";W": "hint -W fillcmdline_notrail winopen ",
         ";T": "hint -W fillcmdline_notrail tabopen ",
+        ";z": "hint -z",
         ";m":
             "composite hint -pipe img src | js -p tri.excmds.open('images.google.com/searchbyimage?image_url=' + JS_ARG)",
         ";M":


### PR DESCRIPTION
Hello all,

Thank you for all of your work on tridactyl!

I've added a hint that scrolls the selected element to the top of the viewport (operating on text elements).

This is something I've wanted for a while, since I have a hard time maintaining reading flow when scrolling the page ends up cutting off part of a paragraph. 

If this is an undesired feature or I've missed something, let me know!

Cheers,

Manny