### PR TITLE
Add shortcut for ignore mode

### DIFF
--- a/src/static/clippy/1-tutor.md
+++ b/src/static/clippy/1-tutor.md
@@ -26,7 +26,7 @@ The idea behind Tridactyl is to allow you to navigate the web more efficiently w
     -   You can enter this mode with `:` and exit it with `Escape` or `Enter`.
 -   Ignore mode
     -   This mode passes all keypresses through to the web page. It is useful for websites that have their own keybinds, such as games and Gmail.
-    -   You can toggle the mode with `Shift-Insert` or `Ctrl-Alt-Backtick`.
+    -   You can toggle the mode with `Shift-Insert`, `Ctrl-Alt-Backtick`, or `Shift-Esc`.
 
 Almost all of the modes are controlled by series of keypresses. In this tutorial, a sequence of keys such as `zz` should be entered by pressing the key `z`, letting go, and then pressing the key `z`. There is no need to hold both keys at once, if that were even possible. (`zz` resets the zoom level to the default, so it probably didn't seem to do anything). Sometimes `help` refers to a command that must be entered in command mode; it should hopefully always be clear from context which we mean.
 


### PR DESCRIPTION
When I started using tridactyl, I didn't find any shortcut to the ignore mode that was viable for laptop keyboards (at least on mine, since I haven't got backticks and `Ins` must be activated with `Fn`). `Shift-Esc` is relatively harmless and pretty easy to remember, so I think it may be a good one for beginners.