### PR TITLE
Return keys=[] from parser so things don't blow up if exstr is ""

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3452,7 +3452,7 @@ export async function unbind(...args: string[]) {
 export async function unbindurl(pattern: string, mode: string, keys: string) {
     const args_obj = parse_bind_args(mode, keys)
 
-    return config.setURL(pattern, args_obj.configName, args_obj.key, "")
+    return config.setURL(pattern, args_obj.configName, args_obj.key, null)
 }
 
 /**

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -169,6 +169,7 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
                 exstr: perfect[1] + numericPrefixToExstrSuffix(numericPrefix),
                 isMatch: true,
                 numericPrefix: numericPrefix.length ? Number(numericPrefix.map(ke => ke.key).join("")) : undefined,
+                keys: [],
             }
         } catch (e) {
             if (!(e instanceof RangeError)) throw e


### PR DESCRIPTION
I'm not sure that this is actually what's going on, but it does look like a potential issue and I don't think this will break anything.