### PR TITLE
Cache conversion of bind configs to minimalkeys

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -143,7 +143,7 @@ ALL_EXCMDS = {
 }
 // }
 
-import { mapstrToKeyseq } from "@src/lib/keyseq"
+import { mapstrToKeyseq, reset_cache } from "@src/lib/keyseq"
 
 //#background_helper
 // {
@@ -3236,6 +3236,7 @@ export function comclear(name: string) {
 */
 //#background
 export function bind(...args: string[]) {
+    clear_keymap_cache()
     const args_obj = parse_bind_args(...args)
     let p = Promise.resolve()
     if (args_obj.excmd !== "") {
@@ -3253,6 +3254,16 @@ export function bind(...args: string[]) {
         p = fillcmdline_notrail("#", args_obj.key, "=", config.getDynamic(args_obj.configName, args_obj.key))
     }
     return p
+}
+
+/*
+ * Internal function called by [[bind]] and [[unbind]] to ensure binds are updated without needing a page reload.
+ *
+ * You never need to call this manually unless you have used e.g. `set nmaps.` directly.
+ */
+//#content
+export function clear_keymap_cache() {
+    reset_cache()
 }
 
 /**
@@ -3506,6 +3517,7 @@ export function blacklistadd(url: string) {
 */
 //#background
 export async function unbind(...args: string[]) {
+    clear_keymap_cache()
     const args_obj = parse_bind_args(...args)
     if (args_obj.excmd !== "") throw new Error("unbind syntax: `unbind key`")
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -143,7 +143,7 @@ ALL_EXCMDS = {
 }
 // }
 
-import { mapstrToKeyseq, reset_cache } from "@src/lib/keyseq"
+import { mapstrToKeyseq } from "@src/lib/keyseq"
 
 //#background_helper
 // {
@@ -3236,7 +3236,6 @@ export function comclear(name: string) {
 */
 //#background
 export function bind(...args: string[]) {
-    clear_keymap_cache()
     const args_obj = parse_bind_args(...args)
     let p = Promise.resolve()
     if (args_obj.excmd !== "") {
@@ -3254,16 +3253,6 @@ export function bind(...args: string[]) {
         p = fillcmdline_notrail("#", args_obj.key, "=", config.getDynamic(args_obj.configName, args_obj.key))
     }
     return p
-}
-
-/*
- * Internal function called by [[bind]] and [[unbind]] to ensure binds are updated without needing a page reload.
- *
- * You never need to call this manually unless you have used e.g. `set nmaps.` directly.
- */
-//#content
-export function clear_keymap_cache() {
-    reset_cache()
 }
 
 /**
@@ -3517,7 +3506,6 @@ export function blacklistadd(url: string) {
 */
 //#background
 export async function unbind(...args: string[]) {
-    clear_keymap_cache()
     const args_obj = parse_bind_args(...args)
     if (args_obj.excmd !== "") throw new Error("unbind syntax: `unbind key`")
 

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -352,10 +352,6 @@ export function mapstrMapToKeyMap(mapstrMap: Map<string, MapTarget>): KeyMap {
 
 let KEYMAP_CACHE = {}
 
-export function reset_cache() {
-    KEYMAP_CACHE = {}
-}
-
 export function translateKeysInPlace(keys, conf): void {
     // If so configured, translate keys using the key translation map
     if (config.get("keytranslatemodes")[conf] === "true") {
@@ -449,3 +445,9 @@ export function translateKeysUsingKeyTranslateMap(
 }
 
 // }}}
+
+browser.storage.onChanged.addListener((changes, areaname) => {
+    if ("userconfig" in changes) {
+        KEYMAP_CACHE = {}
+    }
+})

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -350,6 +350,12 @@ export function mapstrMapToKeyMap(mapstrMap: Map<string, MapTarget>): KeyMap {
     return newKeyMap
 }
 
+let KEYMAP_CACHE = {}
+
+export function reset_cache() {
+    KEYMAP_CACHE = {}
+}
+
 export function translateKeysInPlace(keys, conf): void {
     // If so configured, translate keys using the key translation map
     if (config.get("keytranslatemodes")[conf] === "true") {
@@ -362,12 +368,15 @@ export function translateKeysInPlace(keys, conf): void {
  * Return a "*maps" config converted into sequences of minimalkeys (e.g. "nmaps")
  */
 export function keyMap(conf): KeyMap {
+    if (KEYMAP_CACHE[conf]) return KEYMAP_CACHE[conf]
+
     let maps: any = config.get(conf)
     if (maps === undefined) throw new Error("No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal")
 
     // Convert to KeyMap
     maps = new Map(Object.entries(maps))
-    return mapstrMapToKeyMap(maps)
+    KEYMAP_CACHE[conf] = mapstrMapToKeyMap(maps)
+    return KEYMAP_CACHE[conf]
 }
 
 // }}}

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -350,15 +350,20 @@ export function mapstrMapToKeyMap(mapstrMap: Map<string, MapTarget>): KeyMap {
     return newKeyMap
 }
 
-export function keyMap(conf, keys): KeyMap {
-    let maps: any = config.get(conf)
-    if (maps === undefined) throw new Error("No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal")
-
+export function translateKeysInPlace(keys, conf): void {
     // If so configured, translate keys using the key translation map
     if (config.get("keytranslatemodes")[conf] === "true") {
         const translationmap = config.get("keytranslatemap")
         translateKeysUsingKeyTranslateMap(keys, translationmap)
     }
+}
+
+/**
+ * Return a "*maps" config converted into sequences of minimalkeys (e.g. "nmaps")
+ */
+export function keyMap(conf): KeyMap {
+    let maps: any = config.get(conf)
+    if (maps === undefined) throw new Error("No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal")
 
     // Convert to KeyMap
     maps = new Map(Object.entries(maps))

--- a/src/parsers/genericmode.ts
+++ b/src/parsers/genericmode.ts
@@ -3,6 +3,7 @@
 import * as keyseq from "@src/lib/keyseq"
 
 export function parser(conf, keys): keyseq.ParserResponse {
-    const maps = keyseq.keyMap(conf, keys)
+    const maps = keyseq.keyMap(conf)
+    keyseq.translateKeysInPlace(keys, conf)
     return keyseq.parse(keys, maps)
 }

--- a/src/parsers/nmode.ts
+++ b/src/parsers/nmode.ts
@@ -29,7 +29,8 @@ export function parser(keys: KeyboardEvent[]) {
     keys = keyseq.stripOnlyModifiers(keys)
     if (keys.length === 0) return { keys: [], isMatch: false }
     const conf = mode2maps.get(modeState.mode) || modeState.mode + "maps"
-    const maps: any = keyseq.keyMap(conf, keys)
+    const maps: any = keyseq.keyMap(conf)
+    keyseq.translateKeysInPlace(keys, conf)
     const key = keys[0].key
 
     if (key === "Escape") {


### PR DESCRIPTION
@glacambre from our conversation in #1645 - this seems to roughly halve the delay between pressing a key and seeing an effect on screen. Tested with a high speed camera (I am in awe of smartphones) and then eyeballing the results; and with `cpulimit --limit 50 -i npm run run` with results again analysed by sight. I can't tell the difference in realtime but I imagine it will make some people happy.

TODO:

- [x] check what translatekeysusingkeytranslatemap is doing (it reeks of side effects)
- [x] invalidate the cache on bind/unbind calls