### PR TITLE
Fix make_tutorial

### DIFF
--- a/scripts/make_tutorial.sh
+++ b/scripts/make_tutorial.sh
@@ -12,7 +12,7 @@ dest="../../../generated/static/clippy/"
 
 for page in $pages
 do
-    fileroot=$(echo "$page" | cut -d'.' -f-1)
+    fileroot=$(echo "$page" | cut -d'.' -f-2)
     sed "/REPLACETHIS/,$ d" tutor.template.html > "$dest$fileroot.html"
     "$(npm bin)/marked" "$page" >> "$dest$fileroot.html"
     sed "1,/REPLACETHIS/ d" tutor.template.html >> "$dest$fileroot.html"


### PR DESCRIPTION
PR#1412 broke tutorial generation by adding a dot at the beginning of
$page. This fixes that.