### PR TITLE
Portable builds

### DIFF
--- a/scripts/bodgecss.sh
+++ b/scripts/bodgecss.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-imports=$(find src/static/themes/ -name '*.css'| sed "s/^src\/static\///" | sed "s/^.*$/@import url\('..\/\0'\);/")
+imports=$(find src/static/themes/ -name '*.css'| awk -F"/" '{ printf "@import url('\''../%s/%s/%s'\'');\n", $3, $4, $5 }')
 
 shopt -s globstar
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -77,8 +77,9 @@ fi
 
 if [ -e "$TRIDACTYL_LOGO" ] ; then
     # sed and base64 take different arguments on Mac
-    case "$OSTYPE" in
-      darwin*) sed -i "" "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO")@" build/static/themes/default/default.css;;
+    case "$(uname)" in
+      Darwin*) sed -i "" "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO")@" build/static/themes/default/default.css;;
+      OpenBSD) sed -in "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO" | tr -d '\r\n')@" build/static/themes/default/default.css;;
       *) sed "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 --wrap 0 "$TRIDACTYL_LOGO")@" -i build/static/themes/default/default.css;;
     esac
 else

--- a/scripts/excmds_macros.py
+++ b/scripts/excmds_macros.py
@@ -149,7 +149,7 @@ def main():
             }
 
     for context in ("background", "content"):
-        with open("src/excmds.ts") as source:
+        with open("src/excmds.ts", encoding="utf-8") as source:
             output = PRELUDE
             lines = iter(source)
             for line in lines:
@@ -162,7 +162,7 @@ def main():
                 else:
                     output += line
             # print(output.rstrip())
-            with open("src/.excmds_{context}.generated.ts".format(**locals()), "w") as sink:
+            with open("src/.excmds_{context}.generated.ts".format(**locals()), "w", encoding="utf-8") as sink:
                 print(output.rstrip(), file=sink)
 
 


### PR DESCRIPTION
Refactored a couple of things in the build scripts to allow for builds on other OSes.
Tested on OpenBSD 6.4 and Archlinux.

The biggest change is in `build.sh` where I threw out the `$OSTYPE` check for `uname`.
`$OSTYPE` is not portable and the assumption is that we have `uname` available on all platforms (Windows via cygwin/msys/WSL).