### PR TITLE
Add tabsort option to allow sorting by "most recently visited" tab

### DIFF
--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -3,6 +3,7 @@ import { browserBg } from "@src/lib/webext.ts"
 import { enumerate } from "@src/lib/itertools"
 import * as Containers from "@src/lib/containers"
 import * as Completions from "@src/completions"
+import * as config from "@src/lib/config"
 
 class BufferCompletionOption extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
@@ -152,7 +153,11 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         // Get alternative tab, defined as last accessed tab.
         tabs.sort((a, b) => (b.lastAccessed - a.lastAccessed))
         const alt = tabs[1]
-        tabs.sort((a, b) => (a.index - b.index))
+
+        const useMruTabOrder = (config.get("tabsort") === "mru")
+        if (!useMruTabOrder) {
+            tabs.sort((a, b) => (a.index - b.index))
+        }
 
         for (const tab of tabs) {
             options.push(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -691,6 +691,11 @@ export class default_config {
     tabopenpos: "next" | "last" = "next"
 
     /**
+     * Controls which tab order to use when opening the tab/buffer list. Either mru = sort by most recent tab or default = by tab index
+     */
+    tabsort: "mru" | "default" = "default"
+
+    /**
      * Where to open tabs opened with hinting - as if it had been middle clicked, to the right of the current tab, or at the end of the tabs.
      */
     relatedopenpos: "related" | "next" | "last" = "related"


### PR DESCRIPTION
See https://github.com/tridactyl/tridactyl/issues/1040

Sometimes you have dozens of tabs open and want to switch between several recent tabs quickly. 

This PR adds a config option to set the tab/buffer list order to "most recently visited"