### PR TITLE
Drop ftdetect hack from rc output, makes it difficult to use plugin

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -148,5 +148,5 @@ autocmd DocStart ^http(s?)://www.reddit.com js tri.excmds.urlmodify("-t", "www",
 " Mosquito nets won't make themselves
 autocmd DocStart ^http(s?)://www.amazon.co.uk js tri.excmds.urlmodify("-t", "www", "smile")
 
-" This will have to do until someone writes us a nice syntax file :)
-" vim: set filetype=vim:
+" For syntax highlighting see https://github.com/tridactyl/vim-tridactyl
+" vim: set filetype=tridactyl

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1485,7 +1485,7 @@ export function parseConfig(): string {
     if (p.logging.length > 0)
         s.logging = `" Logging\n${p.logging.join("\n")}\n\n`
 
-    const ftdetect = `" vim: set filetype=vim:`
+    const ftdetect = `" For syntax highlighting see https://github.com/tridactyl/vim-tridactyl\n" vim: set filetype=tridactyl`
 
     return `${s.general}${s.binds}${s.subconfigs}${s.aliases}${s.aucmds}${
         s.aucons


### PR DESCRIPTION
Having a modeline with a bogus filetype in the RC files makes it really hard to use [`vim-tridactyl`](https://github.com/tridactyl/vim-tridactyl) which will detect and set the filetype just fine as long as there are no dirty hacks resetting it afterwards.

The syntax is far from complete, but I personally think it's already far more usable than forcing `vim` syntax onto something that isn't. I suggest leaving this modeline hack off entirely, starting now.