### PR TITLE
Fix: "browser.tabs" may have an explicit "undefined" in some cases

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -78,7 +78,7 @@ if [ -e "$TRIDACTYL_LOGO" ] ; then
     # sed and base64 take different arguments on Mac
     case "$(uname)" in
       Darwin*) sed -i "" "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO")@" build/static/themes/default/default.css;;
-      OpenBSD) sed -in "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO" | tr -d '\r\n')@" build/static/themes/default/default.css;;
+      *BSD) sed -in "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 "$TRIDACTYL_LOGO" | tr -d '\r\n')@" build/static/themes/default/default.css;;
       *) sed "s@REPLACE_ME_WITH_BASE64_TRIDACTYL_LOGO@$(base64 --wrap 0 "$TRIDACTYL_LOGO")@" -i build/static/themes/default/default.css;;
     esac
 else

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -14,7 +14,7 @@ export function inContentScript() {
     Background page
 */
 export function getContext() {
-    if (!("tabs" in browser)) {
+    if (!browser.tabs) {
         return "content"
     } else if (
         browser.runtime.getURL("_generated_background_page.html") ===


### PR DESCRIPTION
I have no idea why, but on NetBSD for some reason, the property ``browser.tabs`` in a content script has an explicit ``undefined`` as opposed to be missing. This means ``getContext()`` may misidentify the type of context.