### PR TITLE
MacOS build fixes.

### DIFF
--- a/scripts/bodgecss.sh
+++ b/scripts/bodgecss.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-imports=$(find src/static/themes/ -name '*.css'| awk -F"/" '{ printf "@import url('\''../%s/%s/%s'\'');\n", $3, $4, $5 }')
+set -e
 
-shopt -s globstar
+imports=$(find src/static/themes -name '*.css'| awk -F"/" '{ printf "@import url('\''../%s/%s/%s'\'');\n", $3, $4, $5 }')
 
-for css in $(ls build/static/css/**/*.css); do
+
+for css in build/static/css/*.css; do
     printf '%s\n%s\n' "$imports" "$(cat $css)" > $css
 done

--- a/scripts/pretty
+++ b/scripts/pretty
@@ -31,7 +31,7 @@ main() {
 
   if [ -n "$stagedFiles" ]; then
     # Could use git-update-index --cacheinfo to add a file without creating directories and stuff.
-    local tmpdir=$(mktemp -p . -d "pretty.XXXXXXXXX")
+    local tmpdir=$(mktemp -d "pretty.XXXXXXXXX")
     IFS=$'\n'
     for file in $stagedFiles; do
       if cmp -s <(staged "$file") "$file"; then


### PR DESCRIPTION
- Fix `find` in bodgecss.sh appending an extra /
- Remove bashism from bodgecss.sh which doesn't work in 3.2 (macos default)
- Remove `-p .` from mktemp which is unnecessary and doesn't exist on macos.