### PR TITLE
excmds.ts: Fix `hint -pipe` not working

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3532,12 +3532,21 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
     if (option == "-br") option = "-qb"
 
     // extract flags
+    // Note: we need to process 'pipe' separately because it could be interpreted as -p -i -e otherwise
+    const pipeIndex = option.indexOf("pipe")
+    if (pipeIndex >= 0) {
+        option = option.slice(0, pipeIndex) + option.slice(pipeIndex + 1)
+    }
+
     const options = new Set(option.length ? option.slice(1).split("") : [])
     const rapid = options.delete("q")
     const jshints = options.delete("J")
     const withSelectors = options.delete("c")
 
     option = "-" + Array.from(options).join("")
+    if (pipeIndex >= 0) {
+        option = "-pipe"
+    }
 
     let selectHints = new Promise(r => r())
     let hintTabOpen = async (href, active = !rapid) => {


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/pull/1381 broke `hint -pipe`
(just try `:composite hint -pipe a href | tabopen` for example).
This commit makes `-pipe` work again.