### PR TITLE
scrolling.ts: fix smooth scrolling

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -54,9 +54,19 @@ class ScrollingData {
         if (elapsed >= this.duration || this.elem[this.pos] === this.endPos)
             return this.endPos
 
-        const result = ((this.endPos - this.startPos) * elapsed) / this.duration
-        if (result >= 1 || result <= -1) return this.startPos + result
-        return this.elem[this.pos] + (this.startPos < this.endPos ? 1 : -1)
+        let result = this.startPos + (((this.endPos - this.startPos) * elapsed) / this.duration)
+        if (this.startPos < this.endPos) {
+            // We need to ceil() because only highdpi screens have a decimal this.elem[this.pos]
+            result = Math.ceil(result)
+            // We *have* to make progress, otherwise we'll think the element can't be scrolled
+            if (result == this.elem[this.pos])
+                result += 1
+        } else {
+            result = Math.floor(result)
+            if (result == this.elem[this.pos])
+                result -= 1
+        }
+        return result
     }
 
     /** Updates the position of this.elem, returns true if the element has been scrolled, false otherwise. */


### PR DESCRIPTION
This commit fixes smooth scrolling. The issue with smooth scrolling was
that from time to time, pressing `j` would only scroll the page by a
pixel. This happened because the computed scrolling step was smaller
than a pixel. When writing to elem.scrollTop, this value would be
rounded to the nearest integer, which sometimes was equal to the
previous scrollTop value. This resulted in Tridactyl believing that the
element couldn't be further scrolled and stopping there.

This is fixed by using Math.ceil()/round() on the step in order to make
sure a round value is obtained. This value is then compared to the
current scrollTop value and incremented in case they're equal, in order
to make sure scrolling makes progress.

Fixes https://github.com/tridactyl/tridactyl/issues/627 and maybe
https://github.com/tridactyl/tridactyl/issues/54 ?