### PR TITLE
Fix numeric prefixes

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -102,7 +102,6 @@ function* ParserController() {
 
     while (true) {
         let exstr = ""
-        let repeat = 1
         let keyEvents: KeyboardEvent[] = []
         try {
             while (true) {
@@ -155,7 +154,6 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    repeat = response.numericPrefix
                     break
                 } else {
                     keyEvents = response.keys
@@ -165,10 +163,6 @@ function* ParserController() {
                         .join("")
                     logger.debug("suffix: ", contentState.suffix)
                 }
-            }
-            if (repeat > 1) {
-                exstr = "repeat " + repeat.toString() + " " + exstr
-                logger.debug("repeating: ", repeat)
             }
             controller.acceptExCmd(exstr)
             contentState.suffix = ""

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -102,6 +102,7 @@ function* ParserController() {
 
     while (true) {
         let exstr = ""
+        let repeat = 1
         let keyEvents: KeyboardEvent[] = []
         try {
             while (true) {
@@ -154,6 +155,7 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
+                    repeat = response.numericPrefix
                     break
                 } else {
                     keyEvents = response.keys
@@ -163,6 +165,10 @@ function* ParserController() {
                         .join("")
                     logger.debug("suffix: ", contentState.suffix)
                 }
+            }
+            if (repeat > 1) {
+                exstr = "repeat " + repeat.toString() + " " + exstr
+                logger.debug("repeating: ", repeat)
             }
             controller.acceptExCmd(exstr)
             contentState.suffix = ""

--- a/src/lib/itertools.ts
+++ b/src/lib/itertools.ts
@@ -180,9 +180,7 @@ export function flatten(arr) {
 export function* drop(iterable, predicate) {
     let allmatched = true
     for (const elem of iterable) {
-        if (allmatched && predicate(elem)) {
-            continue
-        } else {
+        if (!(allmatched && predicate(elem))) {
             allmatched = false
             yield elem
         }

--- a/src/lib/itertools.ts
+++ b/src/lib/itertools.ts
@@ -176,3 +176,25 @@ export function flatten(arr) {
     }
     return result
 }
+
+export function* drop(iterable, predicate) {
+    let allmatched = true
+    for (const elem of iterable) {
+        if (allmatched && predicate(elem)) {
+            continue
+        } else {
+            allmatched = false
+            yield elem
+        }
+    }
+}
+
+export function* take(iterable, predicate) {
+    for (const elem of iterable) {
+        if (predicate(elem)) {
+            yield elem
+        } else {
+            return
+        }
+    }
+}

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -142,7 +142,11 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
                 possibleMappings,
                 ([k, v]) => k.length === keyseq.length,
             )
-            return { value: perfect[1], numericPrefix: keyseqToNumber(numericPrefix), exstr: perfect[1], isMatch: true }
+            return {
+                value: perfect[1],
+                exstr: perfect[1] + numericPrefixToExstrSuffix(numericPrefix),
+                isMatch: true,
+            }
         } catch (e) {
             if (!(e instanceof RangeError)) throw e
         }
@@ -345,9 +349,12 @@ export function isNumeric(keyEvent: KeyEventLike) {
     return !hasModifiers(keyEvent) && keyEvent.key.match(NUMERIC_REG)
 }
 
-function keyseqToNumber(keyseq: KeyEventLike[]): number {
-    if (keyseq.length === 0) { return 1 }
-    return Number(keyseq.map(k => k.key).join(""))
+function numericPrefixToExstrSuffix(numericPrefix: KeyEventLike[]) {
+    if (numericPrefix.length > 0) {
+        return " " + numericPrefix.map(k => k.key).join("")
+    } else {
+        return ""
+    }
 }
 
 /**

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -21,7 +21,7 @@
 */
 
 /** */
-import { find, filter, izip } from "@src/lib/itertools"
+import { drop, filter, find, izip, take } from "@src/lib/itertools"
 import { Parser } from "@src/lib/nearley_utils"
 import * as bracketexpr_grammar from "@src/grammars/.bracketexpr.generated"
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
@@ -111,6 +111,7 @@ export interface ParserResponse {
     value?: any
     exstr?: any
     isMatch: boolean
+    numericPrefix?: number
 }
 
 export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
@@ -120,11 +121,16 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
             !["Control", "Shift", "Alt", "AltGraph", "Meta"].includes(key.key),
     )
 
+    // Split into numeric prefix and non-numeric suffix
+    let numericPrefix = Array.from(take(keyseq, isNumeric))
+    keyseq = Array.from(drop(keyseq, isNumeric))
+
     // If keyseq is a prefix of a key in map, proceed, else try dropping keys
     // from keyseq until it is empty or is a prefix.
     let possibleMappings = completions(keyseq, map)
     while (possibleMappings.size === 0 && keyseq.length > 0) {
         keyseq.shift()
+        numericPrefix = []
         possibleMappings = completions(keyseq, map)
     }
 
@@ -136,12 +142,17 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
                 possibleMappings,
                 ([k, v]) => k.length === keyseq.length,
             )
-            return { value: perfect[1], exstr: perfect[1], isMatch: true }
+            return { value: perfect[1], numericPrefix: keyseqToNumber(numericPrefix), exstr: perfect[1], isMatch: true }
         } catch (e) {
             if (!(e instanceof RangeError)) throw e
         }
     }
-    return { keys: keyseq, isMatch: keyseq.length > 0 }
+
+    // keyseq is the longest suffix of keyseq that is the prefix of a
+    // command, numericPrefix is a numeric prefix of that. We want to
+    // preserve that whole thing, so concat them back together before
+    // returning.
+    return { keys: numericPrefix.concat(keyseq), isMatch: keyseq.length > 0 }
 }
 
 /** True if seq1 is a prefix or equal to seq2 */
@@ -327,6 +338,16 @@ export function hasNonShiftModifiers(keyEvent: KeyEventLike) {
 /** A simple key event is a non-special key (length 1) that is not modified by ctrl, alt, or shift. */
 export function isSimpleKey(keyEvent: KeyEventLike) {
     return !(keyEvent.key.length > 1 || hasNonShiftModifiers(keyEvent))
+}
+
+const NUMERIC_REG = /\d/
+export function isNumeric(keyEvent: KeyEventLike) {
+    return !hasModifiers(keyEvent) && keyEvent.key.match(NUMERIC_REG)
+}
+
+function keyseqToNumber(keyseq: KeyEventLike[]): number {
+    if (keyseq.length === 0) { return 1 }
+    return Number(keyseq.map(k => k.key).join(""))
 }
 
 /**


### PR DESCRIPTION
Teach keyseq to record and report numeric prefixes. Code isn't as clean as I'd like, but it's at least relatively well-contained.

Teach the content controller to append this to the exstr if it's present.

I think that this fixes #466.