### PR TITLE
excmds.ts: Fix taball moving to tab in wrong window

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2880,9 +2880,12 @@ export async function taball(id: string) {
         id = windows.indexOf(tab.windowId) + "." + (tab.index + 1)
         logger.info(`taball: Bad tab id: ${prevId}, defaulting to ${id}`)
     }
-    const [winindex, tabindex] = id.split(".")
-    await browser.windows.update(windows[parseInt(winindex, 10) - 1], { focused: true })
-    return browser.tabs.update(await idFromIndex(tabindex), { active: true })
+    const [winindex, tabindex_string] = id.split(".")
+    const winid = windows[parseInt(winindex, 10) - 1]
+    const tabindex_number = parseInt(tabindex_string, 10) - 1
+    const tabid = (await browser.tabs.query({ windowId: winid, index: tabindex_number }))[0].id
+    await browser.windows.update(winid, { focused: true })
+    return browser.tabs.update(tabid, { active: true })
 }
 
 // }}}


### PR DESCRIPTION
This commit fixes a bug reported by cmcaine. The issue was that when you
have multiple windows on multiple workspaces, taball wouldn't switch
focus to the right tab. This happened because taball relied on
browser.windows.update(id, {focused: true}) having switched to the right
window before calling idFromIndex. This didn't always work because
sometimes window managers will keep the current window focused.