### PR TITLE
Allow js/jsb to load local javascript file.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4416,13 +4416,50 @@ async function js_helper(str: string[]) {
 }
 
 /**
- * Lets you execute JavaScript in the page context. If you want to get the result back, use `composite js ... | fillcmdline`
+ * Lets you execute JavaScript in the page context. If you want to get the
+ * result back, use
  *
- * Some of Tridactyl's functions are accessible here via the `tri` object. Just do `console.log(tri)` in the web console on the new tab page to see what's available.
+ *     `composite js ... | fillcmdline`
  *
- * If you want to pipe an argument to `js`, you need to use the "-p" flag and then use the JS_ARG global variable, e.g:
+ *  @returns Last value of the Javascript statement
  *
- * `composite get_current_url | js -p alert(JS_ARG)`
+ * Usage:
+ *
+ *        `js [-p] javascript code ... [arg]`
+ *
+ *        `js [-s|-r|-p] javascript_filename [arg]`
+ *
+ *   - options
+ *     - -p pass an argument to js. The argument is passed as the last
+ *          argument of the cmdline, i.e. `str[str.length-1]`
+ *     - -s load the js source from a Javascript file.
+ *     - -r load the js source from a Javascript file inside config directory.
+ *          Default: `~/.config/tridactyl/`.
+ *
+ * Some of Tridactyl's functions are accessible here via the `tri` object. Just
+ * do `console.log(tri)` in the web console on the new tab page to see what's
+ * available.
+ *
+ * If you want to pipe an argument to `js`, you need to use the "-p" flag and
+ * then use the JS_ARG global variable, e.g:
+ *
+ *     `composite get_current_url | js -p alert(JS_ARG)`
+ *
+ * To run Javasript from a source file:
+ *
+ *     `js -s ~/JSLib/my_script.js`
+ *
+ * To run Javascript file under config dir: `~/.config/tridactyl/sample.js`
+ *
+ *     `js -r sample.js`
+ *
+ * The Javascript were executed in local scope. If you want to reuse the code
+ * in other :js calls, you can add your functions or variables into a global
+ * namespace, like `window.` or `tri.`, e.g.:
+ *
+ *     `js tri.hello = function (){ alert("hello world!") };`
+ *     `js tri.hello()`
+ *
  */
 /* tslint:disable:no-identical-functions */
 //#content

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1657,7 +1657,7 @@ export function urlparent(count = 1) {
  *   path). -1 will append to the existing path, -2 will remove the last path
  *   level, and so on.
  *
- *   ```text
+ *   ```plaintext
  *   http://website.com/this/is/the/path/component
  *   Graft point:       ^    ^  ^   ^    ^        ^
  *   From left:         0    1  2   3    4        5

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4370,12 +4370,12 @@ export async function echo(...str: string[]) {
 async function js_helper(str: string[]) {
     let doSource = false
     let jsContent = null
-    let JS_ARG
+    /* tslint:disable:no-unused-declaration */
+    /* tslint:disable:no-dead-store */
+    let JS_ARG = null
 
     while (true) {
         if (str[0].startsWith("-p")) {
-            /* tslint:disable:no-unused-declaration */
-            /* tslint:disable:no-dead-store */
             JS_ARG = str[str.length - 1]
             str = str.slice(1, -1)
         } else if (str[0].startsWith("-s")) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4400,9 +4400,6 @@ async function js_helper(str: string[]) {
 
     if (doSource) {
         let sourcePath = str.join(" ")
-        if (sourcePath.search(/(^|[\/\\])..[\/\\]/) >= 0) {
-            throw new Error('Source Path cannot contains "/../"')
-        }
         if (fromRC) {
             const sep = "/"
             const rcPath = (await Native.getrcpath()).split(sep).slice(0, -1)


### PR DESCRIPTION
Add a flag `-s` to source js files from user's config directory:

    :js -s test.js

With the ability to load js files, `tridactylrc` can have its javascript
code into seperate files.

Since the js code was run by calling `eval()` in local scope of calling
function, the variables and functions decleared in the js file will lost
after eval().

To make the content of javascript file reusable, user could export
functions into some globals like `window.` or `tri.`.