### PR TITLE
Fix precommit hook

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -3,7 +3,7 @@
 # Accepts no arguments
 # Returns git-add'ed files as a list of filenames separated by a newline character
 cachedTSLintFiles() {
-    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx"
+    git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" "*.ts" "*.tsx" ":(exclude)*.d.ts"
 }
 
 # Accepts no arguments
@@ -33,7 +33,7 @@ tslintUgly() {
     local acc=""
     local IFS=$'\n'
     local tmpdir=$(mktemp -d "tslint.XXXXXXXXX")
-    for jsfile in $1; do
+    for jsfile in "$@"; do
         tmpfile="$tmpdir/$jsfile"
         mkdir -p "$(dirname "$tmpfile")"
         staged "$jsfile" > "$tmpfile"


### PR DESCRIPTION
Two issues: we were iterating on the same argument and tslint doesn't
like .d.ts files.