### PR TITLE
WIP: show possible matches in mode indicator

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -11,6 +11,7 @@ const logger = new Logger("controller")
 
 function PrintableKey(k) {
     let result = k.key
+    console.log(k)
     if (
         result === "Control" ||
         result === "Meta" ||
@@ -156,10 +157,17 @@ function* ParserController() {
                     exstr = response.exstr
                     break
                 } else {
-                    keyEvents = response.keys
+                    keyEvents = response.potMatches
+                    console.log([...keyEvents.keys()])
                     // show current keyEvents as a suffix of the contentState
-                    contentState.suffix = keyEvents
-                        .map(x => PrintableKey(x))
+                    contentState.suffix = [...keyEvents.keys()]
+                        .map(y => {
+                            console.log(y)
+                            ; (y as any).map(x => {
+                                console.log(x)
+                                PrintableKey(x.key)
+                            }).join(" ")
+                        })
                         .join("")
                     logger.debug("suffix: ", contentState.suffix)
                 }

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -112,6 +112,7 @@ export interface ParserResponse {
     exstr?: any
     isMatch: boolean
     numericPrefix?: number
+    potMatches?: KeyMap
 }
 
 export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
@@ -156,7 +157,7 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
     // command, numericPrefix is a numeric prefix of that. We want to
     // preserve that whole thing, so concat them back together before
     // returning.
-    return { keys: numericPrefix.concat(keyseq), isMatch: keyseq.length > 0 }
+    return { keys: numericPrefix.concat(keyseq), isMatch: keyseq.length > 0, potMatches: possibleMappings }
 }
 
 /** True if seq1 is a prefix or equal to seq2 */


### PR DESCRIPTION
Not currently working. Making this PR so I can have a break and work on something else. Related: #1120.

To-do:

- Make it work
- Cut current suffix from matches; consider showing ex-str they're bound to
- Only show 3 - 5 matches (`;` has 40!) - have ellipsis to show when they are truncated
- Style nicely - one match per line
