### PR TITLE
Lowercase tsconfig values

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "moduleResolution": "Node",
+    "moduleResolution": "node",
     "noImplicitAny": false,
     "noEmitOnError": true,
     "outDir": "build/tsc-out",
     "sourceMap": true,
-    "target": "ES2017",
-    "lib": ["ES2017","dom", "dom.iterable"],
+    "target": "es2017",
+    "lib": ["es2017","dom", "dom.iterable"],
     "typeRoots": ["node_modules/@types", "node_modules/web-ext-types/"],
     "experimentalDecorators": true,
     "alwaysStrict": true,


### PR DESCRIPTION
While `tsc` apparently *accepts* values of mixed-case, it seems to *prefer* lowercase ones. This clears up this warning from `tsc` v3.6.3:

> Value is not accepted. Valid values: "es5", "es6", "es2015", "es7", "es2016", "es2017", "es2018", "es2019", "es2020", "esnext", "dom", "dom.iterable", "webworker", "webworker.importscripts", "scripthost", "es2015.core", "es2015.collection", "es2015.generator", "es2015.iterable", "es2015.promise", "es2015.proxy", "es2015.reflect", "es2015.symbol", "es2015.symbol.wellknown", "es2016.array.include", "es2017.object", "es2017.intl", "es2017.sharedmemory", "es2017.string", "es2017.typedarrays", "es2018.asynciterable", "es2018.intl", "es2018.promise", "es2018.regexp", "es2019.array", "es2019.object", "es2019.string", "es2019.symbol", "es2020.string", "es2020.symbol.wellknown", "esnext.asynciterable", "esnext.array", "esnext.bigint", "esnext.intl", "esnext.symbol".