### PR TITLE
Feature: new vmap '=' to expand selection to encompass parent nodes c…

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -340,6 +340,7 @@ export class default_config {
         "k": 'js document.getSelection().modify("extend","backward","line")',
         "$": 'js document.getSelection().modify("extend","forward","lineboundary")',
         "0": 'js document.getSelection().modify("extend","backward","lineboundary")',
+        "=": 'js let n = document.getSelection().anchorNode.parentNode; let s = window.getSelection(); let r = document.createRange(); s.removeAllRanges(); r.selectNodeContents(n); s.addRange(r)',
         "🕷🕷INHERITS🕷🕷": "nmaps",
     }
 


### PR DESCRIPTION
This is in response to an earlier pull request [#2188](https://github.com/tridactyl/tridactyl/pull/2188)