### PR TITLE
Remove onchanged listener from state

### DIFF
--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -11,6 +11,7 @@ export type TabMessageType =
     | "finding_content"
     | "commandline_cmd"
     | "commandline_frame"
+    | "state"
     | "lock"
 
 export type NonTabMessageType =

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -153,7 +153,10 @@ export async function messageAllTabs(
         try {
             responses.push(await messageTab(tab.id, type, command, args))
         } catch (e) {
-            logger.error(e)
+            // Skip errors caused by tabs we aren't running on
+            if (e.message != "Could not establish connection. Receiving end does not exist.") {
+                logger.error(e)
+            }
         }
     }
     return responses

--- a/src/state.ts
+++ b/src/state.ts
@@ -63,10 +63,14 @@ const state = (new Proxy(overlay, {
             logger.debug("State changed!", property, value)
             target[property] = value
             browser.storage.local.set({ state: target } as any)
+
             // dispatch message to all content state.ts's
-            // it doesn't currently appear to be used in background - if it is, "simply" need to use farnoy's typed messages
             // Wait for reply from each tab to say that they have updated their own state
             await messaging.messageAllTabs("state", "stateUpdate", [{state: target}])
+
+            // Ideally this V would use Farnoy's typed messages but
+            // I haven't had time to get my head around them
+            await browser.runtime.sendMessage({type:"state", command: "stateUpdate", args: [{state: target}]})
 
             // Release named lock
             await locks.release("state")

--- a/src/state.ts
+++ b/src/state.ts
@@ -70,7 +70,7 @@ const state = (new Proxy(overlay, {
 
             // Ideally this V would use Farnoy's typed messages but
             // I haven't had time to get my head around them
-            await browser.runtime.sendMessage({type:"state", command: "stateUpdate", args: [{state: target}]})
+            await browser.runtime.sendMessage({type: "state", command: "stateUpdate", args: [{state: target}]})
 
             // Release named lock
             await locks.release("state")


### PR DESCRIPTION
As detailed in #1764, the `onChanged` event leads to race conditions.

This PR sketches out how we might move away from it in state.ts. Once we've worked that out, we can do a similar thing to src/lib/config.ts and fix, with luck, #1409. 

Todo:

- ~~Get tabs to reply to messages~~
- ~~Look into named locks (has someone already done this for WebExtensions before? Probably, right?)~~ done in #2161
- ~~fix `g;`~~

I'm not sure I'll have time to do either so any help with this would be appreciated.