### PR TITLE
Make openInNewTab always open in background

### DIFF
--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -105,7 +105,7 @@ export async function openInNewTab(
 ) {
     const thisTab = await activeTab()
     const options: any = {
-        active: kwargs.active,
+        active: false,
         url,
         cookieStoreId: kwargs.cookieStoreId,
     }
@@ -135,7 +135,11 @@ export async function openInNewTab(
             break
     }
 
-    return browserBg.tabs.create(options)
+    if (kwargs.active === false) { // load in background
+        return browserBg.tabs.create(options)
+    } else { // load in background and then activate, per issue #1993
+        return browserBg.tabs.create(options).then(newtab => browserBg.tabs.update(newtab.id, { active: true }))
+    }
 }
 
 // lazily copied from excmds.ts' winopen - forceURI really ought to be moved to lib/webext


### PR DESCRIPTION
New active tabs focus address bar, while new inactive tabs do not. By
opening all tabs as inactive, then making active afterwards, focus can
be maintained on content for all new tabs.

I tested this on my system and it appears to behave correctly, but I'm
uncertain of possible edge cases.

Fixes #1993 