### PR TITLE
Hide hoverlink on command line open

### DIFF
--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -58,6 +58,18 @@ init().catch(e => {
 export function show() {
     try {
         cmdline_iframe.classList.remove("hidden")
+        /* Hide "hoverlink" pop-up which obscures command line
+         *
+         * Inspired by VVimpulation: https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5
+         *
+         * Known issue: currently scrolls the page to the bottom.
+         */
+        const a = window.document.createElement("A")
+        ; (a as any).href = "#"
+        document.body.appendChild(a)
+        a.focus()
+        document.body.removeChild(a)
+
         const height =
             cmdline_iframe.contentWindow.document.body.offsetHeight + "px"
         cmdline_iframe.setAttribute("style", `height: ${height} !important;`)


### PR DESCRIPTION
Inspired by VVimpulation - https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5

Currently scrolls page to the bottom; should fix that before merging.