### PR TITLE
config.ts: make sure mapobj[key] is defined

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1366,7 +1366,7 @@ export async function update() {
                         // Keep only the ones with im_* functions
                         .filter(
                             key =>
-                                mapobj[key].search(
+                                mapobj[key]?.search(
                                     "^im_|([^a-zA-Z0-9_-])im_",
                                 ) >= 0,
                         )


### PR DESCRIPTION
Tridactyl's commandline is completely broken for me. I believe this happens because of an error that is thrown on page load. This page load error seems to indicate that the problem comes from mapobj[key] not necessarily being defined, although I may very well be wrong since webpack now renames variables and turns Tridactyl into a one-liner.