### PR TITLE
Make repeat wait for completion of each excmd before continuing

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2555,12 +2555,12 @@ async function getnexttabs(tabid: number, n?: number) {
 
 */
 //#both
-export function repeat(n = 1, ...exstr: string[]) {
+export async function repeat(n = 1, ...exstr: string[]) {
     let cmd = controller.last_ex_str
     if (exstr.length > 0) cmd = exstr.join(" ")
     logger.debug("repeating " + cmd + " " + n + " times")
     for (let i = 0; i < n; i++) {
-        controller.acceptExCmd(cmd)
+        await controller.acceptExCmd(cmd)
     }
 }
 


### PR DESCRIPTION
This makes e.g. `repeat 5 tabmove -1` work the way you'd expect.