### PR TITLE
If yarn bin not in $PATH, pre-commit hook always fails

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -38,7 +38,7 @@ tslintUgly() {
         tmpfile="$tmpdir/$jsfile"
         mkdir -p "$(dirname "$tmpfile")"
         staged "$jsfile" > "$tmpfile"
-        tslint -q "$tmpfile" 2>/dev/null || acc="$jsfile"$'\n'"$acc"
+        "$(yarn bin)/tslint" -q "$tmpfile" 2>/dev/null || acc="$jsfile"$'\n'"$acc"
     done
     rm -rf "$tmpdir"
     echo "$acc"


### PR DESCRIPTION
Fix #1841