### PR TITLE
Tighten types

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1197,7 +1197,7 @@ function focusRightHint() {
 }
 
 /** @hidden */
-export function parser(keys: KeyboardEvent[]) {
+export function parser(keys: keyseq.KeyEventLike[]) {
     const parsed = keyseq.parse(
         keys,
         keyseq.mapstrMapToKeyMap(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1341,7 +1341,7 @@ export async function save(storage: "local" | "sync" = get("storageloc")) {
  */
 export async function update() {
     // Updates a value both in the main config and in sub (=site specific) configs
-    const updateAll = (setting: any[], fn: (any) => any) => {
+    const updateAll = (setting: string[], fn: (any) => any) => {
         const val = getDeepProperty(USERCONFIG, setting)
         if (val) {
             set(...setting, fn(val))

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -112,19 +112,26 @@ export interface ParserResponse {
     keys?: KeyEventLike[]
     value?: any
     exstr?: any
-    isMatch: boolean
+    isMatch?: boolean
     numericPrefix?: number
 }
 
-function splitNumericPrefix(keyseq: KeyEventLike[]): [KeyEventLike[], KeyEventLike[]] {
+function splitNumericPrefix(
+    keyseq: KeyEventLike[],
+): [KeyEventLike[], KeyEventLike[]] {
     // If the first key is in 1:9, partition all numbers until you reach a non-number.
-    if (!hasModifiers(keyseq[0]) && [1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(keyseq[0].key))) {
+    if (
+        !hasModifiers(keyseq[0]) &&
+        [1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(keyseq[0].key))
+    ) {
         const prefix = [keyseq[0]]
         for (const ke of keyseq.slice(1)) {
-            if (!hasModifiers(ke) && [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(ke.key)))
+            if (
+                !hasModifiers(ke) &&
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(ke.key))
+            )
                 prefix.push(ke)
-            else
-                break
+            else break
         }
         const rest = keyseq.slice(prefix.length)
         return [prefix, rest]
@@ -145,12 +152,11 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
     keyseq = stripOnlyModifiers(keyseq)
 
     // If the keyseq is now empty, abort.
-    if (keyseq.length === 0)
-        return { keys: [], isMatch: false }
+    if (keyseq.length === 0) return { keys: [], isMatch: false }
 
     // Split into numeric prefix and non-numeric suffix
     let numericPrefix: KeyEventLike[]
-    [numericPrefix, keyseq] = splitNumericPrefix(keyseq)
+    ;[numericPrefix, keyseq] = splitNumericPrefix(keyseq)
 
     // If keyseq is a prefix of a key in map, proceed, else try dropping keys
     // from keyseq until it is empty or is a prefix.
@@ -173,7 +179,9 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
                 value: perfect[1],
                 exstr: perfect[1] + numericPrefixToExstrSuffix(numericPrefix),
                 isMatch: true,
-                numericPrefix: numericPrefix.length ? Number(numericPrefix.map(ke => ke.key).join("")) : undefined,
+                numericPrefix: numericPrefix.length
+                    ? Number(numericPrefix.map(ke => ke.key).join(""))
+                    : undefined,
                 keys: [],
             }
         } catch (e) {
@@ -367,7 +375,10 @@ export function keyMap(conf): KeyMap {
     if (KEYMAP_CACHE[conf]) return KEYMAP_CACHE[conf]
 
     let maps: any = config.get(conf)
-    if (maps === undefined) throw new Error("No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal")
+    if (maps === undefined)
+        throw new Error(
+            "No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal",
+        )
 
     // Convert to KeyMap
     maps = new Map(Object.entries(maps))

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -374,14 +374,14 @@ export function translateKeysInPlace(keys, conf): void {
 export function keyMap(conf): KeyMap {
     if (KEYMAP_CACHE[conf]) return KEYMAP_CACHE[conf]
 
-    let maps: any = config.get(conf)
-    if (maps === undefined)
+    const mapobj: {[keyseq: string]: string} = config.get(conf)
+    if (mapobj === undefined)
         throw new Error(
             "No binds defined for this mode. Reload page with <C-r> and add binds, e.g. :bind --mode=[mode] <Esc> mode normal",
         )
 
     // Convert to KeyMap
-    maps = new Map(Object.entries(maps))
+    const maps = new Map(Object.entries(mapobj))
     KEYMAP_CACHE[conf] = mapstrMapToKeyMap(maps)
     return KEYMAP_CACHE[conf]
 }

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -110,8 +110,8 @@ type KeyMap = Map<MinimalKey[], MapTarget>
 
 export interface ParserResponse {
     keys?: KeyEventLike[]
-    value?: any
-    exstr?: any
+    value?: string
+    exstr?: string
     isMatch?: boolean
     numericPrefix?: number
 }

--- a/src/parsers/gobblemode.ts
+++ b/src/parsers/gobblemode.ts
@@ -1,5 +1,5 @@
 import { contentState } from "@src/content/state_content"
-import { isSimpleKey } from "@src/lib/keyseq"
+import { isSimpleKey, KeyEventLike } from "@src/lib/keyseq"
 
 /** Simple container for the gobble state. */
 class GobbleState {
@@ -27,7 +27,7 @@ function reset() {
 }
 
 /** Receive keypress. If applicable, execute a command. */
-export function parser(keys: KeyboardEvent[]) {
+export function parser(keys: KeyEventLike[]) {
     const key = keys[0].key
 
     if (key === "Escape") {

--- a/src/parsers/nmode.ts
+++ b/src/parsers/nmode.ts
@@ -25,7 +25,7 @@ export function init(endCommand: string, mode = "normal", numCommands = 1) {
 }
 
 /** Receive keypress. If applicable, execute a command. */
-export function parser(keys: KeyboardEvent[]) {
+export function parser(keys: keyseq.KeyEventLike[]) {
     keys = keyseq.stripOnlyModifiers(keys)
     if (keys.length === 0) return { keys: [], isMatch: false }
     const conf = mode2maps.get(modeState.mode) || modeState.mode + "maps"

--- a/src/parsers/nmode.ts
+++ b/src/parsers/nmode.ts
@@ -29,7 +29,7 @@ export function parser(keys: keyseq.KeyEventLike[]) {
     keys = keyseq.stripOnlyModifiers(keys)
     if (keys.length === 0) return { keys: [], isMatch: false }
     const conf = mode2maps.get(modeState.mode) || modeState.mode + "maps"
-    const maps: any = keyseq.keyMap(conf)
+    const maps = keyseq.keyMap(conf)
     keyseq.translateKeysInPlace(keys, conf)
     const key = keys[0].key
 


### PR DESCRIPTION
daa65adcc8dde7ef9a3c61dd43ec64b9ff3e2b6b has sent me on a crusade to
banish `: any` types as far as possible