### PR TITLE
Gamepadactyl

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6,6 +6,13 @@ if ((window as any).tridactyl_content_lock !== undefined) {
 }
 (window as any).tridactyl_content_lock = "locked"
 
+import * as gamepads from "@src/lib/gamepad"
+// This needs to be as early as possible, otherwise we won't get the event and
+// will never know about the gamepad
+window.addEventListener("gamepadconnected", (e) => {
+    gamepads.register((e as any).gamepad);
+});
+
 // Be careful: typescript elides imports that appear not to be used if they're
 // assigned to a name.  If you want an import just for its side effects, make
 // sure you import it like this:
@@ -75,6 +82,7 @@ function listen(elem) {
     )
 }
 listen(window)
+gamepads.addButtonListener(guardedAcceptKey)
 document.addEventListener("readystatechange", _ =>
     getAllDocumentFrames().forEach(f => listen(f)),
 )

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -31,6 +31,9 @@ function PrintableKey(k) {
     if (k.shiftKey) {
         result = "S-" + result
     }
+    if (k.gamepad) {
+        result = "G-" + result
+    }
     if (result.length > 1) {
         result = "<" + result + ">"
     }

--- a/src/grammars/bracketexpr.ne
+++ b/src/grammars/bracketexpr.ne
@@ -2,7 +2,7 @@
 
 BracketExpr -> "<" Modifier ModKey ">" {% bexpr=>bexpr.slice(1,-1) %}
              | "<" Key ">" {% bexpr=>[{}].concat(bexpr.slice(1,-1)) %}
-Modifier -> [acmsACMS]:? [acmsACMS]:? [acmsACMS]:? [acmsACMS]:? "-" {%
+Modifier -> [acmsgAMCSG]:? [acmsgAMCSG]:? [acmsgAMCSG]:? [acmsgAMCSG]:? "-" {%
     /** For each modifier present,
         add its long name as an attribute set to true to an object */
     (mods, _, reject) => {
@@ -11,6 +11,7 @@ Modifier -> [acmsACMS]:? [acmsACMS]:? [acmsACMS]:? [acmsACMS]:? "-" {%
             ["C", "ctrlKey"],
             ["M", "metaKey"],
             ["S", "shiftKey"],
+            ["G", "gamepad"],
         ])
 
         let modifiersObj = {}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -294,8 +294,16 @@ export class default_config {
         zI: "zoom 3",
         zO: "zoom 0.3",
         ".": "repeat",
-        "<SA-ArrowUp><SA-ArrowUp><SA-ArrowDown><SA-ArrowDown><SA-ArrowLeft><SA-ArrowRight><SA-ArrowLeft><SA-ArrowRight>ba":
-            "open https://www.youtube.com/watch?v=M3iOROuTuMA",
+        // Mappings for an xbox 360 controller
+        "<G-0>": "fillcmdline", // A button
+        "<G-1>": "back", // B button
+        "<G-2>": "tabclose", // X button
+        "<G-3>": "forward", // Y button
+        "<G-4>": "tabprev", // right button
+        "<G-5>": "tabnext", // left button
+        "<G-6>": "followpage prev", // back button
+        "<G-7>": "followpage next", // start button
+        "<G-9>": "hint", // left-joystick click
     }
 
     hintmaps = {

--- a/src/lib/gamepad.ts
+++ b/src/lib/gamepad.ts
@@ -1,0 +1,53 @@
+
+export class GamepadEvent {
+    public altKey = false
+    public ctrlKey = false
+    public isTrusted = true
+    public metaKey = false
+    public shiftKey = false
+    public gamepad = true
+
+    constructor(public key) {}
+}
+
+const listeners = new Map([["button", []]]);
+export function addButtonListener(listener) {
+    const buttonListeners = listeners.get("button");
+    buttonListeners.push(listener);
+};
+
+const debouncingMs = 100;
+const lastPressed = new Map();
+export function pollGamepads() {
+    const buttonListeners = listeners.get("button");
+    for (const gamepad of gamepads) {
+        if (!gamepad.connected) {
+            continue;
+        }
+
+        let pressedButtons = lastPressed.get(gamepad);
+        if (pressedButtons === undefined) {
+            pressedButtons = [];
+            lastPressed.set(gamepad, pressedButtons);
+        }
+
+        for (let i = 0; i < gamepad.buttons.length; ++i) {
+            const button = gamepad.buttons[i];
+            const last = pressedButtons[i] || 0;
+            const now = performance.now()
+            if (button.pressed && ((now - last) > debouncingMs)) {
+                pressedButtons[i] = now;
+                buttonListeners.forEach(listener => listener(new GamepadEvent(`${i}`)));
+            }
+        }
+    }
+    if (gamepads.some(pad => pad.connected)) {
+        window.requestAnimationFrame(pollGamepads);
+    }
+};
+
+const gamepads = []
+export function register(gamepad) {
+    gamepads.push(gamepad);
+    pollGamepads();
+}


### PR DESCRIPTION
As [bovine3dom said on matrix](https://matrix.to/#/!xmubtggllUtLrQiGyn:matrix.org/$1566330020150744QfSIq:matrix.org?via=matrix.org&via=arcn.mx&via=yuri.im),
Tridactyl needs gamepad support in order to expand and be able to reach
new users. This is the first step on the road to Tridactyl becoming the
true google-stadia enabled, gamer-oriented, billion-dollars making
service as a software it can be.

Note that I wouldn't actually recommend merging this for the following reasons:

- You have to use `requestAnimationFrame()` in the content script every time a gamepad is detected, even if it isn't actually used by the user (this is rather inefficient).

- It doesn't actually work 100% of the time. Sometimes we don't get the gamepadconnected event and users have to disconnect/reconnect their gamepad in order for tridactyl to detect the gamepad again.

- Because we do our processing in the content script, pressing any button that changes the current tab also triggers the command in the new tab (because Tridactyl detects that the button is pressed in the new tab before the user has any chance to release it).

- Not every gamepad button is supported by the gamepad API. For example, there isn't any way to check for the state of an xbox 360 controller's dirrectional pad.

- I didn't implement joystick support. This could probably be done by using angles for bindings but I couldn't be bothered.

- For some reason, bindings do not work for the command line. The normal-mode ones are used instead. I didn't check what happened for other modes.

There probably are other reasons not to merge this but these are the ones I can think of right now.