### PR TITLE
Teach config-rc to string-join lines ending with \

### DIFF
--- a/src/background/config_rc.ts
+++ b/src/background/config_rc.ts
@@ -50,7 +50,11 @@ export async function runRc(rc: string) {
 }
 
 export function rcFileToExCmds(rcText: string): string[] {
-    const excmds = rcText.split("\n")
+    // string-join lines that end with /
+    const joined = rcText.replace(/\\\n/g, "")
+
+    // Split into individual excmds
+    const excmds = joined.split("\n")
 
     // Remove empty and comment lines
     return excmds.filter(x => /\S/.test(x) && !x.trim().startsWith('"'))


### PR DESCRIPTION
This makes longer invocations _much_ more tolerable, which is super
useful for things like replacing long (racy) sequences of
`autocontain` directives with stuff like the following:

```
js window.tri.config.set('autocontain', Object.fromEntries([ \
  ['youtube\.com', 'sreyn@goog'], \
  ['www\.google\.com', 'sreyn@goog'], \
  " ...
].map(([k, v]) => ['^https?://[^/]*' + k + '/', v])))
```