### PR TITLE
treat autocontain settings as url patterns

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3316,25 +3316,41 @@ export function autocmd(event: string, url: string, ...excmd: string[]) {
     config.set("autocmds", event, url, excmd.join(" "))
 }
 
-/** Automatically open matching URLs in a specified container.
+/** Automatically open a domain and all its subdomains in a specified container.
+ *
+ *  This function accepts a `-u` flag to treat the pattern as a URL rather than a domain.
+ *  For example: `autocontain -u ^https?://[^/]*youtube\.com/ google` is equivalent to `autocontain youtube\.com google`
  *
  *  For declaring containers that do not yet exist, consider using `auconscreatecontainer true` in your tridactylrc.
  *  This allows tridactyl to automatically create containers from your autocontain directives. Note that they will be random icons and colors.
  *
  * ** NB: This is an experimental feature, if you encounter issues please create an issue on github. **
  *
- *  The domain pattern is passed through as a regular expression so there are a few gotchas to be aware of:
+ *  The domain is passed through as a regular expression so there are a few gotchas to be aware of:
  *  * Unescaped periods will match *anything*. `autocontain google.co.uk work` will match `google!co$uk`. Escape your periods or accept that you might get some false positives.
- *  * To match a domain you can use regex in your pattern. `autocontain ^https?://[^/]*google\.(co\.uk|com) work` will match either `google.co.uk` or `google.com`.
+ *  * You can use regex in your pattern. `autocontain google\.(co\.uk|com) work` will match either `google.co.uk` or `google.com`.
  *
  * This *should* now peacefully coexist with the Temporary Containers and Multi-Account Containers addons. Do not trust this claim. If a fight starts the participants will try to open infinite tabs. It is *strongly* recommended that you use a tridactylrc so that you can abort a sorceror's-apprentice scenario by killing firefox, commenting out all of autocontainer directives in your rc file, and restarting firefox to clean up the mess. There are a number of strange behaviors resulting from limited coordination between extensions. Redirects can be particularly surprising; for example, with `:autocontain will-redirect.example.org example` set and `will-redirect.example.org` redirecting to `redirected.example.org`, navigating to `will-redirect.example.org` will result in the new tab being in the `example` container under some conditions and in the `firefox-default` container under others.
  *
- *  @param pattern a regex to match URLs which should be opened in the specified container
- *  @param container The container to open the url in.
+ *  @param args a regex pattern to match URLs followed by the container to open the URL in.
  */
 //#background
-export function autocontain(domain: string, container: string) {
-    config.set("autocontain", domain, container)
+export function autocontain(...args: string[]) {
+    if (args.length === 0) throw new Error("Invalid autocontain arguments.")
+
+    const urlMode = args[0] === "-u"
+    if (urlMode) {
+        args.splice(0, 1)
+    }
+    if (args.length !== 2) throw new Error("syntax: autocontain [-u] pattern container")
+
+    let [pattern, container] = args
+
+    if (!urlMode) {
+        pattern = `^https?://[^/]*${pattern}/`
+    }
+
+    config.set("autocontain", pattern, container)
 }
 
 /** Remove autocmds

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3316,20 +3316,20 @@ export function autocmd(event: string, url: string, ...excmd: string[]) {
     config.set("autocmds", event, url, excmd.join(" "))
 }
 
-/** Automatically open a domain and all its subdomains in a specified container.
+/** Automatically open matching URLs in a specified container.
  *
  *  For declaring containers that do not yet exist, consider using `auconscreatecontainer true` in your tridactylrc.
  *  This allows tridactyl to automatically create containers from your autocontain directives. Note that they will be random icons and colors.
  *
  * ** NB: This is an experimental feature, if you encounter issues please create an issue on github. **
  *
- *  The domain is passed through as a regular expression so there are a few gotchas to be aware of:
+ *  The domain pattern is passed through as a regular expression so there are a few gotchas to be aware of:
  *  * Unescaped periods will match *anything*. `autocontain google.co.uk work` will match `google!co$uk`. Escape your periods or accept that you might get some false positives.
- *  * You can use regex in your domain pattern. `autocontain google\,(co\.uk|com) work` will match either `google.co.uk` or `google.com`.
+ *  * To match a domain you can use regex in your pattern. `autocontain ^https?://[^/]*google\.(co\.uk|com) work` will match either `google.co.uk` or `google.com`.
  *
  * This *should* now peacefully coexist with the Temporary Containers and Multi-Account Containers addons. Do not trust this claim. If a fight starts the participants will try to open infinite tabs. It is *strongly* recommended that you use a tridactylrc so that you can abort a sorceror's-apprentice scenario by killing firefox, commenting out all of autocontainer directives in your rc file, and restarting firefox to clean up the mess. There are a number of strange behaviors resulting from limited coordination between extensions. Redirects can be particularly surprising; for example, with `:autocontain will-redirect.example.org example` set and `will-redirect.example.org` redirecting to `redirected.example.org`, navigating to `will-redirect.example.org` will result in the new tab being in the `example` container under some conditions and in the `firefox-default` container under others.
  *
- *  @param domain The domain which will trigger the autoContain directive. Includes all subdomains.
+ *  @param pattern a regex to match URLs which should be opened in the specified container
  *  @param container The container to open the url in.
  */
 //#background

--- a/src/lib/autocontainers.ts
+++ b/src/lib/autocontainers.ts
@@ -281,7 +281,7 @@ export class AutoContain implements IAutoContain {
         const aucons = Config.get("autocontain")
         const ausites = Object.keys(aucons)
         const aukeyarr = ausites.filter(
-            e => url.search("^https?://[^/]*" + e + "/") >= 0,
+            e => url.search(e) >= 0,
         )
         if (aukeyarr.length > 1) {
             logger.error(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1331,6 +1331,16 @@ export async function update() {
             )
             set("configversion", "1.7")
         },
+        "1.7": () => {
+            const autocontain = getDeepProperty(USERCONFIG, ["autocontain"])
+            unset("autocontain")
+            if (autocontain !== undefined) {
+              Object.entries(autocontain).forEach(([domain, container]) => {
+                set("autocontain", `^https?://[^/]*${domain}/`, container)
+              })
+            }
+            set("configversion", "1.8")
+        },
     }
     if (!get("configversion")) set("configversion", "0.0")
     const updatetest = v => {


### PR DESCRIPTION
This aims to be more consistent and in line with the `seturl` family of settings.

I imagine this change will be inconvenient considering most users probably only care to specify an anchored domain pattern, but I take issue with it being inflexible. I think this change can be justified given that it's consistent with seturl/bindurl/etc, but an alternate approach may be to instead change `autocontain` excmd to include the `https?://etc` pattern, and still allow some other way (flag? `js tri.config.set`?) to set a full pattern when desired instead of hard-coding the pattern in `lib/autocontainers`.

EDIT: not sure what's with the test failure? as far as I can tell autocontain isn't used in any existing tests.