### PR TITLE
Implement `urlparenttrailingslash` option

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1556,7 +1556,9 @@ export function urlroot() {
  */
 //#content
 export function urlparent(count = 1) {
-    const parentUrl = UrlUtil.getUrlParent(window.location, count)
+    const trailingSlash = config.get("urlparenttrailingslash") === "true"
+
+    const parentUrl = UrlUtil.getUrlParent(window.location, trailingSlash, count)
 
     if (parentUrl !== null) {
         window.location.href = parentUrl.href

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -928,6 +928,12 @@ export class default_config {
      * Corresponds to 'showcmd' option of vi.
      */
     modeindicatorshowkeys: "true" | "false" = "false"
+
+    /**
+     * Whether a trailing slash is appended when we get the parent of a url with
+     * gu (or other means).
+     */
+    urlparenttrailingslash: "true" | "false" = "true"
 }
 
 /** @hidden */

--- a/src/lib/url_util.test.ts
+++ b/src/lib/url_util.test.ts
@@ -74,7 +74,7 @@ function test_parent() {
     ]
 
     for (let [url, exp_parent] of cases) {
-        let parent = UrlUtil.getUrlParent(new URL(url))
+        let parent = UrlUtil.getUrlParent(new URL(url), true)
 
         test(`parent of ${url} --> ${exp_parent}`, () =>
             expect(parent ? parent.href : parent).toEqual(exp_parent))

--- a/src/lib/url_util.test.ts
+++ b/src/lib/url_util.test.ts
@@ -81,6 +81,46 @@ function test_parent() {
     }
 }
 
+function test_parent_with_slash_strip() {
+    const cases = [
+        // root URL, nothing to do!
+        ["http://example.com", null],
+        // URL with query string
+        ["http://example.com?key=value", "http://example.com/"],
+        // url with hash/anchor - strip the fragment
+        ["http://example.com#anchor", "http://example.com/"],
+        // query + hash: lose the hash only
+        ["http://example.com?key=val#hash", "http://example.com/?key=val"],
+        // single level path
+        ["http://example.com/path", "http://example.com/"],
+        // multi-level path
+        ["http://example.com/path1/path2", "http://example.com/path1"],
+        [
+            "http://example.com/path1/path2/path3",
+            "http://example.com/path1/path2",
+        ],
+        // subdomains
+        ["http://sub.example.com", "http://example.com/"],
+        // subdom with path, leave subdom
+        ["http://sub.example.com/path", "http://sub.example.com/"],
+        // trailing slash
+        ["http://sub.example.com/path/", "http://sub.example.com/"],
+        ["http://sub.example.com/path/to/", "http://sub.example.com/path"],
+        // repeated slash
+        ["http://example.com/path//", "http://example.com/"],
+        ["http://example.com//path//", "http://example.com/"],
+        ["http://example.com//path//", "http://example.com/"],
+    ]
+
+    for (const [url, exp_parent] of cases) {
+        const parent = UrlUtil.getUrlParent(new URL(url), false)
+
+        test(`parent of ${url} --> ${exp_parent}`, () =>
+            expect(parent ? parent.href : parent).toEqual(exp_parent))
+    }
+}
+
+
 function test_download_filename() {
     let cases = [
         // simple domain only
@@ -321,6 +361,7 @@ function test_url_query_interpolation() {
 test_increment()
 test_root()
 test_parent()
+test_parent_with_slash_strip()
 test_download_filename()
 test_query_delete()
 test_query_replace()

--- a/src/lib/url_util.ts
+++ b/src/lib/url_util.ts
@@ -57,31 +57,37 @@ export function getUrlRoot(url) {
  * * Remove one level from the path if there is one, or
  * * Remove one subdomain from the front if there is one
  *
- * @param url   the URL to get the parent of
- * @return      the parent of the URL, or null if there is no parent
- * @count       how many "generations" you wish to go back (1 = parent, 2 = grandparent, etc.)
+ * @param url               the URL to get the parent of
+ * @param trailingSlash     whether the returned URL has a trailing slash
+ * @param count             how many "generations" you wish to go back (1 = parent, 2 = grandparent, etc.)
+ * @return                  the parent of the URL, or null if there is no parent
  */
-export function getUrlParent(url, count = 1) {
+export function getUrlParent(url, trailingSlash, count = 1) {
     // Helper function.
-    function gup(parent, count) {
+    function gup(parent, trailingSlash, count) {
         if (count < 1) {
+            // remove trailing slash(s) if desired
+            if (!trailingSlash) {
+                // remove 1 or more trailing slashes
+                parent.pathname = parent.pathname.replace(/\/+$/, "")
+            }
             return parent
         }
         // strip, in turn, hash/fragment and query/search
         if (parent.hash) {
             parent.hash = ""
-            return gup(parent, count - 1)
+            return gup(parent, trailingSlash, count - 1)
         }
         if (parent.search) {
             parent.search = ""
-            return gup(parent, count - 1)
+            return gup(parent, trailingSlash, count - 1)
         }
 
         // empty path is '/'
         if (parent.pathname !== "/") {
             // Remove trailing slashes and everything to the next slash:
             parent.pathname = parent.pathname.replace(/\/[^\/]*?\/*$/, "/")
-            return gup(parent, count - 1)
+            return gup(parent, trailingSlash, count - 1)
         }
 
         // strip off the first subdomain if there is one
@@ -92,7 +98,7 @@ export function getUrlParent(url, count = 1) {
             if (domains.length > 2) {
                 // domains.pop()
                 parent.host = domains.slice(1).join(".")
-                return gup(parent, count - 1)
+                return gup(parent, trailingSlash, count - 1)
             }
         }
 
@@ -106,7 +112,7 @@ export function getUrlParent(url, count = 1) {
     }
 
     const parent = new URL(url)
-    return gup(parent, count)
+    return gup(parent, trailingSlash, count)
 }
 
 /** Very incomplete lookup of extension for common mime types that might be


### PR DESCRIPTION
Adds a new option called `urlparenttrailingslash` that corresponds to whether a trailing slash should be present at the end of URLs returned by getUrlParent.

Only thing I was unsure about was the doc syntax for optional arguments. In src/lib/url_utils.ts someone had used a different syntax for the optional argument `@count...`. It seemed incorrect but on review I thought that maybe that was the standard for optional arguments.