### PR TITLE
Sort completion result based on Fuse.js score

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -155,6 +155,7 @@ export abstract class CompletionSourceFuse extends CompletionSource {
     fuse = undefined
 
     protected lastExstr: string
+    protected sortScoredOptions = false
 
     protected optionContainer = html`<table class="optionContainer"></table>`
 
@@ -274,8 +275,10 @@ export abstract class CompletionSourceFuse extends CompletionSource {
         }
 
         // sort this.options by score
-        const sorted_options = matches.map(index => this.options[index])
-        this.options = sorted_options.concat(hidden_options)
+        if (this.sortScoredOptions) {
+            const sorted_options = matches.map(index => this.options[index])
+            this.options = sorted_options.concat(hidden_options)
+        }
     }
 
     /** Call to replace the current display */

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -257,9 +257,13 @@ export abstract class CompletionSourceFuse extends CompletionSource {
     setStateFromScore(scoredOpts: ScoredOption[], autoselect = false) {
         const matches = scoredOpts.map(res => res.index)
 
+        const hidden_options = []
         for (const [index, option] of enumerate(this.options)) {
             if (matches.includes(index)) option.state = "normal"
-            else option.state = "hidden"
+            else {
+                option.state = "hidden"
+                hidden_options.push(option)
+            }
         }
 
         // ideally, this would not deselect anything unless it fell off the list of matches
@@ -268,6 +272,10 @@ export abstract class CompletionSourceFuse extends CompletionSource {
         } else {
             this.deselect()
         }
+
+        // sort this.options by score
+        const sorted_options = matches.map(index => this.options[index])
+        this.options = sorted_options.concat(hidden_options)
     }
 
     /** Call to replace the current display */

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -297,6 +297,7 @@ export abstract class CompletionSourceFuse extends CompletionSource {
             if (option.state !== "hidden")
                 this.optionContainer.appendChild(option.html)
         }
+        this.next(0)
 
         /* console.log('updateDisplay', this.optionContainer, newContainer) */
 

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -8,6 +8,7 @@ import * as config from "@src/lib/config"
 class BufferCompletionOption extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
     public fuseKeys = []
+    public tabIndex: number
 
     constructor(
         public value: string,
@@ -16,6 +17,8 @@ class BufferCompletionOption extends Completions.CompletionOptionHTML
         container: browser.contextualIdentities.ContextualIdentity,
     ) {
         super()
+        this.tabIndex = tab.index
+
         // Two character tab properties prefix
         let pre = ""
         if (tab.active) pre += "%"
@@ -86,6 +89,22 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
+    /** Return the scoredOption[] result for the nth tab */
+    private nthTabscoredOptions(
+        n: number,
+        options: BufferCompletionOption[]
+    ): Completions.ScoredOption[] {
+        for (const [index, option] of enumerate(options)) {
+            if (option.tabIndex === n) {
+                return [{
+                    index,
+                    option,
+                    score: 0,
+                },]
+            }
+        }
+    }
+
     /** Score with fuse unless query is a single # or looks like a tab index */
     scoredOptions(
         query: string,
@@ -98,13 +117,8 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
                 let index = Number(args[0]) - 1
                 if (Math.abs(index) < options.length) {
                     index = index.mod(options.length)
-                    return [
-                        {
-                            index,
-                            option: options[index],
-                            score: 0,
-                        },
-                    ]
+                    // options order might change by scored sorting
+                    return this.nthTabscoredOptions(index, options)
                 }
             } else if (args[0] === "#") {
                 for (const [index, option] of enumerate(options)) {

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -89,22 +89,6 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
-    /** Return the scoredOption[] result for the nth tab */
-    private nthTabscoredOptions(
-        n: number,
-        options: BufferCompletionOption[]
-    ): Completions.ScoredOption[] {
-        for (const [index, option] of enumerate(options)) {
-            if (option.tabIndex === n) {
-                return [{
-                    index,
-                    option,
-                    score: 0,
-                },]
-            }
-        }
-    }
-
     /** Score with fuse unless query is a single # or looks like a tab index */
     scoredOptions(
         query: string,
@@ -137,6 +121,22 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
 
         // If not yet returned...
         return super.scoredOptions(query, options)
+    }
+
+    /** Return the scoredOption[] result for the nth tab */
+    private nthTabscoredOptions(
+        n: number,
+        options: BufferCompletionOption[]
+    ): Completions.ScoredOption[] {
+        for (const [index, option] of enumerate(options)) {
+            if (option.tabIndex === n) {
+                return [{
+                    index,
+                    option,
+                    score: 0,
+                }, ]
+            }
+        }
     }
 
     private async fillOptions() {

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -66,6 +66,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
             "Tabs",
         )
 
+        this.sortScoredOptions = true
         this.updateOptions()
         this._parent.appendChild(this.node)
     }


### PR DESCRIPTION
The completion uses Fuse.js to match user filter. The matching is fuzzy, therefore sometime looks weird. The results are much easier to follow by putting better matched results at the top.

There might need some fine tuning on how to make use of the fuse matching for better result. Fuse seemed to have the ability to put weight on searching fields, like `title` has more weight than the `url` etc. I'm not familiar with Fuse to work on that.

