### PR TITLE
TSLint: enable no-unused-declaration rule

### DIFF
--- a/compiler/metadata/ClassMetadata.ts
+++ b/compiler/metadata/ClassMetadata.ts
@@ -1,4 +1,4 @@
-import { Type } from "../types/AllTypes"
+
 import { SymbolMetadata } from "./SymbolMetadata"
 
 export class ClassMetadata {

--- a/compiler/types/Type.ts
+++ b/compiler/types/Type.ts
@@ -1,4 +1,3 @@
-import * as ts from "typescript"
 
 export interface Type {
     kind: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,6 +275,15 @@
         "es6-promise": "^2.0.1"
       }
     },
+    "@phenomnomnominal/tsquery": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-3.0.0.tgz",
+      "integrity": "sha512-SW8lKitBHWJ9fAYkJ9kJivuctwNYCh3BUxLdH0+XiR1GPBiu+7qiZzh8p8jqlj1LgVC1TbvfNFroaEsmYlL8Iw==",
+      "dev": true,
+      "requires": {
+        "esquery": "^1.0.1"
+      }
+    },
     "@types/css": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@types/css/-/css-0.0.31.tgz",
@@ -10634,6 +10643,29 @@
         }
       }
     },
+    "tslint-etc": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/tslint-etc/-/tslint-etc-1.5.1.tgz",
+      "integrity": "sha512-XkVRP4dUZ7a5/8grP3BHFCan8f8ZWHoSSNXLC9Hw9vflHOwEHNuW2ltm6EqHKI7s9b6QHE4U5Jk19ntWmqIE0w==",
+      "dev": true,
+      "requires": {
+        "@phenomnomnominal/tsquery": "^3.0.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^3.0.0",
+        "tsutils-etc": "^1.0.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
+          "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
+      }
+    },
     "tslint-sonarts": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslint-sonarts/-/tslint-sonarts-1.9.0.tgz",
@@ -10651,6 +10683,12 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tsutils-etc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.1.0.tgz",
+      "integrity": "sha512-pJlLtLmQPUyGHqY/Pq6EGnpGmQCnnTDZetQ7eWkeQ5xaw4GtfcR1Zt7HMKFHGDDp53HzQfbqQ+7ps6iJbfa9Hw==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ts-jest": "^24.0.0",
     "ts-node": "^8.0.2",
     "tslint": "^5.14.0",
+    "tslint-etc": "^1.5.1",
     "tslint-sonarts": "^1.9.0",
     "typedoc": "^0.14.2",
     "typedoc-default-themes": "git://github.com/tridactyl/typedoc-default-themes.git#fix_weird_member_names_bin",

--- a/src/background/config_rc.ts
+++ b/src/background/config_rc.ts
@@ -1,7 +1,5 @@
 import * as Controller from "@src/background/controller_background"
 import * as Native from "@src/lib/native"
