### PR TITLE
Actually make tridactyl listen for `:editor` return code

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -250,11 +250,14 @@ export async function editor(file: string, line: number, col: number, content?: 
             : config.get("editorcmd"))
         .replace(/%l/, line)
         .replace(/%c/, col)
+    let exec
     if (editorcmd.indexOf("%f") !== -1) {
-        await run(editorcmd.replace(/%f/, file))
+        exec = await run(editorcmd.replace(/%f/, file))
     } else {
-        await run(editorcmd + " " + file)
+        exec = await run(editorcmd + " " + file)
     }
+    if (exec.code != 0)
+        return exec
     return read(file)
 }
 


### PR DESCRIPTION
This piece of code was missing from 91dffe6. This actually closes #1455.
Note that you need your terminal emulator to forward the exit code of
your editor in order for this to work.