### PR TITLE
Add strong typing to background messages

### DIFF
--- a/scripts/excmds_macros.py
+++ b/scripts/excmds_macros.py
@@ -68,7 +68,7 @@ def get_block(lines):
     """next(lines) contains an open brace: return all the lines up to close brace.
 
     Moves the lines iterator, so useful for consuming a block.
-    
+
     """
     brace_balance = 0
     block = ""
@@ -139,7 +139,7 @@ def background(lines, context):
                    return Messaging.message(
                        "excmd_background",
                        "{sig.name}",
-                       [{message_params}],
+                       {message_params}
                    )
                }}\n""".format(**locals()))
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -163,7 +163,7 @@ browser.tabs.onCreated.addListener(
 
 // An object to collect all of our statistics in one place.
 const statsLogger: perf.StatsLogger = new perf.StatsLogger()
-export const messages = {
+const messages = {
     excmd_background: excmds_background,
     controller_background: controller,
     performance_background: statsLogger,

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,7 +2,7 @@
 
 /* tslint:disable:import-spacing */
 
-import "@src/lib/browser_proxy_background"
+import * as proxy_background from "@src/lib/browser_proxy_background"
 
 import * as controller from "@src/lib/controller"
 import * as perf from "@src/perf"
@@ -55,8 +55,6 @@ controller.setExCmds({
     "text": EditorCmds,
     "hint": HintingCmds
 })
-messaging.addListener("excmd_background", messaging.attributeCaller(excmds_background))
-messaging.addListener("controller_background", messaging.attributeCaller(controller))
 
 // {{{ tri.contentLocation
 // When loading the background, use the active tab to know what the current content url is
@@ -165,10 +163,19 @@ browser.tabs.onCreated.addListener(
 
 // An object to collect all of our statistics in one place.
 const statsLogger: perf.StatsLogger = new perf.StatsLogger()
-messaging.addListener(
-    "performance_background",
-    messaging.attributeCaller(statsLogger),
-)
+export const messages = {
+    excmd_background: excmds_background,
+    controller_background: controller,
+    performance_background: statsLogger,
+    download_background: {
+        downloadUrl: download_background.downloadUrl,
+        downloadUrlAs: download_background.downloadUrlAs,
+    },
+    browser_proxy_background: {shim: proxy_background.shim}
+}
+export type Messages = typeof messages
+
+messaging.setupListener(messages)
 // Listen for statistics from the background script and store
 // them. Set this one up to log directly to the statsLogger instead of
 // going through messaging.

--- a/src/background/download_background.ts
+++ b/src/background/download_background.ts
@@ -146,14 +146,3 @@ export async function downloadUrlAs(url: string, saveAs: string) {
         browser.downloads.onChanged.addListener(onDownloadComplete)
     })
 }
-
-import * as Messaging from "@src/lib/messaging"
-
-// Get messages from content
-Messaging.addListener(
-    "download_background",
-    Messaging.attributeCaller({
-        downloadUrl,
-        downloadUrlAs,
-    }),
-)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -839,9 +839,9 @@ export async function restart() {
 //#content
 export async function saveas(...filename: string[]) {
     if (filename.length > 0) {
-        return Messaging.message("download_background", "downloadUrlAs", [window.location.href, filename.join(" ")])
+        return Messaging.message("download_background", "downloadUrlAs", window.location.href, filename.join(" "))
     } else {
-        return Messaging.message("download_background", "downloadUrl", [window.location.href, true])
+        return Messaging.message("download_background", "downloadUrl", window.location.href, true)
     }
 }
 
@@ -3962,7 +3962,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
             selectHints = hinting.pipe_elements(
                 elems,
                 elem => {
-                    Messaging.message("download_background", "downloadUrl", [new URL(elem[attr], window.location.href).href, saveAs])
+                    Messaging.message("download_background", "downloadUrl", new URL(elem[attr], window.location.href).href, saveAs)
                     return elem
                 },
                 rapid,
@@ -4074,7 +4074,7 @@ export function rot13(n: number) {
  */
 //#content
 export function run_exstr(...commands: string[]) {
-    return Messaging.message("controller_background", "acceptExCmd", commands)
+    return Messaging.message("controller_background", "acceptExCmd", commands.join(""))
 }
 
 // }}}

--- a/src/lib/browser_proxy.ts
+++ b/src/lib/browser_proxy.ts
@@ -7,11 +7,11 @@ const browserProxy = new Proxy(Object.create(null), {
             {
                 get(_, func) {
                     return (...args) =>
-                        message("browser_proxy_background", "shim", [
+                        message("browser_proxy_background", "shim",
                             api,
                             func,
                             args,
-                        ])
+                        )
                 },
             },
         )

--- a/src/lib/browser_proxy_background.ts
+++ b/src/lib/browser_proxy_background.ts
@@ -1,11 +1,5 @@
 /** Shim to access BG browser APIs from content. */
 
-function shim(api, func, args) {
+export function shim(api, func, args) {
     return browser[api][func](...args)
 }
-
-import { addListener, attributeCaller, MessageType } from "@src/lib/messaging"
-addListener(
-    "browser_proxy_background" as MessageType,
-    attributeCaller({ shim }),
-)

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -95,6 +95,8 @@ export function setupListener<Root>(root: Root) {
     });
 }
 
+type StripPromise<T> = T extends Promise<infer U> ? U : T
+
 /** Send a message to non-content scripts */
 export async function message<
     Type extends keyof Messages.Background,
@@ -107,7 +109,7 @@ export async function message<
         args
     }
 
-    return browser.runtime.sendMessage<typeof message, ReturnType<F>>(message)
+    return browser.runtime.sendMessage<typeof message, StripPromise<ReturnType<F>>>(message)
 }
 
 /** Message the active tab of the currentWindow */

--- a/src/message_protocols.ts
+++ b/src/message_protocols.ts
@@ -1,0 +1,3 @@
+// This file re-exports types for message protocols for background, content and commandline contexts
+
+export { Messages as Background } from "@src/background"

--- a/src/newtab.ts
+++ b/src/newtab.ts
@@ -47,6 +47,6 @@ window.addEventListener("load", _ => {
 // Periodically nag people about updates.
 window.addEventListener("load", _ => {
     if (config.get("update", "nag") === true) {
-        Messaging.message("controller_background", "acceptExCmd", ["updatecheck auto_polite"])
+        Messaging.message("controller_background", "acceptExCmd", "updatecheck auto_polite")
     }
 })

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -416,7 +416,5 @@ class MetricName {
 }
 
 function sendStats(list: PerformanceEntryList) {
-    messaging.message("performance_background", "receiveStatsJson", [
-        JSON.stringify(list),
-    ])
+    messaging.message("performance_background", "receiveStatsJson", JSON.stringify(list))
 }


### PR DESCRIPTION
This was broken off from #1948 to have a smaller PR.

Only the RPC calls to the background page are converted. To elide empty argument lists, the interface changes to accept `...args`, not `args` array