### PR TITLE
Add recontain excmd

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2567,6 +2567,38 @@ export async function viewcontainers() {
             .replace(/ /g, "%20")
 }
 
+/** Opens the current tab in another container.
+
+    This is probably not a good idea if you care about tracking protection!
+    Transfering URLs from one container to another allows websites to track
+    you across those containers.
+
+    Read more here:
+    https://github.com/mozilla/multi-account-containers/wiki/Moving-between-containers
+
+    @param containerName The container name, fuzzy matched like `-c` on [[tabopen]]. Leave empty to uncontain.
+ */
+//#background
+export async function recontain(containerName = "") {
+    const thisTab = await activeTab()
+
+    let container
+    await Container.fuzzyMatch(containerName[0])
+        .then(match => {
+            container = match
+        })
+        .catch(() => {
+            container = Container.DefaultContainer.cookieStoreId
+        })
+
+    await openInNewTab(thisTab.url, {
+        active: true,
+        related: true,
+        cookieStoreId: container,
+    })
+    return browser.tabs.remove(thisTab.id)
+}
+
 // }}}
 //
 // {{{ MISC

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -31,7 +31,7 @@ const ContainerIcon = [
     "chill",
 ]
 
-const DefaultContainer = Object.freeze(
+export const DefaultContainer = Object.freeze(
     fromString("default", "invisible", "noicond", "firefox-default"),
 )
 


### PR DESCRIPTION
Allows putting the current tab into (or out of) a container.

This has been one of the last things I always need to reach to the mouse for... 

The other being [simple tab groups](https://github.com/Drive4ik/simple-tab-groups) which I would give a shot at integrating whenever #377 makes it in (tridactyl is already whitelisted to use it's api: https://github.com/Drive4ik/simple-tab-groups/issues/406)