### PR TITLE
Add default subconfig for followpagepatterns www.google.com

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,7 +58,14 @@ class default_config {
     /**
      * Internal field to handle site-specific configs. Use :seturl/:unseturl to change these values.
      */
-    subconfigs: { [key: string]: default_config } = {}
+    subconfigs: { [key: string]: default_config } = {
+        "www.google.com": {
+            "followpagepatterns": {
+                "next": "Next",
+                "prev": "Previous"
+            }
+        } as default_config
+    }
 
     /**
      * Internal field to handle site-specific config priorities. Use :seturl/:unseturl to change this value.


### PR DESCRIPTION
This doesn't currently work - it looks like only subconfigs in user config
are considered. Probably need to use mergeDeep somewhere in `getURL`.

Would fix #943 once fixed and merged.