### PR TITLE
gen_metadata.ts: Fix compiler pass not working with typescript 3.5.1

### DIFF
--- a/compiler/gen_metadata.ts
+++ b/compiler/gen_metadata.ts
@@ -11,6 +11,8 @@ export function toSimpleType(typeNode) {
         // IndexedAccessTypes are things like `fn<T keyof Class>(x: T, y: Class[T])`
         // This doesn't seem to be easy to deal with so let's kludge it for now
         case ts.SyntaxKind.IndexedAccessType:
+        // Unknown is just like any, but slightly stricter
+        case ts.SyntaxKind.UnknownKeyword:
         case ts.SyntaxKind.AnyKeyword:
             return new AllTypes.AnyType()
         case ts.SyntaxKind.BooleanKeyword:


### PR DESCRIPTION
TypeScript 3.5.1 added a new 'Unknown' keyword which behaves similarly
to any, except when assigning a value to a variable that already holds a
value. This is not something we care about and so we can just treat it
as any.