### PR TITLE
excmds.ts: Fix hint -J

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3540,7 +3540,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
 
     const options = new Set(option.length ? option.slice(1).split("") : [])
     const rapid = options.delete("q")
-    const jshints = options.delete("J")
+    const jshints = !options.delete("J")
     const withSelectors = options.delete("c")
 
     option = "-" + Array.from(options).join("")


### PR DESCRIPTION
https://github.com/tridactyl/tridactyl/pull/1381 inverted the behavior
of -J. This commit fixes that.