### PR TITLE
finding.ts: scroll elems to the center of the screen rather than the top

### DIFF
--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -34,7 +34,7 @@ class FindHighlight extends HTMLSpanElement {
         }
         ; (this as any).focus = () => {
             if (!DOM.isVisible(this.children[0])) {
-                this.children[0].scrollIntoView()
+                this.children[0].scrollIntoView({ block: "center", inline: "center" })
             }
             let parentNode = this.node.parentNode
             while (parentNode && !(parentNode instanceof HTMLAnchorElement)) {


### PR DESCRIPTION
This is a small workaround for websites that use navigation bars which
sometimes cover `:find` matches when you jump to them.