### PR TITLE
Add `tri` omnibox keyword as another escape hatch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ You can bind your own shortcuts in normal mode with the `:bind` command. For exa
 ## WebExtension-related issues
 
 -   Navigation to any about:\* pages using `:open` requires the native messenger.
--   Firefox will not load Tridactyl on about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab and Ctrl-W are your escape hatches.
+-   Firefox will not load Tridactyl on about:\*, some file:\* URIs, view-source:\*, or data:\*. On these pages Ctrl-L (or F6), Ctrl-Tab, Ctrl-W, and the `tri` [omnibox keyword](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Omnibox) are your escape hatches.
     -   addons.mozilla.org is now supported so long as you run `fixamo` first.
 -   Tridactyl now supports changing the Firefox GUI if you have the native messenger installed via `guiset`. There's quite a few options available, but `guiset gui none` is probably what you want, perhaps followed up with `guiset tabs always`. See `:help guiset` for a list of all possible options.
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,6 +23,7 @@ import state from "@src/state"
 import * as webext from "@src/lib/webext"
 import { AutoContain } from "@src/lib/autocontainers"
 import * as extension_info from "@src/lib/extension_info"
+import * as omnibox from "@src/background/omnibox"
 
 // Add various useful modules to the window for debugging
 ; (window as any).tri = Object.assign(Object.create(null), {
@@ -206,5 +207,11 @@ window.tri = Object.assign(window.tri || Object.create(null), {
     // console.
     statsLogger,
 })
+
+// }}}
+
+// {{{ OMNIBOX
+
+omnibox.init()
 
 // }}}

--- a/src/background/omnibox.ts
+++ b/src/background/omnibox.ts
@@ -1,0 +1,33 @@
+/**
+ * Allows users to enter tridactyl commands from the omnibox by using
+ * the `:` keyword.
+ */
+import * as controller from "@src/lib/controller"
+
+export async function inputStartedListener() {
+}
+
+export async function inputChangedListener(
+    currentInput: string,
+    emitSuggestion: (suggestions: browser.omnibox.SuggestResult[]) => null
+) {
+}
+
+export async function inputEnteredListener(
+    input: string, disposition:
+    browser.omnibox.OnInputEnteredDisposition) {
+    controller.acceptExCmd(input)
+}
+
+export async function inputCancelledListener() {
+}
+
+export async function init() {
+    browser.omnibox.onInputStarted.addListener(inputStartedListener)
+    browser.omnibox.onInputChanged.addListener(inputChangedListener)
+    browser.omnibox.onInputEntered.addListener(inputEnteredListener)
+    browser.omnibox.onInputCancelled.addListener(inputCancelledListener)
+    browser.omnibox.setDefaultSuggestion({
+        description: `Execute a Tridactyl exstr (for example, "tabopen -c container www.google.com")`,
+    })
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -70,5 +70,8 @@
     "options_ui": {
         "page": "static/docs/classes/_src_lib_config_.default_config.html",
         "open_in_tab": true
+    },
+    "omnibox": {
+	"keyword": "tri"
     }
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/omnibox

This allows the user to enter a string like `tri tabopen -c container www.google.com` to execute an exstr from the omnibox. It is _not_ a replacement for the tridactyl commandline; display and interactions are both extremely limited. However, it's probably a decent escape hatch for when you land on a page with the URL bar focused.