-import Logger from "@src/lib/logging"
-const logger = new Logger("rc")
 
 export async function source(filename = "auto") {
     let rctext = ""

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -21,7 +21,6 @@ import * as perf from "@src/perf"
 import "@src/lib/number.clamp"
 import "@src/lib/html-tagged-template"
 import * as Completions from "@src/completions"
-import { FindCompletionSource } from "./completions/Find"
 import { TabAllCompletionSource } from "@src/completions/TabAll"
 import { BufferCompletionSource } from "@src/completions/Tab"
 import { BmarkCompletionSource } from "@src/completions/Bmark"
@@ -36,7 +35,6 @@ import { SessionsCompletionSource } from "@src/completions/Sessions"
 import { SettingsCompletionSource } from "@src/completions/Settings"
 import { WindowCompletionSource } from "@src/completions/Window"
 import * as Messaging from "@src/lib/messaging"
-import * as Config from "@src/lib/config"
 import "@src/lib/number.clamp"
 import state from "@src/state"
 import Logger from "@src/lib/logging"
@@ -314,6 +312,7 @@ export async function hide_and_clear() {
     isVisible = false
 }
 
+/* tslint:disable:no-unused-declaration */
 /** @hidden **/
 function setCursor(n = 0) {
     clInput.setSelectionRange(n, n, "none")

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -13,7 +13,6 @@ Concrete completion classes have been moved to src/completions/.
 import * as Fuse from "fuse.js"
 import { enumerate } from "@src/lib/itertools"
 import { toNumber } from "@src/lib/convert"
-import * as config from "@src/lib/config"
 import * as aliases from "@src/lib/aliases"
 
 export const DEFAULT_FAVICON = browser.extension.getURL(

--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -1,6 +1,5 @@
 import * as Completions from "@src/completions"
 import * as Metadata from "@src/.metadata.generated"
-import state from "@src/state"
 import * as config from "@src/lib/config"
 import * as aliases from "@src/lib/aliases"
 

--- a/src/completions/FileSystem.ts
+++ b/src/completions/FileSystem.ts
@@ -1,6 +1,5 @@
 import * as Completions from "@src/completions"
 import * as Native from "@src/lib/native"
-import * as config from "@src/lib/config"
 
 class FileSystemCompletionOption extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {

--- a/src/completions/Find.ts
+++ b/src/completions/Find.ts
@@ -1,7 +1,6 @@
-import { browserBg, activeTabId } from "@src/lib/webext"
+import { activeTabId } from "@src/lib/webext"
 import * as Messaging from "@src/lib/messaging"
 import * as Completions from "../completions"
-import { executeWithoutCommandLine } from "@src/content/commandline_content"
 import * as config from "@src/lib/config"
 
 class FindCompletionOption extends Completions.CompletionOptionHTML

--- a/src/completions/Guiset.ts
+++ b/src/completions/Guiset.ts
@@ -27,7 +27,6 @@ export class GuisetCompletionSource extends Completions.CompletionSourceFuse {
     public async filter(exstr: string) {
         this.lastExstr = exstr
         const [prefix, query] = this.splitOnPrefix(exstr)
-        const option = ""
 
         // Hide self and stop if prefixes don't match
         if (prefix) {

--- a/src/completions/Help.ts
+++ b/src/completions/Help.ts
@@ -2,8 +2,6 @@ import * as Completions from "@src/completions"
 import * as Metadata from "@src/.metadata.generated"
 import * as aliases from "@src/lib/aliases"
 import * as config from "@src/lib/config"
-import state from "@src/state"
-import { browserBg } from "@src/lib/webext"
 
 class HelpCompletionOption extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
@@ -32,7 +30,6 @@ export class HelpCompletionSource extends Completions.CompletionSourceFuse {
         this.lastExstr = exstr
         this.completion = undefined
         const [prefix, query] = this.splitOnPrefix(exstr)
-        const options = ""
 
         // Hide self and stop if prefixes don't match
         if (prefix) {

--- a/src/completions/Settings.ts
+++ b/src/completions/Settings.ts
@@ -1,6 +1,5 @@
 import * as Completions from "@src/completions"
 import * as config from "@src/lib/config"
-import { browserBg } from "@src/lib/webext"
 import * as metadata from "@src/.metadata.generated"
 
 class SettingsCompletionOption extends Completions.CompletionOptionHTML

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -2,7 +2,6 @@ import * as Perf from "@src/perf"
 import { browserBg } from "@src/lib/webext.ts"
 import { enumerate } from "@src/lib/itertools"
 import * as Containers from "@src/lib/containers"
-import * as Messaging from "@src/lib/messaging"
 import * as Completions from "@src/completions"
 
 class BufferCompletionOption extends Completions.CompletionOptionHTML

--- a/src/completions/TabAll.ts
+++ b/src/completions/TabAll.ts
@@ -1,7 +1,6 @@
 import * as Perf from "@src/perf"
 import { browserBg } from "@src/lib/webext"
 import * as Containers from "@src/lib/containers"
-import * as Messaging from "@src/lib/messaging"
 import * as Completions from "@src/completions"
 
 class TabAllCompletionOption extends Completions.CompletionOptionHTML

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -1,10 +1,8 @@
 import { isTextEditable } from "@src/lib/dom"
 import { contentState, ModeName } from "@src/content/state_content"
-import { repeat } from "@src/.excmds_background.generated"
 import Logger from "@src/lib/logging"
 import * as messaging from "@src/lib/messaging"
 
-import { parser as exmode_parser } from "@src/parsers/exmode"
 import * as hinting from "@src/content/hinting"
 import * as gobblemode from "@src/parsers/gobblemode"
 import * as generic from "@src/parsers/genericmode"

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -19,13 +19,9 @@ import {
     map,
     unique,
 } from "@src/lib/itertools"
-import { hasModifiers } from "@src/lib/keyseq"
 import { contentState } from "@src/content/state_content"
-import { messageActiveTab, message } from "@src/lib/messaging"
 import * as config from "@src/lib/config"
-import * as TTS from "@src/lib/text_to_speech"
 import Logger from "@src/lib/logging"
-import * as Messaging from "@src/lib/messaging"
 const logger = new Logger("hinting")
 
 /** Simple container for the state of a single frame's hints. */
@@ -549,9 +545,6 @@ export function killables() {
         DOM.isVisible,
     ])
 }
-
-import { openInNewTab, activeTabContainerId } from "@src/lib/webext"
-import { openInNewWindow } from "@src/lib/webext"
 
 export function pipe(
     selectors = DOM.HINTTAGS_selectors,

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -80,7 +80,6 @@ import * as aliases from "@src/lib/aliases"
 import * as Logging from "@src/lib/logging"
 /** @hidden */
 const logger = new Logging.Logger("excmds")
-import Mark from "mark.js"
 import * as CSS from "css"
 import * as Perf from "@src/perf"
 import * as Metadata from "@src/.metadata.generated"
@@ -104,7 +103,8 @@ import { ownTab } from "@src/lib/webext"
 // {
 /** Message excmds_content.ts in the active tab of the currentWindow */
 import * as BGSELF from "@src/.excmds_background.generated"
-import { messageTab, messageActiveTab } from "@src/lib/messaging"
+import { messageActiveTab } from "@src/lib/messaging"
+/* tslint:disable:no-unused-declaration */
 import { flatten } from "@src/lib/itertools"
 import "@src/lib/number.mod"
 import { firefoxVersionAtLeast } from "@src/lib/webext"
@@ -4057,6 +4057,7 @@ export async function echo(...str: string[]) {
 //#content
 export async function js(...str: string[]) {
     if (str[0].startsWith("-p")) {
+        /* tslint:disable:no-unused-declaration */
         /* tslint:disable:no-dead-store */
         const JS_ARG = str[str.length - 1]
         return eval(str.slice(1, -1).join(" "))
@@ -4072,6 +4073,7 @@ export async function js(...str: string[]) {
 //#background
 export async function jsb(...str: string[]) {
     if (str[0].startsWith("-p")) {
+        /* tslint:disable:no-unused-declaration */
         /* tslint:disable:no-dead-store */
         const JS_ARG = str[str.length - 1]
         return eval(str.slice(1, -1).join(" "))

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -1,5 +1,4 @@
 import * as config from "@src/lib/config"
-import { flatten } from "@src/lib/itertools"
 import state from "@src/state"
 import * as Logging from "@src/lib/logging"
 import {

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1,7 +1,4 @@
-import * as Messaging from "@src/lib/messaging"
-import * as Container from "@src/lib/containers"
-import * as UrlUtil from "@src/lib/url_util"
-import * as config from "@src/lib/config"
+
 import * as csp from "csp-serdes"
 import Logger from "@src/lib/logging"
 

--- a/src/parsers/exmode.ts
+++ b/src/parsers/exmode.ts
@@ -2,10 +2,9 @@
 
 import * as ExCmds from "@src/.excmds_background.generated"
 import * as convert from "@src/lib/convert"
-import * as Config from "@src/lib/config"
 import * as aliases from "@src/lib/aliases"
 import * as Logging from "@src/lib/logging"
-import { enumerate, head, izip } from "@src/lib/itertools"
+import { enumerate, izip } from "@src/lib/itertools"
 const logger = new Logging.Logger("exmode")
 
 /* Converts numbers, boolean, string[].

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -20,7 +20,6 @@
 import * as messaging from "@src/lib/messaging"
 import * as config from "@src/lib/config"
 import * as math from "@src/lib/math"
-import * as itertools from "@src/lib/itertools"
 import * as logging from "@src/lib/logging"
 
 const logger = new logging.Logger("performance")

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint:recommended", "tslint-sonarts"],
+  "extends": ["tslint:recommended", "tslint-sonarts", "tslint-etc"],
   "linterOptions": {
     "exclude": [ "**/.*.generated.ts" ]
   },
@@ -26,6 +26,7 @@
     "no-shadowed-variable": false,
     "no-string-throw": false,
     "no-unsafe-finally": false,
+    "no-unused-declaration": true,
     "object-literal-key-quotes": false,
     "object-literal-sort-keys": false,
     "only-arrow-functions": false,


### PR DESCRIPTION
This rule requires adding a new set of rules, tslint-etc. no-unused-declaration used to be available in tslint:recommended but was deprecated when --noUnusedVariables was added to typescript. The reason we're not using TypeScript's --noUnusedVariables is that it turns unused declarations into an error and prevents compilation, which isn't fun when you're just prototyping things.