### PR TITLE
WIP: statusline

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -270,13 +270,13 @@ config.getAsync("modeindicator").then(mode => {
 
     try {
         // On quick loading pages, the document is already loaded
-        statusIndicator.textContent = contentState.mode || "normal"
+        statusIndicator.textContent = modeindicatorcontent()
         document.body.appendChild(statusIndicator)
         document.head.appendChild(style)
     } catch (e) {
         // But on slower pages we wait for the document to load
         window.addEventListener("DOMContentLoaded", () => {
-            statusIndicator.textContent = contentState.mode || "normal"
+            statusIndicator.textContent = modeindicatorcontent()
             document.body.appendChild(statusIndicator)
             document.head.appendChild(style)
         })
@@ -328,13 +328,17 @@ config.getAsync("modeindicator").then(mode => {
             "config",
             modeindicatorshowkeys,
         )
-        statusIndicator.textContent = result
+        statusIndicator.textContent = modeindicatorcontent(result)
         statusIndicator.className +=
-            " TridactylMode" + statusIndicator.textContent
+            " TridactylMode" + result
 
         if (config.get("modeindicator") !== "true") statusIndicator.remove()
     })
 })
+
+function modeindicatorcontent(modeoveride?) {
+    return (config.get("modeindicatorshowurl") == "true" ? document.location.href + " " : "") + (modeoveride || contentState.mode || "normal")
+}
 
 function protectSlash(e) {
     if (!e.isTrusted) return

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1023,6 +1023,11 @@ export class default_config {
     modeindicatorshowkeys: "true" | "false" = "false"
 
     /**
+     * Show the current URL in the mod indicator.
+     */
+    modeindicatorshowurl: "true" | "false" = "false"
+
+    /**
      * Whether a trailing slash is appended when we get the parent of a url with
      * gu (or other means).
      */


### PR DESCRIPTION
I think it's safe to say that we aren't going to replace the command line with any fancy React-a-like thing any time soon, so we might as well make a statusline. Also, I have discovered since `guiset` breaking the address bar that I actually looked at it quite a bit to work out what page I was on, so I want it back.

Todo: CSS (make into status line rather than floaty thing), add other things to display (e.g. scroll percentage).

Related: https://github.com/tridactyl/tridactyl/issues/210