### PR TITLE
:set storageloc local

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1388,11 +1388,17 @@ export async function update() {
     @hidden
  */
 async function init() {
-    const syncConfig = await browser.storage.sync.get(CONFIGNAME)
-    schlepp(syncConfig[CONFIGNAME])
-    // Local storage overrides sync
     const localConfig = await browser.storage.local.get(CONFIGNAME)
-    schlepp(localConfig[CONFIGNAME])
+
+    if (localConfig === undefined || localConfig.storageloc !== "local") {
+        const syncConfig = await browser.storage.sync.get(CONFIGNAME)
+        if (syncConfig !== undefined) {
+          schlepp(syncConfig[CONFIGNAME])
+        }
+    } else {
+        // These could be merged instead, but the current design does not allow for that
+        schlepp(localConfig[CONFIGNAME])
+    }
 
     await update()
     await save()


### PR DESCRIPTION
This builds on top of #1764 to fix the `storageloc` setting, which has its own set of problems. The overall problem is that the `storageloc` setting itself gets saved to storage, which just results in any sync `onChanged` events from other browsers unsetting `local` and clobbering all of your settings. The opposite problem can also occur, that setting it to `local` results in it being impossible to switch back to `sync` (because on `init()` it will clobber your config all over again). The approach used here is to make sure the setting always / only gets saved to local storage, so that it's consistent and can be toggled at will.

Also, tridactyl saves the entire config in either storage any time `set` is used so although `init` tries to combine the two storages... it's nonsensical since there's no way to control which settings get saved to where. It's also not a deep merge, and local will just ruin your day if you ever want to switch back to sync without doing a sanitise. There are just a lot of problems with it so right now just consider "local" to mean "stop syncing my stuff in both directions". In the future one might imagine a `:set --local` command for managing this more elegantly?