### PR TITLE
Make native{install,update} use corresponding tag for stable build

### DIFF
--- a/native/install.sh
+++ b/native/install.sh
@@ -18,8 +18,10 @@ trap "echoerr 'Failed to install!'" ERR
 
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/tridactyl"
 XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/tridactyl"
-manifest_loc="https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/tridactyl.json"
-native_loc="https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/native_main.py"
+
+# Use argument as version or 1.15.0, as that was the last version before we switched to using tags
+manifest_loc="https://raw.githubusercontent.com/tridactyl/tridactyl/${1:-1.15.0}/native/tridactyl.json"
+native_loc="https://raw.githubusercontent.com/tridactyl/tridactyl/${1:-1.15.0}/native/native_main.py"
 
 # Decide where to put the manifest based on OS
 case "$OSTYPE" in

--- a/native/win_install.ps1
+++ b/native/win_install.ps1
@@ -2,7 +2,8 @@ Param (
     [switch]$Uninstall = $false,
     [switch]$NoPython= $false,
     [string]$DebugDirBase = "",
-    [string]$InstallDirBase = ""
+    [string]$InstallDirBase = "",
+    [string]$Tag = "1.15.0"
 )
 
 #
@@ -18,10 +19,8 @@ $global:WinPython3Command = "py -3 -u"
 $global:MessengerManifestReplaceStr = "REPLACE_ME_WITH_SED"
 $global:PowerShellMinimumVersion = 3
 
-# $git_repo_owner should be "cmcaine" in final release
-$git_repo_owner = "cmcaine"
-# $git_repo_branch should be "master" in final release
-$git_repo_branch = "master"
+$git_repo_owner = "tridactyl"
+$git_repo_branch = $Tag
 $git_repo_proto = "https"
 $git_repo_host = "raw.githubusercontent.com"
 $git_repo_name = "tridactyl"

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -654,12 +654,13 @@ export async function native() {
  */
 //#background
 export async function nativeinstall() {
+    const tag = TRI_VERSION.includes("pre") ? "master" : TRI_VERSION
     if ((await browser.runtime.getPlatformInfo()).os === "win") {
-        const installstr = await config.get("win_nativeinstallcmd")
+        const installstr = (await config.get("win_nativeinstallcmd")).replace("%WINTAG", "-Tag " + tag)
         await yank(installstr)
         fillcmdline("# Installation command copied to clipboard. Please paste and run it from cmd.exe, PowerShell, or MinTTY to install the native messenger.")
     } else {
-        const installstr = await config.get("nativeinstallcmd")
+        const installstr = (await config.get("nativeinstallcmd")).replace("%TAG", tag)
         await yank(installstr)
         fillcmdline("# Installation command copied to clipboard. Please paste and run it in your shell to install the native messenger.")
     }
@@ -704,15 +705,16 @@ export async function source_quiet(...fileArr: string[]) {
  */
 //#background
 export async function updatenative(interactive = true) {
+    const tag = TRI_VERSION.includes("pre") ? "master" : TRI_VERSION
     if (await Native.nativegate("0", interactive)) {
         if ((await browser.runtime.getPlatformInfo()).os === "mac") {
             if (interactive) logger.error("Updating the native messenger on OSX is broken. Please use `:installnative` instead.")
             return
         }
         if ((await browser.runtime.getPlatformInfo()).os === "win") {
-            await Native.run(await config.get("win_nativeinstallcmd"))
+            await Native.run((await config.get("win_nativeinstallcmd")).replace("%WINTAG", "-Tag " + tag))
         } else {
-            await Native.run(await config.get("nativeinstallcmd"))
+            await Native.run((await config.get("nativeinstallcmd")).replace("%TAG", tag))
         }
 
         if (interactive) native()

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -788,14 +788,18 @@ export class default_config {
 
     /**
      * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger.
+     *
+     * %TAG will be replaced with your version of Tridactyl for stable builds, or "master" for beta builds
      */
     nativeinstallcmd =
-        "curl -fsSl https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/install.sh | bash"
+        "curl -fsSl https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/install.sh -o /tmp/trinativeinstall.sh && bash /tmp/trinativeinstall.sh %TAG"
 
     /**
      * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger.
+     *
+     * Replaces %WINTAG with "-Tag $TRI_VERSION", similarly to [[nativeinstallcmd]].
      */
-    win_nativeinstallcmd = `powershell -NoProfile -InputFormat None -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))"`
+    win_nativeinstallcmd = `powershell -NoProfile -InputFormat None -Command "$TempFile = New-TemporaryFile; (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1',$TempFile); ./$TempFile %WINTAG"`
 
     /**
      * Used by :updatecheck and related built-in functionality to automatically check for updates and prompt users to upgrade.


### PR DESCRIPTION
Beta builds will always use most recent messenger, which I think is probably fair;
old beta builds are unsupported.

Fixes #493.

Untested on Windows.