### PR TITLE
Remove `set csp clobber`

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -107,7 +107,6 @@ command fixamo js tri.excmds.setpref("privacy.resistFingerprinting.block_mozAddo
 
 " Make Tridactyl work on more sites at the expense of some security. For
 " details, read the comment at the top of this file.
-set csp clobber
 fixamo_quiet
 
 " Make quickmarks for the sane Tridactyl issue view

--- a/contributing.md
+++ b/contributing.md
@@ -87,7 +87,7 @@ Here's an example: you're writing the [`native()`](https://github.com/tridactyl/
 -   math.ts: Math stuff.
 -   messaging.ts: Implementation of Tridactyl's messaging functions (attributeCaller, message, messageTab, messageOwnTab...).
 -   native.ts: Wrappers around Firefox's native messaging API. Also has "higher-level" functions that interact with the native messenger (finding the user's favorite editor, reading/setting preferences...).
--   requests.ts: CSP-clobbering code.
+-   requests.ts: CSP-clobbering code. Not used anymore.
 -   text_to_speech.ts: Various wrappers around Firefox's TTS APIs.
 -   url_util.ts: Url incrementation, query-extraction, interpolation.
 -   webext.ts: Wrappers around Firefox's APIs (activeTab(), ownTab()...).
@@ -95,7 +95,7 @@ Here's an example: you're writing the [`native()`](https://github.com/tridactyl/
 
 ### src/
 
--   background.ts: Entry point of Tridactyl's background script. Deals with various things that didn't deserve their own file when they were implemented: autocommands, autocontainers, CSP hijacking...
+-   background.ts: Entry point of Tridactyl's background script. Deals with various things that didn't deserve their own file when they were implemented: autocommands, autocontainers...
 -   commandline_frame.ts: Entry point of the command line. Sets up various event listeners and updates completions when needed.
 -   completions/\*.ts: All completion sources available to Tridactyl. Imported by commandline_frame.ts
 -   completions.ts: Scaffolding used by completion sources in the "completions" folder.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -5,7 +5,6 @@ If changing one of these settings fixes your bug, please visit the corresponding
 -   `:seturl $URL_OF_THE_WEBSITE noiframe true` and then reload the page. This disables the Tridactyl commandline on a specific url. [#639](https://github.com/tridactyl/tridactyl/issues/639)
 -   `:set allowautofocus true` and then reload the page. This allows website to use the javascript `focus()` function. [#550](https://github.com/tridactyl/tridactyl/issues/550)
 -   `:set modeindicator false` and then reload the page. This disables the mode indicator. [#821](https://github.com/tridactyl/tridactyl/issues/821)
--   `:get csp`. If the value returned is "untouched", try `:set csp clobber`. If the value is "clobber", try `:set csp untouched`. In both cases, please reload the page. This disables (or prevents disabling) some security settings of the page. [#109](https://github.com/tridactyl/tridactyl/issues/109)
 
 # Native Editor/Messenger issues
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -77,33 +77,6 @@ browser.tabs.onActivated.addListener(ev => {
     })
 })
 
-// {{{ Clobber CSP
-
-// This should be removed once https://bugzilla.mozilla.org/show_bug.cgi?id=1267027 is fixed
-function addCSPListener() {
-    browser.webRequest.onHeadersReceived.addListener(
-        request.clobberCSP,
-        { urls: ["<all_urls>"], types: ["main_frame"] },
-        ["blocking", "responseHeaders"],
-    )
-}
-
-function removeCSPListener() {
-    browser.webRequest.onHeadersReceived.removeListener(request.clobberCSP)
-}
-
-config.getAsync("csp").then(csp => csp === "clobber" && addCSPListener())
-
-config.addChangeListener("csp", (old, cur) => {
-    if (cur === "clobber") {
-        addCSPListener()
-    } else {
-        removeCSPListener()
-    }
-})
-
-// }}}
-
 // Prevent Tridactyl from being updated while it is running in the hope of fixing #290
 browser.runtime.onUpdateAvailable.addListener(_ => undefined)
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3280,6 +3280,12 @@ export function set(key: string, ...values: string[]) {
         throw "Warning: `noiframeon $url1 $url2` has been deprecated in favor of `:seturl $url1 noiframe true`. The right seturl calls have been made for you but from now on please use `:seturl`."
     }
 
+    if (key === "csp" && values[0] === "clobber") {
+        const msg = "#Error: Mozilla asked us to remove our csp-clobbering code. See https://github.com/tridactyl/tridactyl/issues/1800"
+        fillcmdline_tmp(3000, msg)
+        throw msg
+    }
+
     return config.set(...validateSetArgs(key, values))
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -900,6 +900,7 @@ export class default_config {
     minincsearchlen = 3
 
     /**
+     * Deprecated.
      * Change this to "clobber" to ruin the "Content Security Policy" of all sites a bit and make Tridactyl run a bit better on some of them, e.g. raw.github*
      */
     csp: "untouched" | "clobber" = "untouched"


### PR DESCRIPTION
This just removes the background.ts code that detects whether the user
wants to clobber their csp and adds an error message if the user tries
to `set csp clobber`.
The `csp` setting is marked as deprecated but left untouched in case we
find a way to edit CSP in a way that complies with Mozilla's policies.
The csp-editing code in `requests.ts` is left untouched for the same
reason.