### PR TITLE
Fix build.sh to return proper exit code.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,7 +46,7 @@ fi
 
 scripts/newtab.md.sh
 scripts/make_tutorial.sh
-scripts/make_docs.sh &
+scripts/make_docs.sh
 
 "$(npm bin)/nearleyc" src/grammars/bracketexpr.ne \
   > src/grammars/.bracketexpr.generated.ts
@@ -62,9 +62,7 @@ else
 fi
 
 (webpack --display errors-only \
-  && scripts/git_version.sh) &
-
-wait
+  && scripts/git_version.sh)
 
 scripts/bodgecss.sh
 scripts/authors.sh


### PR DESCRIPTION
Remove background scripts/wait from building script to allow proper return
codes to propagate.

I measured the build time to see if there's any advantage of running those scripts in the background, and it was actually slower than without ` &`/`wait`.

Fixes #1088 