### PR TITLE
native.ts: fix getProfileUncached when loading fallback default profile

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -578,7 +578,7 @@ export async function getProfileUncached() {
         // Multiple profiles used but no -p or --profile, this means that we're using the default profile
         for (const profileName of Object.keys(iniObject)) {
             const profile = iniObject[profileName]
-            if (profile.Default === 1) {
+            if (profile.Default === 1 || profile.Default === "1") {
                 return profile
             }
         }


### PR DESCRIPTION
On my setup, I was getting an error on `:guiset` where the profile would never get discovered. I found that the `iniObject[profileName]` object had a `Default` property as Number type so it was always failing. This seems to fix that. Let me know if anything needs to be changed, thanks!