### PR TITLE
browser.extension.getURL -> browser.runtime.getURL

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -15,7 +15,7 @@ import { enumerate } from "@src/lib/itertools"
 import { toNumber } from "@src/lib/convert"
 import * as aliases from "@src/lib/aliases"
 
-export const DEFAULT_FAVICON = browser.extension.getURL(
+export const DEFAULT_FAVICON = browser.runtime.getURL(
     "static/defaultFavicon.svg",
 )
 

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -103,7 +103,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
         // In the nonewtab version, this will return `null` and upset getURL.
         // Ternary op below prevents the runtime error.
         const newtab = (browser.runtime.getManifest()).chrome_url_overrides.newtab
-        const newtaburl = newtab !== null ? browser.extension.getURL(newtab) : null
+        const newtaburl = newtab !== null ? browser.runtime.getURL(newtab) : null
         if (!query || config.get("historyresults") === 0) {
             return (await browserBg.topSites.get())
                 .filter(page => page.url !== newtaburl)

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -24,7 +24,7 @@ const cmdline_iframe = window.document.createElementNS(
 cmdline_iframe.className = "cleanslate"
 cmdline_iframe.setAttribute(
     "src",
-    browser.extension.getURL("static/commandline.html"),
+    browser.runtime.getURL("static/commandline.html"),
 )
 cmdline_iframe.setAttribute("id", "cmdline_iframe")
 

--- a/src/content/editor.ts
+++ b/src/content/editor.ts
@@ -6,7 +6,7 @@ export const EditorCmds = new Proxy(_EditorCmds, {
     get(target, property) {
         if (target[property]) {
             return (...args) => {
-                if ((document.activeElement as any).src === browser.extension.getURL("static/commandline.html")) {
+                if ((document.activeElement as any).src === browser.runtime.getURL("static/commandline.html")) {
                     return messageOwnTab("commandline_frame", "editor_function", [property].concat(args))
                 }
                 return _EditorCmds[property](DOM.getLastUsedInput(), ...args)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1279,7 +1279,7 @@ export async function help(...helpItems: string[]) {
                 if (resolved.includes(helpItem)) break
             }
             if (resolved.length > 0) {
-                return browser.extension.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem
+                return browser.runtime.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem
             }
             return ""
         },
@@ -1294,13 +1294,13 @@ export async function help(...helpItems: string[]) {
                 if (helpItem in bindings) {
                     helpItem = bindings[helpItem].split(" ")
                     helpItem = ["composite", "fillcmdline"].includes(helpItem[0]) ? helpItem[1] : helpItem[0]
-                    return browser.extension.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem
+                    return browser.runtime.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem
                 }
             }
             return ""
         },
         // -e: look for an excmd
-        "-e": (settings, helpItem) => browser.extension.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem,
+        "-e": (settings, helpItem) => browser.runtime.getURL("static/docs/modules/_src_excmds_.html") + "#" + helpItem,
         // -s: look for a setting
         "-s": (settings, helpItem) => {
             let subSettings = settings
@@ -1314,7 +1314,7 @@ export async function help(...helpItems: string[]) {
                 }
             }
             if (settingHelpAnchor !== "") {
-                return browser.extension.getURL("static/docs/classes/_src_lib_config_.default_config.html") + "#" + settingHelpAnchor.slice(0, -1)
+                return browser.runtime.getURL("static/docs/classes/_src_lib_config_.default_config.html") + "#" + settingHelpAnchor.slice(0, -1)
             }
             return ""
         },
@@ -1344,7 +1344,7 @@ export async function help(...helpItems: string[]) {
         }, "")
     }
 
-    if ((await activeTab()).url.startsWith(browser.extension.getURL("static/docs/"))) {
+    if ((await activeTab()).url.startsWith(browser.runtime.getURL("static/docs/"))) {
         open(url)
     } else {
         tabopen(url)
@@ -1356,7 +1356,7 @@ export async function help(...helpItems: string[]) {
  */
 //#background
 export async function tutor(newtab?: string) {
-    const tutor = browser.extension.getURL("static/clippy/1-tutor.html")
+    const tutor = browser.runtime.getURL("static/clippy/1-tutor.html")
     if (newtab) tabopen(tutor)
     else open(tutor)
 }
@@ -1366,7 +1366,7 @@ export async function tutor(newtab?: string) {
  */
 //#background
 export async function credits(excmd?: string) {
-    const creditspage = browser.extension.getURL("static/authors.html")
+    const creditspage = browser.runtime.getURL("static/authors.html")
     tabopen(creditspage)
 }
 
@@ -4151,7 +4151,7 @@ export async function issue() {
         logger.warning("issue(): Couldn't find textarea element in github issue page.")
         return
     }
-    let template = await (fetch(browser.extension.getURL("issue_template.md"))
+    let template = await (fetch(browser.runtime.getURL("issue_template.md"))
         .then(resp => resp.body.getReader())
         .then(reader => reader.read())
         .then(r => (new TextDecoder("utf-8")).decode(r.value)))


### PR DESCRIPTION
Function is deprecated:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL

Replacement has essentially identical functionality:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL

I'm sure that there's _some_ difference between the "path in install directory" and "path relative to manifest.json", but I don't think that we're going to be the ones running into it.