### PR TITLE
Faster tab completion

### DIFF
--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -159,13 +159,23 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
             tabs.sort((a, b) => (a.index - b.index))
         }
 
+        const container_all = await browserBg.contextualIdentities.query({})
+        const container_map = new Map()
+        container_all.forEach(elem => container_map.set(elem.cookieStoreId, elem))
+        // firefox-default is not in contextualIdenetities
+        container_map.set("firefox-default", Containers.DefaultContainer)
+
         for (const tab of tabs) {
+            let tab_container = container_map.get(tab.cookieStoreId)
+            if (!tab_container) {
+                tab_container = Containers.DefaultContainer
+            }
             options.push(
                 new BufferCompletionOption(
                     (tab.index + 1).toString(),
                     tab,
                     tab === alt,
-                    await Containers.getFromId(tab.cookieStoreId),
+                    tab_container
                 ),
             )
         }

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -31,7 +31,7 @@ const ContainerIcon = [
     "chill",
 ]
 
-const DefaultContainer = Object.freeze(
+export const DefaultContainer = Object.freeze(
     fromString("default", "invisible", "noicond", "firefox-default"),
 )
 


### PR DESCRIPTION
Get tab container info using `browser.contextualIdentities.query()` as sugguested by @glacambre.

It seemed that options of tabs were not changed during completion update, i.e. filter user input. Therefore, the options do not need to be recreated every time.
