### PR TITLE
Add setting of URL queries if they don't already exist

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1515,6 +1515,12 @@ export function urlparent(count = 1) {
  *   all instances respectively
  *      * `http://example.com` -> (`-r [ea] X g`) -> `http://XxXmplX.com`
  *
+ * * Query set mode: `urlmodify -s <query> <value>`
+ *
+ *   Sets the value of a query to be a specific one. If the query already
+ *   exists, it will be replaced.
+ *      * `http://e.com?id=abc` -> (`-s foo bar`) -> `http://e.com?id=abc&foo=bar
+ *
  * * Query replace mode: `urlmodify -q <query> <new_val>`
  *
  *   Replace the value of a query with a new one:
@@ -1555,18 +1561,20 @@ export function urlparent(count = 1) {
  * @param mode      The replace mode:
  *  * -t text replace
  *  * -r regexp replace
+ *  * -s set the value of the given query
  *  * -q replace the value of the given query
  *  * -Q delete the given query
  *  * -g graft a new path onto URL or parent path of it
  * @param replacement the replacement arguments (depends on mode):
  *  * -t <old> <new>
  *  * -r <regexp> <new> [flags]
+ *  * -s <query> <value>
  *  * -q <query> <new_val>
  *  * -Q <query>
  *  * -g <graftPoint> <newPathTail>
  */
 //#content
-export function urlmodify(mode: "-t" | "-r" | "-q" | "-Q" | "-g", ...args: string[]) {
+export function urlmodify(mode: "-t" | "-r" | "-s" | "-q" | "-Q" | "-g", ...args: string[]) {
     const oldUrl = new URL(window.location.href)
     let newUrl
 
@@ -1592,6 +1600,13 @@ export function urlmodify(mode: "-t" | "-r" | "-q" | "-Q" | "-g", ...args: strin
             newUrl = oldUrl.href.replace(regexp, args[1])
             break
 
+        case "-s":
+            if (args.length !== 2) {
+                throw new Error("Query setting needs 2 arguments:" + "<query> <value>")
+            }
+
+            newUrl = UrlUtil.addQueryValue(oldUrl, args[0], args[1])
+            break
         case "-q":
             if (args.length !== 2) {
                 throw new Error("Query replacement needs 2 arguments:" + "<query> <new_val>")

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1605,7 +1605,7 @@ export function urlmodify(mode: "-t" | "-r" | "-s" | "-q" | "-Q" | "-g", ...args
                 throw new Error("Query setting needs 2 arguments:" + "<query> <value>")
             }
 
-            newUrl = UrlUtil.addQueryValue(oldUrl, args[0], args[1])
+            newUrl = UrlUtil.setQueryValue(oldUrl, args[0], args[1])
             break
         case "-q":
             if (args.length !== 2) {

--- a/src/lib/url_util.ts
+++ b/src/lib/url_util.ts
@@ -258,6 +258,35 @@ export function deleteQuery(url: URL, matchQuery: string): URL {
 }
 
 /**
+ * Sets the value of a query in a URL with a specific one
+ *
+ * @param url           the URL to act on
+ * @param matchQuery    the query key to set the value for
+ * @param value         the value to use
+ */
+export function addQueryValue(
+    url: URL,
+    matchQuery: string,
+    value: string,
+): URL {
+    const newUrl = new URL(url.href)
+
+    // get each query separately, leave the "?" off
+    const qys = getUrlQueries(url)
+
+    // if the query exists just replace it
+    if (qys.map(q => q.split("=")[0]).includes(matchQuery)) {
+        return replaceQueryValue(url, matchQuery, value)
+    }
+
+    // the query does not exist so add it
+    qys.push(matchQuery + "=" + value)
+    setUrlQueries(newUrl, qys)
+
+    return newUrl
+}
+
+/**
  * Replace the value of a query in a URL with a new one
  *
  * @param url           the URL to act on

--- a/src/lib/url_util.ts
+++ b/src/lib/url_util.ts
@@ -264,7 +264,7 @@ export function deleteQuery(url: URL, matchQuery: string): URL {
  * @param matchQuery    the query key to set the value for
  * @param value         the value to use
  */
-export function addQueryValue(
+export function setQueryValue(
     url: URL,
     matchQuery: string,
     value: string,


### PR DESCRIPTION
This PR adds the ability to add queries using `urlmodify`.

Consider accessing the website <http://www.youtube.com> but wanting to force the old website using the query `disable_polymer=1`. `urlmodify` only allows replacing or deleting of queries, but not adding non-existing ones. This PR adds the `-s` option to `urlmodify` for setting specific queries.