### PR TITLE
Fix travis build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13788,7 +13788,7 @@
       }
     },
     "web-ext-types": {
-      "version": "github:kelseasy/web-ext-types#f029d61a2a5baa619a29bdaed12586377bbb92d3",
+      "version": "github:kelseasy/web-ext-types#ed7d0bc45e34f12548412fb0dc1d51db5390b238",
       "from": "github:kelseasy/web-ext-types",
       "dev": true
     },


### PR DESCRIPTION
Update to latest web-ext-types, which contains all the types we need.

Build for this branch: https://travis-ci.org/nfvs/tridactyl/builds/498174612
