### PR TITLE
Fix #1805: preferentially scroll focused elements

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -185,6 +185,9 @@ export async function recursiveScroll(
 
             // If that didn't work, go on to recursive scroll
             node = document.documentElement
+
+            // Invalidate the cache if the user changes focus
+            lastFocused = document.activeElement
         }
     }
     let treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT)
@@ -202,7 +205,6 @@ export async function recursiveScroll(
         ) {
             // Cache the node for next time and stop trying to scroll
             lastRecursiveScrolled = treeWalker.currentNode
-            lastFocused = document.activeElement // Invalidate the cache if the user changes focus
             lastX = xDistance
             lastY = yDistance
             return true

--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -149,8 +149,18 @@ export async function scroll(
 
 let lastRecursiveScrolled = null
 let lastFocused = null
+let currentFocused = document.activeElement as any
 let lastX = 0
 let lastY = 0
+
+document.addEventListener("mousedown", event => {
+    currentFocused = event.target
+})
+
+document.addEventListener("focusin", event => {
+    currentFocused = event.target
+})
+
 /** Tries to find a node which can be scrolled either x pixels to the right or
  *  y pixels down among the Elements in {nodes} and children of these Elements.
  *
@@ -167,7 +177,7 @@ export async function recursiveScroll(
     if (!node) {
         const sameSignX = xDistance < 0 === lastX < 0
         const sameSignY = yDistance < 0 === lastY < 0
-        const sameElement = lastFocused == document.activeElement
+        const sameElement = lastFocused == currentFocused
         if (lastRecursiveScrolled && sameSignX && sameSignY && sameElement) {
             // We're scrolling in the same direction as the previous time so
             // let's try to pick up from where we left
@@ -176,7 +186,11 @@ export async function recursiveScroll(
         } else {
 
             // Try scrolling the active node or one of its parent elements
-            node = document.activeElement
+
+            // If nothing has been given focus explicitly use the activeElement
+            if (!currentFocused || currentFocused.nodeName == "#document") currentFocused = document.activeElement
+
+            node = currentFocused
             while (true) {
                 if ((await scroll(xDistance, yDistance, node))) return true
                 node = node.parentElement
@@ -187,7 +201,7 @@ export async function recursiveScroll(
             node = document.documentElement
 
             // Invalidate the cache if the user changes focus
-            lastFocused = document.activeElement
+            lastFocused = currentFocused
         }
     }
     let treeWalker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT)

--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -153,6 +153,11 @@ let currentFocused = document.activeElement as any
 let lastX = 0
 let lastY = 0
 
+// export let currentFocused exports it as readonly, so we have to write a function
+export function setCurrentFocus(v) {
+    currentFocused = v
+}
+
 document.addEventListener("mousedown", event => {
     currentFocused = event.target
 })

--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -180,7 +180,7 @@ export async function recursiveScroll(
             while (true) {
                 if ((await scroll(xDistance, yDistance, node))) return true
                 node = node.parentElement
-                if (node === null) break
+                if (!node) break
             }
 
             // If that didn't work, go on to recursive scroll

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3780,7 +3780,7 @@ export function setnull(...keys: string[]) {
         - -S save the linked image
         - -a save-as the linked resource
         - -A save-as the linked image
-        - -; focus an element
+        - -; focus an element and set it as the element or the child of the element to scroll
         - -# yank an element's anchor URL to clipboard
         - -c [selector] hint links that match the css selector
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
@@ -4070,6 +4070,7 @@ export async function hint(option?: string, selectors?: string, ...rest: string[
                 hinting.hintables(selectors),
                 elem => {
                     elem.focus()
+                    scrolling.setCurrentFocus(elem)
                     return elem
                 },
                 rapid,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -278,7 +278,7 @@ export class default_config {
         ";S": "hint -S",
         ";a": "hint -a",
         ";A": "hint -A",
-        ";;": "hint -;",
+        ";;": "hint -; *",
         ";#": "hint -#",
         ";v": "hint -W mpvsafe",
         ";w": "hint -w",


### PR DESCRIPTION
~~Some caveats:~~

- ~~`;;` needs a link to focus before you can focus it~~
- ~~just clicking in the element you want to scroll isn't good enough~~

~~so I'm leaving #1805 open. I reckon this is 95% of the way there, though.~~

Edit: caveats fixed. Fixes #1805. I reckon. Might be worth adding some stuff to the tutorial about it?

@glacambre do we have a list of sites for testing scrolling on? It works on the usual suspects I've tried so far - AWS, Rust, CUDA.

