### PR TITLE
Fix hinting tag position for multiline links

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -479,7 +479,16 @@ class Hint {
             offsetLeft += rect.left
         }
 
-        const rect = target.getBoundingClientRect()
+        // Find the first visible client rect of the target
+        const clientRects = target.getClientRects()
+        let rect: ClientRect
+        for (const recti of clientRects) {
+            if (recti.bottom + offsetTop > 0 && recti.right + offsetLeft > 0) {
+                rect = recti
+                break
+            }
+        }
+
         this.rect = {
             top: rect.top + offsetTop,
             bottom: rect.bottom + offsetTop,

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -481,7 +481,7 @@ class Hint {
 
         // Find the first visible client rect of the target
         const clientRects = target.getClientRects()
-        let rect: ClientRect
+        let rect = clientRects[0]
         for (const recti of clientRects) {
             if (recti.bottom + offsetTop > 0 && recti.right + offsetLeft > 0) {
                 rect = recti


### PR DESCRIPTION
  Sometime a link spans multilines. The bounding rect of the link is
larger than the first line. In that case, using boundinig rect could
misplace the hinting tag.

Use the first visible clientRect to position the hinting tag.