### PR TITLE
:source race conditions

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1595,7 +1595,8 @@ browser.storage.onChanged.addListener((changes, areaname) => {
             )
 
             // TODO: this should be a deep comparison but this is better than nothing
-            changedKeys.concat(unsetKeys).forEach(key => USERCONFIG[key] = newValue[key])
+            changedKeys.forEach(key => USERCONFIG[key] = newValue[key])
+            unsetKeys.forEach(key => delete USERCONFIG[key])
 
             // Trigger listeners
             unsetKeys.forEach(key => triggerChangeListeners(key, DEFAULTS[key]))

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1541,10 +1541,10 @@ const parseConfigHelper = (pconf, parseobj) => {
 // TODO: BUG! Sync and local storage are merged at startup, but not by this thing.
 browser.storage.onChanged.addListener((changes, areaname) => {
     if (CONFIGNAME in changes) {
-        const { newValue } = changes[CONFIGNAME]
-        const old = USERCONFIG
+        const { newValue, oldValue } = changes[CONFIGNAME]
+        const old = oldValue || {}
 
-        function triggerChangeListeners(key, value = USERCONFIG[key]) {
+        function triggerChangeListeners(key, value = newValue[key]) {
             const arr = changeListeners.get(key)
             if (arr) {
                 const v = old[key] === undefined ? DEFAULTS[key] : old[key]
@@ -1554,10 +1554,10 @@ browser.storage.onChanged.addListener((changes, areaname) => {
 
         if (newValue !== undefined) {
             // A key has been :unset if it exists in USERCONFIG and doesn't in changes and if its value in USERCONFIG is different from the one it has in default_config
-            const unsetKeys = Object.keys(USERCONFIG).filter(
+            const unsetKeys = Object.keys(old).filter(
                 k =>
                     newValue[k] === undefined &&
-                    JSON.stringify(USERCONFIG[k]) !==
+                    JSON.stringify(old[k]) !==
                         JSON.stringify(DEFAULTS[k]),
             )
 
@@ -1567,8 +1567,8 @@ browser.storage.onChanged.addListener((changes, areaname) => {
             ).filter(
                 k =>
                     JSON.stringify(
-                        USERCONFIG[k] !== undefined
-                            ? USERCONFIG[k]
+                        old[k] !== undefined
+                            ? old[k]
                             : DEFAULTS[k],
                     ) !== JSON.stringify(newValue[k]),
             )

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1539,7 +1539,7 @@ const parseConfigHelper = (pconf, parseobj) => {
 
 // Listen for changes to the storage and update the USERCONFIG if appropriate.
 // TODO: BUG! Sync and local storage are merged at startup, but not by this thing.
-browser.storage.onChanged.addListener(async (changes, areaname) => {
+browser.storage.onChanged.addListener((changes, areaname) => {
     if (CONFIGNAME in changes) {
         const { newValue } = changes[CONFIGNAME]
         const old = USERCONFIG
@@ -1573,13 +1573,14 @@ browser.storage.onChanged.addListener(async (changes, areaname) => {
                     ) !== JSON.stringify(newValue[k]),
             )
 
-            USERCONFIG = newValue
+            // TODO: this should be a deep comparison but this is better than nothing
+            changedKeys.concat(unsetKeys).forEach(key => USERCONFIG[key] = newValue[key])
 
             // Trigger listeners
             unsetKeys.forEach(key => triggerChangeListeners(key, DEFAULTS[key]))
 
             changedKeys.forEach(key => triggerChangeListeners(key))
-        } else if (areaname === (await get("storageloc"))) {
+        } else if (areaname === get("storageloc")) {
             // If newValue is undefined and AREANAME is the same value as STORAGELOC, the user wants to clean their config
             USERCONFIG = o({})
 


### PR DESCRIPTION
There have been [a](https://github.com/tridactyl/tridactyl/pull/724) [number](https://github.com/tridactyl/tridactyl/pull/686) [of](https://github.com/tridactyl/tridactyl/pull/1197) [issues](https://github.com/tridactyl/tridactyl/pull/1409) [related](https://github.com/tridactyl/tridactyl/pull/1633) to racy configuration settings and `:source`, `tridactylrc`, etc. This is an attempt to address them. Note this isn't related to the `storageloc` setting though I imagine the `sync` and `local` storage backends may differ in how they're affected due to when and how they call `onChanged`.

First, a description of the problem by outlining the steps which occur when running `:set` multiple times:

1. `config.set("key", value)` updates values in a global `USERCONFIG` object
2. `config.save()` implicitly gets called to save this object into browser storage (local or sync depending on what `storageloc` is set to)
3. The promise returned by save/set resolves with the call to `storage.sync.set()`, and after an await tridactyl continues on to your next command
4. `config.set("anotherkey", value)` repeats the above 3 steps to update `USERCONFIG` and browser storage. The promise resolves again, no problems so far?
5. The browser storage uses the `onChanged` callback to indicate that "key" has been updated, and then this callback incorrectly assigns the `newValue` into the `USERCONFIG` global.
   - At this point, the `anotherkey` setting has been reverted.
6. `config.set("yetanotherkey", value)` repeats the steps again, combining it with your `key` setting, but having lost the `anotherkey` change.
7. Maybe `onChanged` gets called again at this point and brings `anotherkey` back but erases `yetanotherkey` with it, it just all results in an [inconsistent leapfrog](https://github.com/tridactyl/tridactyl/pull/1409) I guess.

This basically boils down to:
- #1290 mitigated this using promises but that doesn't really fix the problem because `onChanged` is [not guaranteed to be run before the `set` promise completes](https://bugzilla.mozilla.org/show_bug.cgi?id=1554088). The current implementation makes incorrect assumptions, but it certainly was a lot worse before when everything got set at once though!
- Trying to maintain global state/cache that matches async storage is messy and inherently racy.
   - Since set() updates the global immediately, a way to tell (and ignore) which `onChanged` are coming from us and which are coming from remote contexts/browsers could help further mitigate the problem, but isn't a full solution.
- onChanged probably should be doing a recursive/deep intersection across the changed settings
- async everywhere on all get/set operations would probably be the full/proper solution in the end, but that's a huge change?

So the commits go into detail on the mitigations I'm adding here, but basically:
- only update settings that have actually changed in `onChanged` (partial fix, not recursive/deep like it ideally should be)
  - this mitigates clobbering when doing multiple sets in a row on distinct settings
  - unfortunately nested objects are still susceptible (like say, any of the `nmap`/etc keybindings)
    - so doesn't fix things `bind`
- check `oldValue` that the browser storage passes to `onChanged` rather than the global `USERCONFIG` state to determine what has changed
  - this enhances the above change to make things less racy
- `get()` the configuration from browser storage before setting any new values
  - this basically adds synchronization between sets to prevent the clobbering race