### PR TITLE
Retry completion.next until there are completions

### DIFF
--- a/src/lib/patience.ts
+++ b/src/lib/patience.ts
@@ -1,0 +1,15 @@
+// Borrowed from
+// https://tech.mybuilder.com/handling-retries-and-back-off-attempts-with-javascript-promises/
+export const sleep = (duration: number) =>
+    new Promise(res => setTimeout(res, duration))
+
+export const backoff = (
+    fn: (...args: any[]) => Promise<any>,
+    retries = 5,
+    delay = 50,
+) =>
+    fn().catch(err => {
+        retries > 1
+            ? sleep(delay).then(() => backoff(fn, retries - 1, delay * 2))
+            : Promise.reject(err)
+    })


### PR DESCRIPTION
This improves the experience of e.g. pressing b<Tab> as it means that it will, within reason, wait until the completions have been populated before firing.

We should probably add a lock for updateOptions and back off if it is in use to improve e.g. `tft<Tab>` which should select ft.com (at least if you have browser history similar to mine), rather than the usual thing of it firing too early and being deselected.