### PR TITLE
Improve smooth scroll

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -87,12 +87,15 @@ class ScrollingData {
     }
 
     scroll(distance: number, duration: number) {
+        this.duration = duration
         this.startTime = performance.now()
         this.startPos = this.elem[this.pos]
+        // If we're already scrolling, update the endPos based off the current endPos
+        if (this.scrolling) {
+            this.endPos = this.endPos + distance
+            return true
+        }
         this.endPos = this.startPos + distance
-        this.duration = duration
-        // If we're already scrolling we don't need to try to scroll
-        if (this.scrolling) return true
         if ("style" in this.elem)
             (this.elem as any).style.scrollBehavior = "unset"
         this.scrolling = this.scrollStep()


### PR DESCRIPTION
Currently, smooth scroll is considerably slower than default scrolling when scrollline is called during an active scroll, it seems this is because the new endpoint is based of the current scroll position rather than the current destination. This change calculates the new endpoint using the previous endpoint rather than current position if a scroll animation is already in progress.
