### PR TITLE
native.ts: implement proper profile-checking

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -510,7 +510,7 @@ export async function nativeopen(...args: string[]) {
             } else {
                 if (firefoxArgs.length === 0) {
                     try {
-                        firefoxArgs = [`-p ${await Native.getProfile()}`]
+                        firefoxArgs = [`-p ${await Native.getProfileName()}`]
                     } catch (e) {
                         logger.debug(e)
                         firefoxArgs = []
@@ -3774,7 +3774,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
             )
             break
 
-       case "-wp":
+        case "-wp":
             selectHints = hinting.pipe_elements(
                 hinting.hintables(),
                 elem => {


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/pull/1355 introduced a bug on
systems where profile names do not match profile paths. Fixing it
required implementing proper profiles.ini parsing, which should help
making profile discovery work on windows.

The new getProfileDir() function breaks compatibility with previous
versions. The previous version turned backslashes into slashes on
windows. I believe doing this is wrong since paths such as
`C:/Users/Bob` do not make any sense on windows. They might work in
mingw and wsl but I believe we should aim to have everything work on
'normal' windows.

I thoroughly tested everything on Linux but couldn't do that on windows/OSX. It'd be nice if people with access to these OS could test this PR, otherwise I'll try to set up VMs.