### PR TITLE
content.ts: Fix pages autofocusing elements

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -73,7 +73,7 @@ document.addEventListener("readystatechange", _ =>
 )
 
 // Prevent pages from automatically focusing elements on load
-config.getAsync("allowautofocus").then(allowautofocus => {
+config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
     if (allowautofocus === "true") {
         return
     }
@@ -90,7 +90,7 @@ config.getAsync("allowautofocus").then(allowautofocus => {
         // On top of blur/focusout events, we need to periodically check the
         // activeElement is the one we want because blur/focusout events aren't
         // always triggered when document.activeElement changes
-        const interval = setInterval(() => { if (document.activeElement != elem) focusElem() }, 10)
+        const interval = setInterval(() => { if (document.activeElement != elem) focusElem() }, 200)
         // When the user starts interacting with the page, stop resetting focus
         function stopResettingFocus() {
             elem.removeEventListener("blur", focusElem)

--- a/src/content.ts
+++ b/src/content.ts
@@ -72,6 +72,47 @@ document.addEventListener("readystatechange", _ =>
     getAllDocumentFrames().forEach(f => listen(f)),
 )
 
+// Prevent pages from automatically focusing elements on load
+config.getAsync("allowautofocus").then(allowautofocus => {
+    if (allowautofocus === "true") {
+        return
+    }
+    const preventAutoFocus = () => {
+        // First, blur whatever element is active. This will make sure
+        // activeElement is the "default" active element
+        ; (document.activeElement as any).blur()
+        const elem = document.activeElement as any
+        // ???: We need to set tabIndex, otherwise we won't get focus/blur events!
+        elem.tabIndex = 0
+        const focusElem = () => elem.focus()
+        elem.addEventListener("blur", focusElem)
+        elem.addEventListener("focusout", focusElem)
+        // On top of blur/focusout events, we need to periodically check the
+        // activeElement is the one we want because blur/focusout events aren't
+        // always triggered when document.activeElement changes
+        const interval = setInterval(() => { if (document.activeElement != elem) focusElem() }, 10)
+        // When the user starts interacting with the page, stop resetting focus
+        function stopResettingFocus() {
+            elem.removeEventListener("blur", focusElem)
+            elem.removeEventListener("focusout", focusElem)
+            clearInterval(interval)
+            window.removeEventListener("keydown", stopResettingFocus)
+            window.removeEventListener("mousedown", stopResettingFocus)
+        }
+        window.addEventListener("keydown", stopResettingFocus)
+        window.addEventListener("mousedown", stopResettingFocus)
+    }
+    const tryPreventAutoFocus = () => {
+        document.removeEventListener("readystatechange", tryPreventAutoFocus)
+        try {
+            preventAutoFocus()
+        } catch (e) {
+            document.addEventListener("readystatechange", tryPreventAutoFocus)
+        }
+    }
+    tryPreventAutoFocus()
+})
+
 // Add various useful modules to the window for debugging
 import * as commandline_content from "@src/content/commandline_content"
 import * as convert from "@src/lib/convert"

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -590,6 +590,11 @@ class default_config {
     allowautofocus: "true" | "false" = "true"
 
     /**
+     * Uses a loop to prevent focus until you interact with a page. Only recommended for use via `seturl` for problematic sites as it can be a little heavy on CPU if running on all tabs. Should be used in conjuction with [[allowautofocus]]
+     */
+    preventautofocusjackhammer: "true" | "false" = "true"
+
+    /**
      * Controls whether the newtab focuses on tridactyl's newtab page or the firefox urlbar.
      *
      * To get FF default behaviour, use "urlbar".


### PR DESCRIPTION
Some pages manage to focus a hidden input field on page load. This puts
tridactyl in insert mode without the user being aware of it. This commit
actively protects users who set `allowautofocus` to "false" against
this.

Closes https://github.com/tridactyl/tridactyl/issues/1492