### PR TITLE
Fix #2050: add WIP visual mode

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -355,6 +355,15 @@ config.getAsync("leavegithubalone").then(v => {
     }
 })
 
+document.addEventListener("selectionchange", () => {
+    const selection = document.getSelection()
+    if (selection.anchorOffset == selection.focusOffset) {
+        contentState.mode = "normal"
+    } else {
+        contentState.mode = "visual"
+    }
+})
+
 // Listen for statistics from each content script and send them to the
 // background for collection. Attach the observer to the window object
 // since there's apparently a bug that causes performance observers to

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -101,6 +101,7 @@ function* ParserController() {
         ignore: keys => generic.parser("ignoremaps", keys),
         hint: hinting.parser,
         gobble: gobblemode.parser,
+        visual: keys => generic.parser("vmaps", keys),
     }
 
     while (true) {

--- a/src/content/state_content.ts
+++ b/src/content/state_content.ts
@@ -8,6 +8,7 @@ export type ModeName =
     | "ignore"
     | "gobble"
     | "input"
+    | "visual"
 
 export class PrevInput {
     inputId: string

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -986,12 +986,12 @@ function getDeepProperty(obj, target: string[]) {
         if (obj["🕷🕷INHERITS🕷🕷"] === undefined)  {
             return getDeepProperty(obj[target[0]], target.slice(1))
         } else {
-            return getDeepProperty(mergeDeep(obj, get(obj["🕷🕷INHERITS🕷🕷"]))[target[0]], target.slice(1))
+            return getDeepProperty(mergeDeep(get(obj["🕷🕷INHERITS🕷🕷"]), obj)[target[0]], target.slice(1))
         }
     } else {
         if (obj === undefined) return obj
         if (obj["🕷🕷INHERITS🕷🕷"] !== undefined) {
-            return mergeDeep(obj, get(obj["🕷🕷INHERITS🕷🕷"]))
+            return mergeDeep(get(obj["🕷🕷INHERITS🕷🕷"]), obj)
         } else {
             return obj
         }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -135,10 +135,11 @@ export class default_config {
      *
      * They consist of key sequences mapped to ex commands.
      */
-    inputmaps = mergeDeep(this.imaps, {
+    inputmaps = {
         "<Tab>": "focusinput -n",
         "<S-Tab>": "focusinput -N",
-    })
+        "__INHERITS__": "imaps",
+    }
 
     /**
      * nmaps contain all of the bindings for "normal mode".
@@ -302,11 +303,12 @@ export class default_config {
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
     }
 
-    vmaps = mergeDeep(this.nmaps, { // we really want a real-time merge as this means that user normal binds will no longer work while text is selected
+    vmaps = {
         "<Escape>": "composite js document.getSelection().empty(); mode normal; hidecmdline",
         "<C-[>": "composite js document.getSelection().empty(); mode normal ; hidecmdline",
         "y": "composite js document.getSelection().toString() | yank",
-    })
+        "__INHERITS__": "nmaps",
+    }
 
     hintmaps = {
         "<Backspace>": "hint.popKey",
@@ -974,9 +976,18 @@ const DEFAULTS = o(new default_config())
  */
 function getDeepProperty(obj, target: string[]) {
     if (obj !== undefined && target.length) {
-        return getDeepProperty(obj[target[0]], target.slice(1))
+        if (obj.__INHERITS__ === undefined)  {
+            return getDeepProperty(obj[target[0]], target.slice(1))
+        } else {
+            return getDeepProperty(mergeDeep(obj, get(obj.__INHERITS__))[target[0]], target.slice(1))
+        }
     } else {
-        return obj
+        if (obj === undefined) return obj
+        if (obj.__INHERITS__ !== undefined) {
+            return mergeDeep(obj, get(obj.__INHERITS__))
+        } else {
+            return obj
+        }
     }
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -313,7 +313,7 @@ export class default_config {
     vmaps = {
         "<Escape>": "composite js document.getSelection().empty(); mode normal; hidecmdline",
         "<C-[>": "composite js document.getSelection().empty(); mode normal ; hidecmdline",
-        "y": "composite js document.getSelection().toString() | yank",
+        "y": "composite js document.getSelection().toString() | clipboard yank",
         "🕷🕷INHERITS🕷🕷": "nmaps",
     }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -317,7 +317,7 @@ export class default_config {
         "l": 'js document.getSelection().modify("extend","forward","character")',
         "h": 'js document.getSelection().modify("extend","backward","character")',
         "e": 'js document.getSelection().modify("extend","forward","word")',
-        "w": 'js document.getSelection().modify("extend","forward","word"); js document.getSelection().modify("extend","forward","character")',
+        "w": 'js document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","forward","character")',
         "j": 'js document.getSelection().modify("extend","forward","line")',
         // "j": 'js document.getSelection().modify("extend","forward","paragraph")', // not implemented in Firefox
         "k": 'js document.getSelection().modify("extend","backward","line")',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -302,6 +302,12 @@ export class default_config {
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
     }
 
+    vmaps = mergeDeep(this.nmaps, { // we really want a real-time merge as this means that user normal binds will no longer work while text is selected
+        "<Escape>": "composite js document.getSelection().empty(); mode normal; hidecmdline",
+        "<C-[>": "composite js document.getSelection().empty(); mode normal ; hidecmdline",
+        "y": "composite js document.getSelection().toString() | yank",
+    })
+
     hintmaps = {
         "<Backspace>": "hint.popKey",
         "<Escape>": "hint.reset",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -318,6 +318,7 @@ export class default_config {
         "h": 'js document.getSelection().modify("extend","backward","character")',
         "e": 'js document.getSelection().modify("extend","forward","word")',
         "w": 'js document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","forward","character")',
+        "b": 'js document.getSelection().modify("extend","backward","word"); document.getSelection().modify("extend",forward","character")',
         "j": 'js document.getSelection().modify("extend","forward","line")',
         // "j": 'js document.getSelection().modify("extend","forward","paragraph")', // not implemented in Firefox
         "k": 'js document.getSelection().modify("extend","backward","line")',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -314,6 +314,15 @@ export class default_config {
         "<Escape>": "composite js document.getSelection().empty(); mode normal; hidecmdline",
         "<C-[>": "composite js document.getSelection().empty(); mode normal ; hidecmdline",
         "y": "composite js document.getSelection().toString() | clipboard yank",
+        "l": 'js document.getSelection().modify("extend","forward","character")',
+        "h": 'js document.getSelection().modify("extend","backward","character")',
+        "e": 'js document.getSelection().modify("extend","forward","word")',
+        "w": 'js document.getSelection().modify("extend","forward","word"); js document.getSelection().modify("extend","forward","character")',
+        "j": 'js document.getSelection().modify("extend","forward","line")',
+        // "j": 'js document.getSelection().modify("extend","forward","paragraph")', // not implemented in Firefox
+        "k": 'js document.getSelection().modify("extend","backward","line")',
+        "$": 'js document.getSelection().modify("extend","forward","lineboundary")',
+        "0": 'js document.getSelection().modify("extend","backward","lineboundary")',
         "🕷🕷INHERITS🕷🕷": "nmaps",
     }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -138,7 +138,14 @@ export class default_config {
     inputmaps = {
         "<Tab>": "focusinput -n",
         "<S-Tab>": "focusinput -N",
-        "__INHERITS__": "imaps",
+        /**
+         * Config objects with this key inherit their keys from the object specified.
+         *
+         * Only supports "root" objects. Subconfigs (`seturl`) work as expected.
+         *
+         * Here, this means that input mode is the same as insert mode except it has added binds for tab and shift-tab.
+         */
+        "🕷🕷INHERITS🕷🕷": "imaps",
     }
 
     /**
@@ -307,7 +314,7 @@ export class default_config {
         "<Escape>": "composite js document.getSelection().empty(); mode normal; hidecmdline",
         "<C-[>": "composite js document.getSelection().empty(); mode normal ; hidecmdline",
         "y": "composite js document.getSelection().toString() | yank",
-        "__INHERITS__": "nmaps",
+        "🕷🕷INHERITS🕷🕷": "nmaps",
     }
 
     hintmaps = {
@@ -976,15 +983,15 @@ const DEFAULTS = o(new default_config())
  */
 function getDeepProperty(obj, target: string[]) {
     if (obj !== undefined && target.length) {
-        if (obj.__INHERITS__ === undefined)  {
+        if (obj["🕷🕷INHERITS🕷🕷"] === undefined)  {
             return getDeepProperty(obj[target[0]], target.slice(1))
         } else {
-            return getDeepProperty(mergeDeep(obj, get(obj.__INHERITS__))[target[0]], target.slice(1))
+            return getDeepProperty(mergeDeep(obj, get(obj["🕷🕷INHERITS🕷🕷"]))[target[0]], target.slice(1))
         }
     } else {
         if (obj === undefined) return obj
-        if (obj.__INHERITS__ !== undefined) {
-            return mergeDeep(obj, get(obj.__INHERITS__))
+        if (obj["🕷🕷INHERITS🕷🕷"] !== undefined) {
+            return mergeDeep(obj, get(obj["🕷🕷INHERITS🕷🕷"]))
         } else {
             return obj
         }


### PR DESCRIPTION
We need to make merging of nmaps happen at runtime before we merge this, or we'll break the binds of people who are just selecting text to help them read. Thoughts on how to do this would be appreciated.

The mode as it stands already works quite nicely with caret mode. Adding hjkl binds to extend the selection would probably be pretty easy.