### PR TITLE
Add type checking to first arg of config.get

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3020,7 +3020,7 @@ export function bind(...args: string[]) {
         for (let i = 0; i < args_obj.key.length; i++) {
             // Check if any initial subsequence of the key exists and will shadow the new binding
             const key_sub = args_obj.key.slice(0, i)
-            if (config.get(args_obj.configName as keyof config.default_config, key_sub)) {
+            if (config.getDynamic(args_obj.configName, key_sub)) {
                 fillcmdline_notrail("# Warning: bind `" + key_sub + "` exists and will shadow `" + args_obj.key + "`. Try running `:unbind --mode=" + args_obj.mode + " " + key_sub + "`")
                 break
             }
@@ -3028,7 +3028,7 @@ export function bind(...args: string[]) {
         p = config.set(args_obj.configName, args_obj.key, args_obj.excmd)
     } else if (args_obj.key.length) {
         // Display the existing bind
-        p = fillcmdline_notrail("#", args_obj.key, "=", config.get(args_obj.configName as keyof config.default_config, args_obj.key))
+        p = fillcmdline_notrail("#", args_obj.key, "=", config.getDynamic(args_obj.configName, args_obj.key))
     }
     return p
 }
@@ -3457,9 +3457,7 @@ export async function quickmark(key: string, ...addressarr: string[]) {
 //#background
 export function get(...keys: string[]) {
     const target = keys.join(".").split(".")
-    const value = config.get(
-        target[0] as keyof config.default_config, ...target.slice(1)
-    )
+    const value = config.getDynamic(...target)
     console.log(value)
     if (typeof value === "object") {
         fillcmdline_notrail(`# ${keys.join(".")} = ${JSON.stringify(value)}`)
@@ -3489,7 +3487,7 @@ export function viewconfig(key?: string) {
     else
         window.location.href =
             "data:application/json," +
-            JSON.stringify(config.get(key as keyof config.default_config))
+            JSON.stringify(config.getDynamic(key))
                 .replace(/#/g, "%23")
                 .replace(/ /g, "%20")
     // base 64 encoding is a cleverer way of doing this, but it doesn't seem to work for the whole config.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3020,7 +3020,7 @@ export function bind(...args: string[]) {
         for (let i = 0; i < args_obj.key.length; i++) {
             // Check if any initial subsequence of the key exists and will shadow the new binding
             const key_sub = args_obj.key.slice(0, i)
-            if (config.get(args_obj.configName, key_sub)) {
+            if (config.get(args_obj.configName as keyof config.default_config, key_sub)) {
                 fillcmdline_notrail("# Warning: bind `" + key_sub + "` exists and will shadow `" + args_obj.key + "`. Try running `:unbind --mode=" + args_obj.mode + " " + key_sub + "`")
                 break
             }
@@ -3028,7 +3028,7 @@ export function bind(...args: string[]) {
         p = config.set(args_obj.configName, args_obj.key, args_obj.excmd)
     } else if (args_obj.key.length) {
         // Display the existing bind
-        p = fillcmdline_notrail("#", args_obj.key, "=", config.get(args_obj.configName, args_obj.key))
+        p = fillcmdline_notrail("#", args_obj.key, "=", config.get(args_obj.configName as keyof config.default_config, args_obj.key))
     }
     return p
 }
@@ -3457,7 +3457,9 @@ export async function quickmark(key: string, ...addressarr: string[]) {
 //#background
 export function get(...keys: string[]) {
     const target = keys.join(".").split(".")
-    const value = config.get(...target)
+    const value = config.get(
+        target[0] as keyof config.default_config, ...target.slice(1)
+    )
     console.log(value)
     if (typeof value === "object") {
         fillcmdline_notrail(`# ${keys.join(".")} = ${JSON.stringify(value)}`)
@@ -3487,7 +3489,7 @@ export function viewconfig(key?: string) {
     else
         window.location.href =
             "data:application/json," +
-            JSON.stringify(config.get(key))
+            JSON.stringify(config.get(key as keyof config.default_config))
                 .replace(/#/g, "%23")
                 .replace(/ /g, "%20")
     // base 64 encoding is a cleverer way of doing this, but it doesn't seem to work for the whole config.

--- a/src/help.ts
+++ b/src/help.ts
@@ -53,7 +53,7 @@ async function addSetting(settingName: string) {
         {},
     )
 
-    const settings = await config.getAsync(settingName)
+    const settings = await config.getAsyncDynamic(settingName)
     // For each setting
     for (const setting of Object.keys(settings)) {
         let excmd = settings[setting].split(" ")
@@ -150,7 +150,7 @@ function addSettingInputs() {
                 const section = a.parentNode
 
                 const settingName = a.name.split(".")
-                const value = await config.getAsync(settingName)
+                const value = await config.getAsyncDynamic(...settingName)
                 if (!value) return console.log("Failed to grab value of ", a)
                 if (!["number", "boolean", "string"].includes(typeof value))
                     return console.log(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -47,7 +47,7 @@ export type LoggingLevel = "never" | "error" | "warning" | "info" | "debug"
  *
  * You can change anything here using `set key1.key2.key3 value` or specific things any of the various helper commands such as `bind` or `command`. You can also jump to the help section of a setting using `:help $settingname`. Some of the settings have an input field containing their current value. You can modify these values and save them by pressing `<Enter>` but using `:set $setting $value` is a good habit to take as it doesn't force you to leave the page you're visiting to change your settings.
  */
-class default_config {
+export class default_config {
     /**
      * Internal version number Tridactyl uses to know whether it needs to update from old versions of the configuration.
      *
@@ -700,6 +700,11 @@ class default_config {
     noiframe: "true" | "false" = "false"
 
     /**
+     * @deprecated A list of URLs on which to not load the iframe. Use `seturl [URL] noiframe true` instead, as shown in [[noiframe]].
+     */
+    noiframeon: string[] = []
+
+    /**
      * Insert / input mode edit-in-$EDITOR command to run
      * This has to be a command that stays in the foreground for the whole editing session
      * "auto" will attempt to find a sane editor in your path.
@@ -998,7 +1003,8 @@ export function getURL(url: string, target: string[]) {
     defaults, if one exists, else undefined.
     @hidden
 */
-export function get(...target) {
+export function get(target_typed?: keyof default_config, ...target: string[]) {
+    target = [(target_typed as string)].concat(target)
     // Window.tri might not be defined when called from the untrusted page context
     let loc = window.location
     if ((window as any).tri && (window as any).tri.contentLocation)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -669,6 +669,13 @@ export class default_config {
     theme = "default"
 
     /**
+     * Storage for custom themes
+     *
+     * Maps theme names to CSS. Predominantly used automatically by [[colourscheme]] to store themes read from disk, as documented by [[colourscheme]]. Setting this manually is untested but might work provided that [[colourscheme]] is then used to change the theme to the right theme name.
+     */
+    customthemes = {}
+
+    /**
      * Whether to display the mode indicator or not.
      */
     modeindicator: "true" | "false" = "true"
@@ -1032,18 +1039,34 @@ export function get(target_typed?: keyof default_config, ...target: string[]) {
     }
 }
 
+/** Get the value of the key target.
+
+    Please only use this with targets that will be used at runtime - it skips static checks. Prefer [[get]].
+*/
+export function getDynamic(...target: string[]) {
+    return get(target[0] as keyof default_config, ...target.slice(1))
+}
+
+/** Get the value of the key target.
+
+    Please only use this with targets that will be used at runtime - it skips static checks. Prefer [[getAsync]].
+*/
+export async function getAsyncDynamic(...target: string[]) {
+    return getAsync(target[0] as keyof default_config, ...target.slice(1))
+}
+
 /** Get the value of the key target, but wait for config to be loaded from the
     database first if it has not been at least once before.
 
     This is useful if you are a content script and you've just been loaded.
     @hidden
 */
-export async function getAsync(...target) {
+export async function getAsync(target_typed?: keyof default_config, ...target: string[]) {
     if (INITIALISED) {
-        return get(...target)
+        return get(target_typed, ...target)
     } else {
         return new Promise(resolve =>
-            WAITERS.push(() => resolve(get(...target))),
+            WAITERS.push(() => resolve(get(target_typed, ...target))),
         )
     }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1004,7 +1004,11 @@ export function getURL(url: string, target: string[]) {
     @hidden
 */
 export function get(target_typed?: keyof default_config, ...target: string[]) {
-    target = [(target_typed as string)].concat(target)
+    if (target_typed === undefined) {
+        target = []
+    } else {
+        target = [(target_typed as string)].concat(target)
+    }
     // Window.tri might not be defined when called from the untrusted page context
     let loc = window.location
     if ((window as any).tri && (window as any).tri.contentLocation)

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -709,7 +709,7 @@ export async function getConfElsePref(
     confName: string,
     prefName: string,
 ): Promise<any> {
-    let option = await config.getAsync(confName)
+    let option = await config.getAsyncDynamic(confName)
     if (option === undefined) {
         try {
             option = await getPref(prefName)


### PR DESCRIPTION
Also document noiframeon, which I discovered was undocumented
because of the type checking.

---

It makes splatted config.gets rather uglier with `...args` ->
`args[0] as keyof config.default_config, args.slice(1)...`.

It has apparently also broken config completions.