### PR TITLE
Fix #214

### DIFF
--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -35,7 +35,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
         super(
             ["open", "tabopen", "winopen"],
             "HistoryCompletionSource",
-            "History",
+            "History and bookmarks",
         )
 
         this._parent.appendChild(this.node)

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -1,6 +1,6 @@
 import * as Completions from "@src/completions"
 import * as config from "@src/lib/config"
-import { browserBg } from "@src/lib/webext"
+import * as providers from "@src/completions/providers"
 
 class HistoryCompletionOption extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
@@ -102,49 +102,11 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
 
     onInput() {}
 
-    private frecency(item: browser.history.HistoryItem) {
-        // Doesn't actually care about recency yet.
-        return item.visitCount * -1
-    }
-
     private async scoreOptions(query: string, n: number) {
-        // In the nonewtab version, this will return `null` and upset getURL.
-        // Ternary op below prevents the runtime error.
-        const newtab = (browser.runtime.getManifest()).chrome_url_overrides.newtab
-        const newtaburl = newtab !== null ? browser.runtime.getURL(newtab) : null
         if (!query || config.get("historyresults") === 0) {
-            return (await browserBg.topSites.get())
-                .filter(page => page.url !== newtaburl)
-                .slice(0, n)
+            return (await providers.getTopSites()).slice(0, n)
         } else {
-            // Search history, dedupe and sort by frecency
-            let history = await browserBg.history.search({
-                text: query,
-                maxResults: config.get("historyresults"),
-                startTime: 0,
-            })
-
-            // Remove entries with duplicate URLs
-            const dedupe = new Map()
-            for (const page of history) {
-                if (page.url !== newtaburl) {
-                    if (dedupe.has(page.url)) {
-                        if (
-                            dedupe.get(page.url).title.length <
-                            page.title.length
-                        ) {
-                            dedupe.set(page.url, page)
-                        }
-                    } else {
-                        dedupe.set(page.url, page)
-                    }
-                }
-            }
-            history = [...dedupe.values()]
-
-            history.sort((a, b) => this.frecency(a) - this.frecency(b))
-
-            return history.slice(0, n)
+            return (await providers.getCombinedHistoryBmarks(query)).slice(0, n)
         }
     }
 }

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -93,7 +93,7 @@ export async function getCombinedHistoryBmarks(query: string): Promise<Array<{ti
         else combinedMap.set(page.url, {title: page.title, url: page.url, history: page})
     })
 
-    const score = x => (x.history ? frecency(x.history) : 0) - (x.bmark ? 1000 : 0)
+    const score = x => (x.history ? frecency(x.history) : 0) - (x.bmark ? config.get("bmarkweight") : 0)
 
     return Array.from(combinedMap.values()).sort((a, b) => score(a) - score(b))
 }

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -1,0 +1,99 @@
+import * as config from "@src/lib/config"
+import { browserBg } from "@src/lib/webext"
+
+export function newtaburl() {
+    // In the nonewtab version, this will return `null` and upset getURL.
+    // Ternary op below prevents the runtime error.
+    const newtab = (browser.runtime.getManifest()).chrome_url_overrides.newtab
+    return newtab !== null ? browser.runtime.getURL(newtab) : null
+}
+
+export async function getBookmarks(query: string) {
+    // Search bookmarks, dedupe and sort by most recent.
+    let bookmarks = await browserBg.bookmarks.search({ query })
+
+    // Remove folder nodes and bad URLs
+    bookmarks = bookmarks.filter(b => {
+        try {
+            return new URL(b.url)
+        } catch (e) {
+            return false
+        }
+    })
+
+    bookmarks.sort((a, b) => b.dateAdded - a.dateAdded)
+
+    // Remove duplicate bookmarks
+    const seen = new Map<string, string>()
+    bookmarks = bookmarks.filter(b => {
+        if (seen.get(b.title) === b.url)
+            return false
+        else {
+            seen.set(b.title, b.url)
+            return true
+        }
+    })
+
+    return bookmarks
+}
+
+function frecency(item: browser.history.HistoryItem) {
+    // Doesn't actually care about recency yet.
+    return item.visitCount * -1
+}
+
+export async function getHistory(query: string): Promise<browser.history.HistoryItem[]> {
+    // Search history, dedupe and sort by frecency
+    let history = await browserBg.history.search({
+        text: query,
+        maxResults: config.get("historyresults"),
+        startTime: 0,
+    })
+
+    // Remove entries with duplicate URLs
+    const dedupe = new Map()
+    for (const page of history) {
+        if (page.url !== newtaburl()) {
+            if (dedupe.has(page.url)) {
+                if (
+                    dedupe.get(page.url).title.length <
+                    page.title.length
+                ) {
+                    dedupe.set(page.url, page)
+                }
+            } else {
+                dedupe.set(page.url, page)
+            }
+        }
+    }
+    history = [...dedupe.values()]
+
+    history.sort((a, b) => frecency(a) - frecency(b))
+
+    return history
+}
+
+export async function getTopSites() {
+    return (await browserBg.topSites.get())
+        .filter(page => page.url !== newtaburl())
+}
+
+export async function getCombinedHistoryBmarks(query: string): Promise<Array<{title: string, url: string}>> {
+    const [history, bookmarks] = await Promise.all([
+        getHistory(query),
+        getBookmarks(query),
+    ])
+
+    // Join records by URL, using the title from bookmarks by preference.
+    const combinedMap = new Map<string, any>(bookmarks.map(bmark => [
+        bmark.url, {title: bmark.title, url: bmark.url, bmark}
+    ]))
+    history.forEach(page => {
+        if (combinedMap.has(page.url)) combinedMap.get(page.url).history = page
+        else combinedMap.set(page.url, {title: page.title, url: page.url, history: page})
+    })
+
+    const score = x => (x.history ? frecency(x.history) : 0) - (x.bmark ? 1000 : 0)
+
+    return Array.from(combinedMap.values()).sort((a, b) => score(a) - score(b))
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -862,6 +862,11 @@ export class default_config {
     historyresults = 50
 
     /**
+     * When displaying bookmarks in history completions, how many page views to pretend they have.
+     */
+    bmarkweight = 100
+
+    /**
      * Number of results that should be shown in completions. -1 for unlimited
      */
     findresults = -1


### PR DESCRIPTION
Refactors bookmark and history searching to a new file as well

and

fe42846 (Colin Caine, 74 minutes ago)
completions/bmarks: dedupe completions

Firefox discourages having more than one bookmark to the same URL, but it
can happen anyway due to sync bugs or something (I have duplicate 
bookmarks, anyway).

This patch deduplicates bookmarks.