### PR TITLE
Improve the documented editorcmd for Vim

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -307,7 +307,7 @@ export function removeTridactylEditorClass(selector: string) {
  *
  * The editorcmd needs to accept a filename, stay in the foreground while it's edited, save the file and exit. By default the filename is added to the end of editorcmd, if you require control over the position of that argument, the first occurrence of %f in editorcmd is replaced with the filename. %l, if it exists, is replaced with the line number of the cursor and %c with the column number. For example:
  * ```
- * set editorcmd terminator -u -e "vim %f -c 'normal %lG%cl'"
+ * set editorcmd terminator -u -e "vim %f '+normal!%lGzv%c|'"
  * ```
  *
  * You're probably better off using the default insert mode bind of `<C-i>` (Ctrl-i) to access this.

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -97,7 +97,10 @@ export async function getBestEditor(): Promise<string> {
     let term_emulators = []
     let tui_editors = []
     let last_resorts = []
-    if ((await browserBg.runtime.getPlatformInfo()).os === "mac") {
+    const os = (await browserBg.runtime.getPlatformInfo()).os
+    const arg_quote = os === "win" ? '"' : "'"
+    const vim_positioning_arg = ` ${arg_quote}+normal!%lGzv%c|${arg_quote}`
+    if (os === "mac") {
         gui_candidates = [
             "/Applications/MacVim.app/Contents/bin/mvim -f",
             "/usr/local/bin/vimr --wait --nvim +only",

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -102,7 +102,7 @@ export async function getBestEditor(): Promise<string> {
     const vim_positioning_arg = ` ${arg_quote}+normal!%lGzv%c|${arg_quote}`
     if (os === "mac") {
         gui_candidates = [
-            "/Applications/MacVim.app/Contents/bin/mvim -f",
+            "/Applications/MacVim.app/Contents/bin/mvim -f" + vim_positioning_arg,
             "/usr/local/bin/vimr --wait --nvim +only",
         ]
         // if anyone knows of any "sensible" terminals that let you send them commands to run,
@@ -113,7 +113,7 @@ export async function getBestEditor(): Promise<string> {
         last_resorts = ["open -nWt"]
     } else {
         // Tempted to put this behind another config setting: prefergui
-        gui_candidates = ["gvim -f"]
+        gui_candidates = ["gvim -f" + vim_positioning_arg]
 
         // we generally try to give the terminal the class "tridactyl_editor" so that
         // it can be made floating, e.g in i3:
@@ -149,7 +149,7 @@ export async function getBestEditor(): Promise<string> {
         ]
     }
 
-    tui_editors = ["vim %f", "nvim %f", "nano %f", "emacs -nw %f"]
+    tui_editors = ["vim" + vim_positioning_arg, "nvim" + vim_positioning_arg, "nano %f", "emacs -nw %f"]
 
     // Consider GUI editors
     let cmd = await firstinpath(gui_candidates)


### PR DESCRIPTION
Problems with the original:
- Addressing the column with `l` assumes that `G` positions the cursor on the first column. But the default behavior already skips leading indent (so is wrong when there's leading whitespace), and with `:set nostartofline`, the current column actually is kept (which completely and randomly messes up the column addressing).
- `:normal` without ! is affected by mappings; users may have tweaked the `G` and `l` (or in the worst case completely changed the behavior, e.g. for use with a different keyboard layout).

This change makes the mapping immune to mappings (with `:normal!`) and uses the `|` command (which uses virtual column addressing independent of the current column or `G` behavior) instead of `c`.
Additionally, `zv` makes the current line visible should it be obscured by folding. (Vim may detect a filetype and automatically enable folding.)
Instead of `-c <cmd>`, the shorter `+<cmd>` form is used. This is just a cosmetic change. Using just a single argument and avoiding any whitespace within it may prevent command-line argument parsing issues.
