### PR TITLE
add exmcmds to load RC file from url

### DIFF
--- a/src/background/config_rc.ts
+++ b/src/background/config_rc.ts
@@ -13,6 +13,25 @@ export async function source(filename = "auto") {
     return true
 }
 
+async function fetchConfig(url: string) {
+    const response = await fetch(url)
+    const reader = response.body.getReader()
+    let rctext = ""
+    const decoder = new TextDecoder("utf-8")
+    while (true) {
+        const { value: chunk, done: isDone } = await reader.read()
+        if (isDone) return rctext
+        rctext += decoder.decode(chunk)
+    }
+}
+
+export async function sourceFromUrl(url: string) {
+    const rctext = await fetchConfig(url)
+    if (!rctext) return false
+    await runRc(rctext)
+    return true
+}
+
 export async function writeRc(conf: string, force = false, filename = "auto") {
     let path: string
     if (filename === "auto") {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -726,7 +726,9 @@ export async function mktridactylrc(...args: string[]) {
  *
  * If no argument given, it will try to open ~/.tridactylrc, ~/.config/tridactyl/tridactylrc or $XDG_CONFIG_HOME/tridactyl/tridactylrc in reverse order. You may use a `_` in place of a leading `.` if you wish, e.g, if you use Windows.
  *
- * If no url is specified with the `--url` flag, the current page's URL is used to locate the RC file.
+ * If no url is specified with the `--url` flag, the current page's URL is used to locate the RC file. Ensure the URL you pass (or page you are on) is a "raw" RC file, e.g. https://raw.githubusercontent.com/tridactyl/tridactyl/master/.tridactylrc and not https://github.com/tridactyl/tridactyl/blob/master/.tridactylrc.
+ *
+ * Tridactyl won't run on many raw pages due to a Firefox bug with Content Security Policy, so you may need to use the `source --url [URL]` form.
  *
  * On Windows, the `~` expands to `%USERPROFILE%`.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -751,6 +751,26 @@ export async function source_quiet(...fileArr: string[]) {
     }
 }
 
+/** Use tridactylrc located at the given url
+ * @param url the url where the raw version of tridactylrc can be found
+ */
+//#background
+export async function source_from_url(url: string) {
+    if (!url) return
+    await rc.sourceFromUrl(url)
+}
+
+/**
+ * Same as [[source_from_url]] but suppresses all errors
+ */
+//#background
+export async function source_from_url_quiet(url: string) {
+    if (!url) return
+    try {
+        await rc.sourceFromUrl(url)
+    } catch (e) {}
+}
+
 /**
  * Updates the native messenger if it is installed, using our GitHub repo. This is run every time Tridactyl is updated.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -726,6 +726,8 @@ export async function mktridactylrc(...args: string[]) {
  *
  * If no argument given, it will try to open ~/.tridactylrc, ~/.config/tridactyl/tridactylrc or $XDG_CONFIG_HOME/tridactyl/tridactylrc in reverse order. You may use a `_` in place of a leading `.` if you wish, e.g, if you use Windows.
  *
+ * If no url is specified with the `--url` flag, the current page's URL is used to locate the RC file.
+ *
  * On Windows, the `~` expands to `%USERPROFILE%`.
  *
  * The RC file is just a bunch of Tridactyl excmds (i.e, the stuff on this help page). Settings persist in local storage; add `sanitise tridactyllocal tridactylsync` to make it more Vim like. There's an [example file](https://raw.githubusercontent.com/cmcaine/tridactyl/master/.tridactylrc) if you want it.
@@ -736,7 +738,7 @@ export async function mktridactylrc(...args: string[]) {
 export async function source(...args: string[]) {
     if (args[0] === "--url") {
         let url = args[1]
-        if (!url) return
+        if (!url || url === "%") url = window.location.href
         if (!(url.startsWith("http://") || url.startsWith("https://"))) url = "http://" + url
         await rc.sourceFromUrl(url)
     } else {
@@ -755,7 +757,7 @@ export async function source_quiet(...args: string[]) {
     try {
         if (args[0] === "--url") {
             let url = args[1]
-            if (!url) return
+            if (!url || url === "%") url = window.location.href
             if (!(url.startsWith("http://") || url.startsWith("https://"))) url = "http://" + url
             await rc.sourceFromUrl(url)
         } else {


### PR DESCRIPTION
From #1818, adds two excmds: source_from_url and source_from_url_quiet to load RC file from a url. The provided url must point to a file.
Example: like this:- 

https://gist.githubusercontent.com/rektrex/97fc44e0ea440238b6d60fae9fe4b562/raw/b6d9a81193d8fa4c6cfd99135e2cb454e411cb73/tridactylrc

and not this:-

https://gist.github.com/rektrex/97fc44e0ea440238b6d60fae9fe4b562