### PR TITLE
Updatecheck in newtab

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -118,7 +118,7 @@ browser.runtime.onStartup.addListener(_ => {
 
 // Nag people about updates.
 // Hope that they're on a tab we can access.
-config.getAsync("updatenag").then(nag => {
+config.getAsync("update", "nag").then(nag => {
     if (nag === true) excmds_background.updatecheck("auto_polite")
 })
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -119,7 +119,7 @@ browser.runtime.onStartup.addListener(_ => {
 // Nag people about updates.
 // Hope that they're on a tab we can access.
 config.getAsync("updatenag").then(nag => {
-    if (nag === true) excmds_background.updatecheck(true)
+    if (nag === true) excmds_background.updatecheck("auto_polite")
 })
 
 // }}}

--- a/src/content.ts
+++ b/src/content.ts
@@ -84,6 +84,7 @@ import * as keyseq from "@src/lib/keyseq"
 import * as native from "@src/lib/native"
 import * as styling from "@src/content/styling"
 import { EditorCmds as editor } from "@src/content/editor"
+import * as updates from "@src/lib/updates"
 /* tslint:disable:import-spacing */
 ; (window as any).tri = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
@@ -107,6 +108,7 @@ import { EditorCmds as editor } from "@src/content/editor"
     styling,
     contentLocation: window.location,
     perf,
+    updates,
 })
 
 logger.info("Loaded commandline content?", commandline_content)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -142,6 +142,7 @@ import { firefoxVersionAtLeast } from "@src/lib/webext"
 import * as rc from "@src/background/config_rc"
 import { mapstrToKeyseq } from "@src/lib/keyseq"
 import * as css_util from "@src/lib/css_util"
+import * as Updates from "@src/lib/updates"
 
 /** @hidden */
 // }
@@ -4124,10 +4125,6 @@ export async function issue() {
     textarea.value = template
 }
 
-//#background_helper
-import * as Parser from "rss-parser"
-import * as semverCompare from "semver-compare"
-
 /**
  * Checks if there are any stable updates available for Tridactyl.
  *
@@ -4138,25 +4135,40 @@ import * as semverCompare from "semver-compare"
  *
  */
 //#background
-export async function updatecheck(polite = false) {
-    try {
-        // If any monster any makes a novelty tag this will break.
-        // So let's just ignore any errors.
-        const parser = new Parser()
-        const feed = await parser.parseURL("https://github.com/tridactyl/tridactyl/tags.atom")
-        const latest = feed.items[0].title
-        const current = TRI_VERSION.replace(/-.*/, "")
-        if (semverCompare(latest, current) > 0) {
-            const releasedate = new Date(feed.items[0].pubDate) // e.g. 2018-12-04T15:24:43.000Z
-            const today = new Date()
-            // any here are to shut up TS - it doesn't think Dates have subtraction defined :S
-            const days_since = ((today as any) - (releasedate as any)) / (1000 * 60 * 60 * 24)
-            if (!polite || (days_since > config.get("updatenagwait") && semverCompare(latest, config.get("updatenaglastversion")) > 0)) {
-                config.set("updatenaglastversion", latest)
-                fillcmdline_tmp(30000, "Tridactyl " + latest + " is available. Visit about:addons, right click Tridactyl, click 'Find Updates'. Restart Firefox once it has downloaded.")
-            }
+export async function updatecheck(source: "manual" | "auto_polite" | "auto_impolite" = "manual") {
+    const forceCheck = source == "manual"
+    const highestKnownVersion = await Updates.getLatestVersion(forceCheck)
+    if (!highestKnownVersion) {
+        return false
+    }
+
+    if (!Updates.shouldNagForVersion(highestKnownVersion)) {
+        if (source == "manual") {
+            fillcmdline_tmp(30000, "You're up to date! Tridactyl version " + highestKnownVersion.version + ".")
         }
-    } catch (e) {}
+        return false
+    }
+
+    const notify = () => {
+        fillcmdline_tmp(30000, "Tridactyl " + highestKnownVersion.version + " is available (you're on " + Updates.getInstalledVersion() + "). Visit about:addons, right click Tridactyl, click 'Find Updates'. Restart Firefox once it has downloaded.")
+    }
+
+    // A bit verbose, but I figured it was important to have the logic
+    // right when it comes to automatically nagging users about the
+    // version they're on.
+    if (source == "manual") {
+        notify()
+    } else if (source == "auto_impolite") {
+        logger.debug("Impolitely nagging user to update. Installed, latest: ",
+                     Updates.getInstalledVersion(), highestKnownVersion)
+        notify()
+        Updates.updateLatestNaggedVersion(highestKnownVersion)
+    } else if (source == "auto_polite" && !Updates.naggedForVersion(highestKnownVersion)) {
+        logger.debug("Politely nagging user to update. Installed, latest: ",
+                     Updates.getInstalledVersion(), highestKnownVersion)
+        notify()
+        Updates.updateLatestNaggedVersion(highestKnownVersion)
+    }
 }
 
 /**  Open a welcome page on first install.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4130,8 +4130,9 @@ export async function issue() {
  *
  * Related settings:
  *
- * - `updatenag = true | false` - checks for updates on Tridactyl start.
- * - `updatenagwait = 7` - waits 7 days before nagging you to update.
+ * - `update.nag = true | false` - checks for updates on Tridactyl start.
+ * - `update.nagwait = 7` - waits 7 days before nagging you to update.
+ * - `update.checkintervalsecs = 86400` - waits 24 hours between checking for an update.
  *
  */
 //#background

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -771,6 +771,16 @@ class default_config {
     updatenaglastversion = "1.14.0"
 
     /**
+     * Time we last checked for an update, milliseconds since unix epoch.
+     */
+    updatelastcheck = 0
+
+    /**
+     * Minimum interval between automatic update checks, in seconds.
+     */
+    updatecheckintervalsecs = 60 * 60 * 24
+
+    /**
      * Profile directory to use with native messenger with e.g, `guiset`.
      */
     profiledir = "auto"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -756,29 +756,34 @@ class default_config {
     win_nativeinstallcmd = `powershell -NoProfile -InputFormat None -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))"`
 
     /**
-     * Whether Tridactyl should check for available updates at startup.
+     * Used by :updatecheck and related built-in functionality to automatically check for updates and prompt users to upgrade.
      */
-    updatenag = true
+    update = {
+        /**
+         * Whether Tridactyl should check for available updates at startup.
+         */
+        nag: true,
 
-    /**
-     * How many days to wait after an update is first available until telling people.
-     */
-    updatenagwait = 7
+        /**
+         * How many days to wait after an update is first available until telling people.
+         */
+        nagwait: 7,
 
-    /**
-     * The version we last nagged you about. We only nag you once per version.
-     */
-    updatenaglastversion = "1.14.0"
+        /**
+         * The version we last nagged you about. We only nag you once per version.
+         */
+        lastnaggedversion: "1.14.0",
 
-    /**
-     * Time we last checked for an update, milliseconds since unix epoch.
-     */
-    updatelastcheck = 0
+        /**
+         * Time we last checked for an update, milliseconds since unix epoch.
+         */
+        lastchecktime: 0,
 
-    /**
-     * Minimum interval between automatic update checks, in seconds.
-     */
-    updatecheckintervalsecs = 60 * 60 * 24
+        /**
+         * Minimum interval between automatic update checks, in seconds.
+         */
+        checkintervalsecs: 60 * 60 * 24,
+    }
 
     /**
      * Profile directory to use with native messenger with e.g, `guiset`.

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -1,0 +1,105 @@
+/** Updates
+
+ Tools for updating tridactyl. Get the running version, check the
+ highest known available beta, nag the user to update at reasonable
+ intervals, etcetera.
+
+ */
+
+import * as RssParser from "rss-parser"
+import * as SemverCompare from "semver-compare"
+import * as Config from "@src/lib/config"
+import * as Logging from "@src/lib/logging"
+
+const logger = new Logging.Logger("updates")
+
+const TRI_VERSION = "REPLACE_ME_WITH_THE_VERSION_USING_SED"
+
+interface TriVersionFeedItem {
+    releaseDate: Date
+    version: string
+}
+
+// initialize to beginning of time to cause a check on startup
+let highestKnownVersion: TriVersionFeedItem
+
+function secondsSinceLastCheck() {
+    const lastCheck = Config.get("lastupdatecheck")
+    return (Date.now() - lastCheck) / 1000
+}
+
+// Get the latest version, with a bit of a cache. This will return
+// immediately if we've already recently checked for an update, so it
+// should be safe to invoke it relatively frequently.
+export async function getLatestVersion(force_check = false) {
+    const pastUpdateInterval = secondsSinceLastCheck() > Config.get("updatecheckintervalsecs")
+    if (force_check || pastUpdateInterval) {
+        await updateVersion()
+    }
+
+    return highestKnownVersion
+}
+
+async function updateVersion() {
+    try {
+        // If any monster any makes a novelty tag this will break.
+        // So let's just ignore any errors.
+        const parser = new RssParser()
+        const feed = await parser.parseURL("https://github.com/tridactyl/tridactyl/tags.atom")
+        const mostRecent = feed.items[0]
+
+        // Update our last update check timestamp and the version itself.
+        Config.set("updatelastcheck", Date.now())
+        highestKnownVersion = {
+            version: mostRecent.title,
+            releaseDate: new Date(mostRecent.pubDate), // e.g. 2018-12-04T15:24:43.000Z
+        }
+        logger.debug("Checked for new version of Tridactyl, found ", highestKnownVersion)
+    } catch (e) {
+        logger.error("Error while checking for updates: ", e)
+    }
+}
+
+export function shouldNagForVersion(version: TriVersionFeedItem) {
+    const timeSinceRelease = (Date.now() - version.releaseDate.getTime()) / 1000
+    const updateNagWaitSeconds = Config.get("updatenagwait") * 24 * 60 * 60
+    const newerThanInstalled = SemverCompare(version.version, getInstalledPatchVersion()) > 0
+
+    return newerThanInstalled && timeSinceRelease > updateNagWaitSeconds
+}
+
+export function naggedForVersion(version: TriVersionFeedItem) {
+    const lastNaggedVersion = Config.get("updatenaglastversion")
+    if (lastNaggedVersion) {
+        // If the version is <= the last nagged version, we've already
+        // nagged for it.
+        return SemverCompare(version.version, lastNaggedVersion) <= 0
+    } else {
+        return false
+    }
+}
+
+export function updateLatestNaggedVersion(version: TriVersionFeedItem) {
+    Config.set("updatenaglastversion", version.version)
+}
+
+export function getInstalledPatchVersion() {
+    // We're currently numbering our releases as
+    // maj.min.patch-numcommits-githash,
+    // e.g. 1.14.9-138-gaab4355. Even more problematically, our
+    // prereleases have maj.min.patch the same as the _preceding
+    // release_, not the _next_ release - 1.14.9-138 actually
+    // _follows_ 1.14.9. As a result, if we used TRI_VERSION directly,
+    // all of our beta users would be incorrectly notified for stable
+    // releases of code that they're well past.
+    //
+    // To address this, we ignore our git version, depend on firefox
+    // to automatically update us if we're on the beta channel, and
+    // disregard the pre-release information entirely when doing our
+    // own update check.
+    return TRI_VERSION.replace(/-.*/, "")
+}
+
+export function getInstalledVersion() {
+    return TRI_VERSION
+}

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -1,5 +1,6 @@
 // This file is only included in newtab.html, after content.js has been loaded
 
+import * as Messaging from "@src/lib/messaging"
 import * as config from "@src/lib/config"
 
 // These functions work with the elements created by tridactyl/scripts/newtab.md.sh
@@ -41,4 +42,11 @@ window.addEventListener("load", _ => {
             window.focus()
         }
     })
+})
+
+// Periodically nag people about updates.
+window.addEventListener("load", _ => {
+    if (config.get("updatenag") === true) {
+        Messaging.message("controller_background", "acceptExCmd", ["updatecheck auto_polite"])
+    }
 })

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -46,7 +46,7 @@ window.addEventListener("load", _ => {
 
 // Periodically nag people about updates.
 window.addEventListener("load", _ => {
-    if (config.get("updatenag") === true) {
+    if (config.get("update", "nag") === true) {
         Messaging.message("controller_background", "acceptExCmd", ["updatecheck auto_polite"])
     }
 })


### PR DESCRIPTION
Invoke `:updatecheck` when the new-tab page loads, rather than at install time or tridactyl start time. This also means that we catch people that leave firefox open for weeks at a time (_cough_ >_>).\

I believe that this fixes #1360.

Related changes:
* New file `@src/lib/updates.ts` with functionality related to checking for updates.
* Logic in `:updatecheck` split so display-relevant logic stays in the excmd while functionality related to actually checking for updates goes into `updates.ts`.
* `:updatecheck` now accepts a `source` enum, rather than a bool, so that manual invocations can bypass the cache and force tridactyl to actually check for an update.
* Since we can now distinguish manual invocations, `updatecheck` now tells you you're up-to-date when that's the case.
* `getLatestVersion` caches the latest result for a configurable duration; if called more frequently it will return from cache immediately instead of going out to the internet, which means we can call it much more frequently without causing issues.
* New config option `updatelastcheck`, so that `getLatestVersion` doesn't have separate cache timeouts for content-mode and background-mode (or more).
* New config option `updatecheckintervalsecs`, the minimum interval between update checks.