### PR TITLE
Treat missing config as an empty object

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1123,7 +1123,7 @@ export async function getAsync(
                 browserconfig = await browser.storage.sync.get(CONFIGNAME)
                 break
         }
-        USERCONFIG = browserconfig[CONFIGNAME]
+        USERCONFIG = browserconfig[CONFIGNAME] || o({})
 
         return get(target_typed, ...target)
     } else {


### PR DESCRIPTION
4428bf957e451b0a2c6d18de7e70e99f8325f476 was incomplete because it did not consider that `storage.get()` can return undefined if there is nothing in storage, which can occur from use of the `sanitise` command.

Fixes #1918