### PR TITLE
TSLint: re-enable bool-param-default rule

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2423,14 +2423,6 @@ export async function viewcontainers() {
 //
 // {{{ MISC
 
-/** Deprecated
- * @hidden
- */
-//#background
-export function suppress(preventDefault?: boolean, stopPropagation?: boolean) {
-    mode("ignore")
-}
-
 //#background
 export function version() {
     fillcmdline_notrail(TRI_VERSION)

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     "align": false,
     "arrow-parens": false,
-    "bool-param-default": false,
     "callable-types": false,
     "class-name": false,
     "cognitive-complexity": false,


### PR DESCRIPTION
The bool-param-default rule requires all optional boolean parameters to
have a default value.