### PR TITLE
perf.ts: remove illegal string

### DIFF
--- a/src/perf.ts
+++ b/src/perf.ts
@@ -164,7 +164,7 @@ export function listenForCounters(
     }
 
     const perfObserver = new PerformanceObserver(callback)
-    perfObserver.observe({ entryTypes: ["mark", "measure"], buffered: true })
+    perfObserver.observe({ entryTypes: ["mark", "measure"] })
     return perfObserver
 }
 


### PR DESCRIPTION
According to
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver/observe
a PerformanceObserverInit object does not have a "buffered" attribute.
This made firefox throw errors in both the command line and the content
script. This might fix
https://github.com/tridactyl/tridactyl/issues/1670.