### PR TITLE
wine-pyinstaller.sh: Fix checkPrerequisite()

### DIFF
--- a/scripts/wine-pyinstaller.sh
+++ b/scripts/wine-pyinstaller.sh
@@ -69,15 +69,12 @@ colorEcho() {
 
 checkPrerequisite() {
   local bin_name="$1"
-  local bin_loc;
-  bin_loc="$(command -v "${bin_name}" 2>/dev/null)"
 
-  if [ -z "${bin_loc}" ] \
-    || [ ! -f "${bin_loc}" ]; then
+  if command -v "${bin_name}" 1>/dev/null 2>/dev/null; then
+    printf '%s\n' "    - '${bin_name}' found."
+  else
     printf '%s\n' "    - '$1' not found, quitting ..."
     exit -1
-  else
-    printf '%s\n' "    - '${bin_name}' found at ${bin_loc}"
   fi
 }
 


### PR DESCRIPTION
The problem was the `[ ! -f "${bin_loc}" ]` check. `command -v` does not
necessarily return an absolute path (it can just return the name of the
command for builtins) and this is what happened for 'printf'. Thus, the
`[ ! -f` check failed.
This check doesn't really make sense. If `command -v $binary` doesn't
fail you're good to go, it doesn't really matter where $binary is
located.