### PR TITLE
native.ts: Fix profiledir != "auto" not working on windows

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -546,7 +546,7 @@ export function getProfileName() {
 
 export async function getProfileDir() {
     let profiledir = config.get("profiledir")
-    if (profiledir != "auto") return Promise.resolve(() => profiledir)
+    if (profiledir != "auto") return Promise.resolve(profiledir)
     return getProfile().then(p => p.absolutePath)
 }
 


### PR DESCRIPTION
Somehow () => profiledir works on linux but doesn't on windows. () =>
profiledir doesn't make sense anyway.