### PR TITLE
autocontainmode: "strict" | "relaxed"

### DIFF
--- a/src/lib/autocontainers.ts
+++ b/src/lib/autocontainers.ts
@@ -77,6 +77,9 @@ export class AutoContain implements IAutoContain {
     ): Promise<browser.webRequest.BlockingResponse> => {
         if (!this.autocontainConfigured()) return { cancel: false }
 
+        // Only handle in strict mode.
+        if (Config.get("autocontainmode") === "relaxed") return { cancel: false }
+
         // Only handle http requests.
         if (details.url.search("^https?://") < 0) return { cancel: false }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -440,6 +440,13 @@ export class default_config {
     })
 
     /**
+     * Strict mode will always ensure a domain is open in the correct container, replacing the current tab if necessary.
+     *
+     * Relaxed mode is less aggressive and instead treats container domains as a default when opening a new tab.
+     */
+    autocontainmode: "strict" | "relaxed" = "strict"
+
+    /**
      * Aliases for the commandline.
      *
      * You can make a new one with `command alias ex-command`.


### PR DESCRIPTION
The current (and still default) autocontain behaviour is to intercept all page loads that match an aucon pattern, and may even replace a tab to do so. "relaxed" mode is introduced here as a way to only apply the rules when opening a new tab, and makes containers more sticky. Alternative mode names to consider could be `"always" | "newtab"`?