### PR TITLE
TSLint: re-activate array-type rule

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -410,7 +410,7 @@ function filterHintsSimple(fstr) {
 */
 function filterHintsVimperator(fstr, reflow = false) {
     /** Partition a fstr into a tagged array of substrings */
-    function partitionFstr(fstr): { str: string; isHintChar: boolean }[] {
+    function partitionFstr(fstr): Array<{ str: string; isHintChar: boolean }> {
         const peek = a => a[a.length - 1]
         const hintChars = defaultHintChars()
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:array-type */
 // '//#' is a start point for a simple text-replacement-type macro. See excmds_macros.py
 
 /** # Tridactyl help page

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -325,7 +325,7 @@ export function getSelector(e: HTMLElement) {
  */
 export function getElemsBySelector(
     selector: string,
-    filters: Array<ElementFilter>,
+    filters: ElementFilter[],
 ) {
     let elems = Array.from(document.querySelectorAll(selector))
     let frameElems = getAllDocumentFrames().reduce((acc, frame) => {
@@ -356,7 +356,7 @@ export function getElemsBySelector(
 export function getNthElement(
     selectors: string,
     nth: number,
-    filters: Array<ElementFilter>,
+    filters: ElementFilter[],
 ): HTMLElement {
     let inputs = getElemsBySelector(selectors, filters)
 

--- a/src/lib/url_util.ts
+++ b/src/lib/url_util.ts
@@ -209,7 +209,7 @@ export function getDownloadFilenameForUrl(url: URL): string {
  *
  * These could be like "query" or "query=val"
  */
-function getUrlQueries(url: URL): Array<string> {
+function getUrlQueries(url: URL): string[] {
     let qys = []
 
     if (url.search) {
@@ -223,7 +223,7 @@ function getUrlQueries(url: URL): Array<string> {
 /**
  * Update a URL with a new array of queries
  */
-function setUrlQueries(url: URL, qys: Array<string>) {
+function setUrlQueries(url: URL, qys: string[]) {
     url.search = ""
 
     if (qys.length) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -20,7 +20,7 @@ const logger = new Logger("state")
 class State {
     lastSearch: string = undefined
     cmdHistory: string[] = []
-    prevInputs: { inputId: string; tab: number; jumppos?: number }[] = [
+    prevInputs: Array<{ inputId: string; tab: number; jumppos?: number }> = [
         {
             inputId: undefined,
             tab: undefined,

--- a/tslint.json
+++ b/tslint.json
@@ -2,7 +2,6 @@
   "extends": ["tslint:recommended", "tslint-sonarts"],
   "rules": {
     "align": false,
-    "array-type": false,
     "arrow-parens": false,
     "ban-types": false,
     "bool-param-default": false,


### PR DESCRIPTION
This rule stipulates that complex array types should be represented as
Array<T> rather than T[].