### PR TITLE
Wait for completion filtering to finish before running next

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -53,7 +53,9 @@ const logger = new Logger("cmdline")
 /** @hidden **/
 const commandline_state = {
     activeCompletions: undefined,
-    clInput: (window.document.getElementById("tridactyl-input") as HTMLInputElement),
+    clInput: window.document.getElementById(
+        "tridactyl-input",
+    ) as HTMLInputElement,
     clear,
     cmdline_history_position: 0,
     completionsDiv: window.document.getElementById("completions"),
@@ -131,7 +133,9 @@ export function enableCompletions() {
             .filter(c => c)
 
         const fragment = document.createDocumentFragment()
-        commandline_state.activeCompletions.forEach(comp => fragment.appendChild(comp.node))
+        commandline_state.activeCompletions.forEach(comp =>
+            fragment.appendChild(comp.node),
+        )
         commandline_state.completionsDiv.appendChild(fragment)
         logger.debug(commandline_state.activeCompletions)
     }
@@ -212,7 +216,7 @@ export function refresh_completions(exstr) {
     if (!commandline_state.activeCompletions) enableCompletions()
     return Promise.all(
         commandline_state.activeCompletions.map(comp =>
-            comp.filter(exstr).then(() => {
+            comp.filterWrapper(exstr).then(() => {
                 if (comp.shouldRefresh()) {
                     return resizeArea()
                 }
@@ -249,7 +253,8 @@ let cmdline_history_current = ""
  *  Otherwise, no need to pass an argument.
  */
 export function clear(evlistener = false) {
-    if (evlistener) commandline_state.clInput.removeEventListener("blur", noblur)
+    if (evlistener)
+        commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.value = ""
     commandline_state.cmdline_history_position = 0
     cmdline_history_current = ""
@@ -270,7 +275,8 @@ async function history(n) {
     if (commandline_state.cmdline_history_position === 0) {
         cmdline_history_current = commandline_state.clInput.value
     }
-    let clamped_ind = matches.length + n - commandline_state.cmdline_history_position
+    let clamped_ind =
+        matches.length + n - commandline_state.cmdline_history_position
     clamped_ind = clamped_ind.clamp(0, matches.length)
 
     const pot_history = matches[clamped_ind]
@@ -279,8 +285,12 @@ async function history(n) {
 
     // if there was no clampage, update history position
     // there's a more sensible way of doing this but that would require more programmer time
-    if (clamped_ind === matches.length + n - commandline_state.cmdline_history_position)
-        commandline_state.cmdline_history_position = commandline_state.cmdline_history_position - n
+    if (
+        clamped_ind ===
+        matches.length + n - commandline_state.cmdline_history_position
+    )
+        commandline_state.cmdline_history_position =
+            commandline_state.cmdline_history_position - n
 }
 commandline_state.history = history
 
@@ -378,13 +388,16 @@ Messaging.addListener("commandline_frame", Messaging.attributeCaller(SELF))
 import { getCommandlineFns } from "@src/lib/commandline_cmds"
 import { KeyEventLike } from "./lib/keyseq"
 commandline_state.fns = getCommandlineFns(commandline_state)
-Messaging.addListener("commandline_cmd", Messaging.attributeCaller(commandline_state.fns))
+Messaging.addListener(
+    "commandline_cmd",
+    Messaging.attributeCaller(commandline_state.fns),
+)
 
 // Listen for statistics from the commandline iframe and send them to
 // the background for collection. Attach the observer to the window
 // object since there's apparently a bug that causes performance
 // observers to be GC'd even if they're still the target of a
 // callback.
-; (window as any).tri = Object.assign(window.tri || {}, {
+;(window as any).tri = Object.assign(window.tri || {}, {
     perfObserver: perf.listenForCounters(),
 })

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -148,6 +148,8 @@ export interface ScoredOption {
     score: number
 }
 
+let FILTERING = 0
+
 export abstract class CompletionSourceFuse extends CompletionSource {
     public node
     public options: CompletionOptionFuse[]
@@ -182,6 +184,13 @@ export abstract class CompletionSourceFuse extends CompletionSource {
         this.lastExstr = exstr
         await this.onInput(exstr)
         return this.updateChain()
+    }
+
+    public async filterWrapper(exstr: string) {
+        FILTERING += 1
+        const ans = await this.filter(exstr)
+        FILTERING -= 1
+        return ans
     }
 
     updateChain(exstr = this.lastExstr, options = this.options) {
@@ -314,10 +323,20 @@ export abstract class CompletionSourceFuse extends CompletionSource {
 
     async next(inc = 1) {
         if (this.state !== "hidden") {
-            // We're abusing `async` here to help us to catch errors in backoff
-            // and to make it easier to return consistent types
-            /* eslint-disable-next-line @typescript-eslint/require-await */
             return backoff(async () => {
+                // we should run another backoff here
+                try {
+                    // We're abusing `async` here to help us to catch errors in backoff
+                    // and to make it easier to return consistent types
+                    /* eslint-disable-next-line @typescript-eslint/require-await */
+                    await backoff(async () => {
+                        if (FILTERING > 0) {
+                            throw "Filtering in progress, tabnext ignored"
+                        }
+                    })
+                } catch (e) {
+                    // If after n tries it still hasn't finished, continue anyway
+                }
                 const visopts = this.options.filter(o => o.state !== "hidden")
                 const currind = visopts.findIndex(o => o.state === "focused")
                 this.deselect()


### PR DESCRIPTION
This should improve e.g. `tft<Tab>` resulting in ft.com being selected rather than `<Tab>` firing too early and then being deselected.

It doesn't seem to make much difference in practice, suggesting that a lot of the work is being done outside of `filter` and isn't being awaited.