### PR TITLE
Feature: expand selection range to entire node

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -36,6 +36,9 @@
 " Binds
 "
 
+" Expand a selected range to encompass contents of parent node. Usefull in visual mode for copying formatted text. For example, syntax highlighted code.
+bind --mode=visual = js let n = document.getSelection().anchorNode.parentNode; let s = window.getSelection(); let r = document.createRange(); s.removeAllRanges(); r.selectNodeContents(n); s.addRange(r);
+
 " Comment toggler for Reddit and Hacker News
 bind ;c hint -c [class*="expand"],[class="togg"]
 


### PR DESCRIPTION
The visual mode is great, but for webpages I have found that elements like span can obstruct text selection. I have been using this bind to make selection way easier, and thought others would find it beneficial as well.