### PR TITLE
Resize command line only once per available completion source

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -133,6 +133,7 @@ let noblur = e => setTimeout(() => clInput.focus(), 0)
 /** @hidden **/
 export function focus() {
     clInput.focus()
+    clInput.removeEventListener("blur", noblur)
     clInput.addEventListener("blur", noblur)
 }
 
@@ -258,7 +259,13 @@ export function insert_space_or_completion() {
 export function refresh_completions(exstr) {
     if (!activeCompletions) enableCompletions()
     return Promise.all(
-        activeCompletions.map(comp => comp.filter(exstr).then(resizeArea)),
+        activeCompletions.map(comp =>
+            comp.filter(exstr).then(() => {
+                if (comp.shouldRefresh()) {
+                    return resizeArea()
+                }
+            }),
+        ),
     ).catch(err => {
         console.error(err)
         return []

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -55,6 +55,7 @@ export abstract class CompletionSource {
     public abstract filter(exstr: string): Promise<void>
 
     private _state: OptionState
+    private _prevState: OptionState
 
     /** Control presentation of Source */
     set state(newstate: OptionState) {
@@ -67,11 +68,17 @@ export abstract class CompletionSource {
                 this.node.classList.add("hidden")
                 break
         }
+        this._prevState = this._state
         this._state = newstate
     }
 
     get state() {
         return this._state
+    }
+
+    shouldRefresh() {
+        // A completion source should be refreshed if it is not hidden or if it just became hidden
+        return this._state != "hidden" || this.state != this._prevState
     }
 
     abstract next(inc?: number): boolean

--- a/src/completions/Rss.ts
+++ b/src/completions/Rss.ts
@@ -35,6 +35,20 @@ export class RssCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     private async updateOptions(exstr = "") {
+        this.lastExstr = exstr
+        let [prefix, query] = this.splitOnPrefix(exstr)
+
+        // Hide self and stop if prefixes don't match
+        if (prefix) {
+            // Show self if prefix and currently hidden
+            if (this.state === "hidden") {
+                this.state = "normal"
+            }
+        } else {
+            this.state = "hidden"
+            return
+        }
+
         if (this.options.length < 1) {
             this.options = (await Messaging.messageOwnTab(
                 "excmd_content",

--- a/src/completions/Sessions.ts
+++ b/src/completions/Sessions.ts
@@ -74,7 +74,20 @@ export class SessionsCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     private async updateOptions(exstr = "") {
-        const [prefix, query] = this.splitOnPrefix(exstr)
+        this.lastExstr = exstr
+        let [prefix, query] = this.splitOnPrefix(exstr)
+
+        // Hide self and stop if prefixes don't match
+        if (prefix) {
+            // Show self if prefix and currently hidden
+            if (this.state === "hidden") {
+                this.state = "normal"
+            }
+        } else {
+            this.state = "hidden"
+            return
+        }
+
         const sessions = await browserBg.sessions.getRecentlyClosed()
         this.options = sessions.map(s => new SessionCompletionOption(s))
     }

--- a/src/completions/TabAll.ts
+++ b/src/completions/TabAll.ts
@@ -50,7 +50,7 @@ export class TabAllCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     async onInput(exstr) {
-        await this.updateOptions()
+        await this.updateOptions(exstr)
     }
 
     /**
@@ -64,7 +64,21 @@ export class TabAllCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     @Perf.measuredAsync
-    private async updateOptions(exstr?: string) {
+    private async updateOptions(exstr = "") {
+        this.lastExstr = exstr
+        let [prefix, query] = this.splitOnPrefix(exstr)
+
+        // Hide self and stop if prefixes don't match
+        if (prefix) {
+            // Show self if prefix and currently hidden
+            if (this.state === "hidden") {
+                this.state = "normal"
+            }
+        } else {
+            this.state = "hidden"
+            return
+        }
+
         const tabsPromise = browserBg.tabs.query({})
         const windowsPromise = this.getWindows()
         const [tabs, windows] = await Promise.all([tabsPromise, windowsPromise])


### PR DESCRIPTION
One of the problems of the command line was that it made a resizeArea()
call for each enabled completion, no matter whether its status was
"hidden" or "normal". This was a problem because a resizeArea call
results in 2 cross-script messages: a "show" and a "focus" message. This
means that for each keystroke, we sent 28 messages. This commit fixes
that thanks to modifications in multiple files:

- commandline_frame.ts: Stop accumulating event listeners on resizeArea
  calls. Make sure completion sources actually need a refresh before
  calling resizeArea().
- completions.ts: Add logic to know whether a completion source needs a
  refresh or not.
- {Rss,Sessions,Tab,TabAll,Window}.ts: Make sure that completions are
  actually needed before computing them.

This seems to make opening the command line slightly faster for me,
although I can't tell if this is placebo or not.