### PR TITLE
[RFC] Aucmds  refactor and Downloadpost

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3141,7 +3141,7 @@
       "dev": true
     },
     "csp-serdes": {
-      "version": "github:cmcaine/csp-serdes#91876274b0bfa5cd10ceebabe9f8cb29b0ccd7aa",
+      "version": "github:cmcaine/csp-serdes#6c6fe34dbd138855e5c26f331b094e9a75358a64",
       "from": "github:cmcaine/csp-serdes"
     },
     "css": {
@@ -3889,7 +3889,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -4052,7 +4052,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -10249,7 +10249,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -11124,7 +11124,7 @@
     },
     "typedoc-default-themes": {
       "version": "git://github.com/tridactyl/typedoc-default-themes.git#74b17dddcafd394d17b112816d2e837993c20dfd",
-      "from": "git://github.com/tridactyl/typedoc-default-themes.git#74b17dddcafd394d17b112816d2e837993c20dfd",
+      "from": "git://github.com/tridactyl/typedoc-default-themes.git#fix_weird_member_names_bin",
       "dev": true
     },
     "typescript": {

--- a/scripts/excmds_macros.py
+++ b/scripts/excmds_macros.py
@@ -39,7 +39,7 @@ class Signature:
             # Type declaration
             if ':' in param:
                 name, typ = map(str.strip, param.split(':'))
-                if (typ not in ('number', 'boolean', 'string', 'string[]', 'ModeName', 'AUCMDS')
+                if (typ not in ('number', 'boolean', 'string', 'string[]', 'ModeName', 'AUCMDS', 'AutocmdArgs')
                         and '|' not in typ
                         and typ[0] not in ['"',"'"]
                    ):

--- a/scripts/excmds_macros.py
+++ b/scripts/excmds_macros.py
@@ -39,7 +39,7 @@ class Signature:
             # Type declaration
             if ':' in param:
                 name, typ = map(str.strip, param.split(':'))
-                if (typ not in ('number', 'boolean', 'string', 'string[]', 'ModeName')
+                if (typ not in ('number', 'boolean', 'string', 'string[]', 'ModeName', 'AUCMDS')
                         and '|' not in typ
                         and typ[0] not in ['"',"'"]
                    ):

--- a/src/background.ts
+++ b/src/background.ts
@@ -147,6 +147,13 @@ browser.tabs.onActivated.addListener(ev => {
         .catch(ignore)
 })
 
+// DownloadPost autocommand.
+browser.downloads.onChanged.addListener((ev: any) => {
+    if (ev.state && ev.state.current === "complete") {
+        messaging
+            .messageActiveTab("excmd_content", "loadaucmds", ["DownloadPost"])
+    }
+})
 // }}}
 
 // {{{ AUTOCONTAINERS

--- a/src/background.ts
+++ b/src/background.ts
@@ -148,10 +148,16 @@ browser.tabs.onActivated.addListener(ev => {
 })
 
 // DownloadPost autocommand.
-browser.downloads.onChanged.addListener((ev: any) => {
+browser.downloads.onChanged.addListener(async (ev: any) => {
     if (ev.state && ev.state.current === "complete") {
+        const dlItem: browser.downloads.DownloadItem = (await browser.downloads.search({id: ev.id}))[0]
+        const args: AutocmdArgs = {
+            url: dlItem.url,
+            file: dlItem.filename,
+            size: dlItem.fileSize
+        }
         messaging
-            .messageActiveTab("excmd_content", "loadaucmds", ["DownloadPost"])
+            .messageActiveTab("excmd_content", "loadaucmds", ["DownloadPost", args])
     }
 })
 // }}}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1680,7 +1680,7 @@ if (fullscreenApiIsPrefixed) {
 
 /** @hidden */
 //#content
-export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "TabEnter" | "TabLeft" | "FullscreenEnter" | "FullscreenLeft" | "FullscreenChange") {
+export async function loadaucmds(cmdType: AUCMDS) {
     const aucmds = await config.getAsync("autocmds", cmdType)
     const ausites = Object.keys(aucmds)
     const aukeyarr = ausites.filter(e => window.document.location.href.search(e) >= 0)
@@ -3131,11 +3131,24 @@ export function set(key: string, ...values: string[]) {
 }
 
 /** @hidden */
-//#background_helper
-const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft", "FullscreenChange", "FullscreenEnter", "FullscreenLeft"]
+export const aucmdlit = <V extends keyof any>(v: V) => v
+export const AUCMDS = {
+    DOCEND: aucmdlit("DocEnd"),
+    DOCLOAD: aucmdlit("DocLoad"),
+    DOCSTART: aucmdlit("DocStart"),
+    DOWNLOADPOST: aucmdlit("DownloadPost"),
+    FULLSCREENCHANGE: aucmdlit("FullscreenChange"),
+    FULLSCREENENTER: aucmdlit("FullscreenEnter"),
+    FULLSCREENLEFT: aucmdlit("FullscreenLeft"),
+    TABENTER: aucmdlit("TabEnter"),
+    TABLEFT: aucmdlit("TabLeft"),
+    TRISTART: aucmdlit("TriStart"),
+}
+export type AUCMDS = (typeof AUCMDS)[keyof typeof AUCMDS]
+
 /** Set autocmds to run when certain events happen.
 
- @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
+ @param event Currently, 'TriStart', 'DocStart', 'DocLoad', 'DownloadPost', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
 
  @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
 
@@ -3153,8 +3166,19 @@ const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLef
 export function autocmd(event: string, url: string, ...excmd: string[]) {
     // rudimentary run time type checking
     // TODO: Decide on autocmd event names
-    if (!AUCMDS.includes(event)) throw event + " is not a supported event."
+    if (!Object.values(AUCMDS).includes(event as AUCMDS)) throw event + " is not a supported event."
     config.set("autocmds", event, url, excmd.join(" "))
+}
+
+/** Remove autocmds
+    @param event Currently, 'TriStart', 'DocStart', 'DocLoad', 'DownloadPost', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
+
+    @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
+*/
+//#background
+export function autocmddelete(event: string, url: string) {
+    if (!Object.values(AUCMDS).includes(event as AUCMDS)) throw event + " is not a supported event."
+    config.unset("autocmds", event, url)
 }
 
 /** Automatically open a domain and all its subdomains in a specified container.
@@ -3178,16 +3202,6 @@ export function autocontain(domain: string, container: string) {
     config.set("autocontain", domain, container)
 }
 
-/** Remove autocmds
- @param event Curently, 'TriStart', 'DocStart', 'DocLoad', 'DocEnd', 'TabEnter', 'TabLeft', 'FullscreenChange', 'FullscreenEnter', and 'FullscreenLeft' are supported
-
- @param url For DocStart, DocEnd, TabEnter, and TabLeft: a fragment of the URL on which the events will trigger, or a JavaScript regex (e.g, `/www\.amazon\.co.*\/`)
-*/
-//#background
-export function autocmddelete(event: string, url: string) {
-    if (!AUCMDS.includes(event)) throw event + " is not a supported event."
-    config.unset("autocmds", event, url)
-}
 
 /**
  *  Helper function to put Tridactyl into ignore mode on the provided URL.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3221,7 +3221,6 @@ export function autocontain(domain: string, container: string) {
     config.set("autocontain", domain, container)
 }
 
-
 /**
  *  Helper function to put Tridactyl into ignore mode on the provided URL.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1678,13 +1678,32 @@ if (fullscreenApiIsPrefixed) {
 }
 // }
 
+/** Expands all occurrences of "<.*>" to matching args.
+   @hidden
+ */
+
+//#content_helper
+export function parseaucmdargs(aucmd: string, args: AutocmdArgs): string {
+    const re = /^\"<(\w+)>\"$/
+    const aucmdarr = aucmd.split(" ").map((s: string) => {
+        const res = s.match(re)
+        if (res && args[res[1]]) {
+            s = args[res[1]]
+        }
+        return s
+    })
+    return aucmdarr.join(" ")
+}
 /** @hidden */
 //#content
-export async function loadaucmds(cmdType: AUCMDS) {
+export async function loadaucmds(cmdType: AUCMDS, args?: AutocmdArgs) {
     const aucmds = await config.getAsync("autocmds", cmdType)
     const ausites = Object.keys(aucmds)
     const aukeyarr = ausites.filter(e => window.document.location.href.search(e) >= 0)
     for (const aukey of aukeyarr) {
+        if (args) {
+            aucmds[aukey] = parseaucmdargs(aucmds[aukey], args)
+        }
         controller.acceptExCmd(aucmds[aukey])
     }
 }

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -33,6 +33,13 @@ interface UIEvent {
     pageY: number
 }
 
+// Autocmd optional arguments
+interface AutocmdArgs {
+    url?: string
+    file?: string
+    size?: number
+}
+
 // This isn't an actual firefox type but it's nice to have one for this kind of object
 // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/find/find
 interface findResult {


### PR DESCRIPTION
This addresses issues #810 and #807. An optional argument of the type
`AutocmdArgs` can be passed to `loadaucmds`. Only a small subset of the variables
mentioned in #810 are implemented. I think it's better to implement these as the
need/request arrives but for the `DownloadPost` aucmd I felt like this was the
most straightforward way to implement.

The `parseaucmdargs` function takes an aucmd and looks for the pattern "<param">
where param is any of the keys provided by `AutocmdArgs` and replaces the pattern
with the matching information from the args.

Example usage:
`:au DownloadPost .* fillcmdline "<file>"`
Will print the full path of the downloaded file on the cmdline.

I'm not attached to the naming convention but it's the same as pentadactyl used.

I have yet to write the documentation for the feature.

Any comments welcome.