### PR TITLE
Add (slightly lame) user configurable browser wide binds

### DIFF
--- a/doc/amo.md
+++ b/doc/amo.md
@@ -7,6 +7,7 @@ Replace Firefox's control mechanism with one modelled on VIM. This is a "Firefox
 -   You want to go to the bottom of the page? Hit `G`. Or the top? `gg`.
 -   You want to focus the text field on Wikipedia to search for another term? `gi`.
 -   Switch to the next tab? `gt`.
+-   Got trapped in a place where Tridactyl can't run? `Ctrl-,`
 -   Go back in time? `H`.
 -   Notice that this tab is rubbish and you want to close it? `d`.
 -   Regret that decision? `u` restores it.

--- a/src/background.ts
+++ b/src/background.ts
@@ -244,9 +244,15 @@ omnibox.init()
 
 // }}}
 
-browser.commands.onCommand.addListener((command_name: string) => {
-    if (command_name !== "escape_hatch") return
-    excmds_background.escapehatch()
+browser.commands.onCommand.addListener(async (command_name: string) => {
+    const commands = await browser.commands.getAll()
+    const command = commands.filter(c => c.name == command_name)[0]
+    return controller.acceptExCmd(
+        config.get(
+            "browsermaps",
+            keyseq.mozMapToMinimalKey(command.shortcut).toMapstr(),
+        ),
+    )
 })
 
 // {{{ Obey Mozilla's orders https://github.com/tridactyl/tridactyl/issues/1800

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3297,6 +3297,12 @@ export function comclear(name: string) {
 
     You can bind to other modes with `bind --mode={insert|ignore|normal|input|ex|hint} ...`, e.g, `bind --mode=insert emacs qall` (NB: unlike vim, all preceeding characters will not be input), or `bind --mode=hint <C-[> hint.reset`.
 
+    `bind --mode=browser [key sequence] [ex command]` binds to a special mode which can be accessed all the time in all browser tabs - even tabs in which Tridactyl cannot run. It comes with a few caveats:
+
+    - you may only have a few browser-mode binds at once. At the time of writing, this is 8, with 3 initially taken by Tridactyl. If you desperately need more, file an [[issue]].
+    - the key sequence must consist of a single, simple key with at least one and no more than two modifiers. An error will be thrown if you try to bind to an invalid key sequence.
+    - the `ex command` you bind to may not work fully unless you are on a tab which Tridactyl has access to. Generally, browser-wide actions like making or closing tabs will work but tab-specific actions like scrolling down or entering hint mode will not.
+
     A list of editor functions can be found
     [here](/static/docs/modules/_src_lib_editor_.html).
 

--- a/src/lib/binding.ts
+++ b/src/lib/binding.ts
@@ -50,16 +50,5 @@ export function parse_bind_args(...args: string[]): bind_args {
 
     result.excmd = args.join(" ")
 
-    // On second thought - I don't think we need this as browser.commands.update() will throw an error for us
-    //
-    // Check we have a Mozilla-compatible sequence for Commands binds
-    // TODO: check that the key is compatible too
-    // NB: +!! is a crazy way of coercing a boolean | undefined to a number
-    // if (result.mode == "browser" && (
-    //     keyseq.length > 1  ||
-    //     [+!!keyseq[0].ctrlKey, +!!keyseq[0].altKey, +!!keyseq[0].shiftKey, +!!keyseq[0].metaKey].reduce((l,r) => Number(l) + Number(r)) < 1 ||
-    //     [+!!keyseq[0].ctrlKey, +!!keyseq[0].altKey, +!!keyseq[0].shiftKey, +!!keyseq[0].metaKey].reduce((l,r) => Number(l) + Number(r)) > 2
-    // )) throw "Error: Incompatible key sequence specified for 'browser' mode binds. Use one or two modifiers with a single key, e.g. <C-.>"
-
     return result
 }

--- a/src/lib/binding.ts
+++ b/src/lib/binding.ts
@@ -45,11 +45,21 @@ export function parse_bind_args(...args: string[]): bind_args {
 
     const key = args.shift()
     // Convert key to internal representation
-    result.key = mapstrToKeyseq(key)
-        .map(k => k.toMapstr())
-        .join("")
+    const keyseq = mapstrToKeyseq(key)
+    result.key = keyseq.map(k => k.toMapstr()).join("")
 
     result.excmd = args.join(" ")
+
+    // On second thought - I don't think we need this as browser.commands.update() will throw an error for us
+    //
+    // Check we have a Mozilla-compatible sequence for Commands binds
+    // TODO: check that the key is compatible too
+    // NB: +!! is a crazy way of coercing a boolean | undefined to a number
+    // if (result.mode == "browser" && (
+    //     keyseq.length > 1  ||
+    //     [+!!keyseq[0].ctrlKey, +!!keyseq[0].altKey, +!!keyseq[0].shiftKey, +!!keyseq[0].metaKey].reduce((l,r) => Number(l) + Number(r)) < 1 ||
+    //     [+!!keyseq[0].ctrlKey, +!!keyseq[0].altKey, +!!keyseq[0].shiftKey, +!!keyseq[0].metaKey].reduce((l,r) => Number(l) + Number(r)) > 2
+    // )) throw "Error: Incompatible key sequence specified for 'browser' mode binds. Use one or two modifiers with a single key, e.g. <C-.>"
 
     return result
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -132,8 +132,6 @@ export class default_config {
         "<AC-Escape>": "mode normal",
         "<AC-`>": "mode normal",
         "<S-Escape>": "mode normal",
-        "<C-^>": "tab #",
-        "<C-6>": "tab #",
         "<C-o>": "nmode normal 1 mode ignore",
     }
 
@@ -150,8 +148,6 @@ export class default_config {
         "<C-i>": "editor",
         "<AC-Escape>": "mode normal",
         "<AC-`>": "mode normal",
-        "<C-6>": "tab #",
-        "<C-^>": "tab #",
         "<S-Escape>": "mode ignore",
     }
 
@@ -221,8 +217,6 @@ export class default_config {
         $: "scrollto 100 x",
         // "0": "scrollto 0 x", // will get interpreted as a count
         "^": "scrollto 0 x",
-        "<C-6>": "tab #",
-        "<C-^>": "tab #",
         H: "back",
         L: "forward",
         "<C-o>": "jumpprev",
@@ -381,6 +375,16 @@ export class default_config {
         "<ArrowRight>": "hint.focusRightHint",
         "<Enter>": "hint.selectFocusedHint",
         "<Space>": "hint.selectFocusedHint",
+    }
+
+    /**
+     * Browser-wide binds accessible in all modes and on pages where Tridactyl "cannot run".
+     * <!-- Note to developers: binds here need to also be listed in manifest.json -->
+     */
+    browsermaps = {
+        "<C-,>": "escapehatch",
+        "<C-6>": "tab #",
+        "<CS-6>": "tab #",
     }
 
     /**

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -24,6 +24,7 @@
 import { filter, find, izip } from "@src/lib/itertools"
 import { Parser } from "@src/lib/nearley_utils"
 import * as config from "@src/lib/config"
+import * as R from "ramda"
 import grammar from "@src/grammars/.bracketexpr.generated"
 const bracketexpr_grammar = grammar
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
@@ -347,6 +348,49 @@ export function mapstrToKeyseq(mapstr: string): MinimalKey[] {
         }
     }
     return keyseq
+}
+
+export const commandKey2jsKey = {
+    Comma: ",",
+    Period: ".",
+    Up: "ArrowUp",
+    Down: "ArrowDown",
+    Left: "ArrowLeft",
+    Right: "ArrowRight",
+}
+
+/*
+ * Convert a Commands API shortcut string to a MinimalKey. NB: no error checking done, media keys probably unsupported.
+ */
+export function mozMapToMinimalKey(mozmap: string): MinimalKey {
+    const arr = mozmap.split("+")
+    const modifiers = {
+        altKey: arr.includes("Alt"),
+        ctrlKey: arr.includes("MacCtrl"), // MacCtrl gives us _actual_ ctrl on all platforms rather than splat on Mac and Ctrl everywhere else
+        shiftKey: arr.includes("Shift"),
+        metaKey: arr.includes("Command"),
+    }
+    let key = arr[arr.length - 1]
+    key = R.propOr(key, key, commandKey2jsKey)
+    // TODO: support mediakeys: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Media_keys
+
+    return new MinimalKey(key, modifiers)
+}
+
+/*
+ * Convert a minimal key to a Commands API compatible bind. NB: no error checking done.
+ *
+ * Ctrl-key behaviour on Mac may be surprising.
+ */
+export function minimalKeyToMozMap(key: MinimalKey): string {
+    const mozMap: string[] = []
+    key.altKey && mozMap.push("Alt")
+    key.ctrlKey && mozMap.push("MacCtrl")
+    key.shiftKey && mozMap.push("Shift")
+    key.metaKey && mozMap.push("Command")
+    const jsKey2commandKey = R.invertObj(commandKey2jsKey)
+    mozMap.push(R.propOr(key.key, key.key, jsKey2commandKey))
+    return mozMap.join("+")
 }
 
 /** Convert a map of mapstrs (e.g. from config) to a KeyMap */

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -371,7 +371,7 @@ export function mozMapToMinimalKey(mozmap: string): MinimalKey {
         metaKey: arr.includes("Command"),
     }
     let key = arr[arr.length - 1]
-    key = R.propOr(key, key, commandKey2jsKey)
+    key = R.propOr(key.toLowerCase(), key, commandKey2jsKey)
     // TODO: support mediakeys: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#Media_keys
 
     return new MinimalKey(key, modifiers)
@@ -389,7 +389,7 @@ export function minimalKeyToMozMap(key: MinimalKey): string {
     key.shiftKey && mozMap.push("Shift")
     key.metaKey && mozMap.push("Command")
     const jsKey2commandKey = R.invertObj(commandKey2jsKey)
-    mozMap.push(R.propOr(key.key, key.key, jsKey2commandKey))
+    mozMap.push(R.propOr(key.key.toUpperCase(), key.key, jsKey2commandKey))
     return mozMap.join("+")
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,11 +16,38 @@
         "newtab": "static/newtab.html"
     },
     "commands": {
-        "escape_hatch": {
+        "command_1": {
             "suggested_key": {
-                "default": "Ctrl+Comma"
+                "default": "MacCtrl+Comma"
             },
-            "description": "Focus or create a tab in which Tridactyl can run"
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_2": {
+            "suggested_key": {
+                "default": "MacCtrl+6"
+            },
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_3": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here.",
+            "suggested_key": {
+                "default": "MacCtrl+Shift+6"
+            }
+        },
+        "command_4": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_5": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_6": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_7": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
+        },
+        "command_8": {
+            "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
         }
     },
     "content_scripts": [

--- a/src/static/clippy/2-normal_mode.md
+++ b/src/static/clippy/2-normal_mode.md
@@ -12,23 +12,34 @@ Many keypresses in normal mode take you into another mode. `t`, for example, put
 
 ## Useful normal mode keybinds
 
-*   `b` brings up a list of your current tabs. Press `Tab`/`Shift-Tab` to cycle through them and enter to select. You can also type to filter down the tabs based on their titles and URLs
-*   Opening web pages:
-    *   `w` opens URLs in new windows
-    *   `o` in the current tab
-    *   `t` in a new tab
-    *   Using a capital letter in place of any of the previous commands opens the command with the current URL pasted into it, i.e, `W`,`O`,`T`
-    *   `s` lets you search easily
-    *   in general, you can search many search engines straight from these prompts by simply starting your query with the search engine, such as `bing` `duckduckgo` or `scholar`
-*   Navigate history with `H` and `L`
-*   `yy` copies the current URL to your clipboard
-*   `p` opens the clipboard contents as a web page, or searches for it, in the current tab. `P` opens it in a new tab
-    *   Protip: quickly search for the source of a quote by using `;p` to copy a paragraph, and `P` to search the internet for it
-*   `zi`,`zo`,`zz` zoom in, out and return to the default zoom
-*   Search text with Firefox's standard `/` binding, jump from match to match with `<C-g>` or `<C-G>` (note that it isn't possible to rebind searching/jumping between matches for now). If you want to use Firefox's `<C-f>` search you'll have to run `unbind <C-f>`.
--   `<C-v>` sends the next keystroke to the current website, bypassing bindings
+-   `b` brings up a list of your current tabs. Press `Tab`/`Shift-Tab` to cycle through them and enter to select. You can also type to filter down the tabs based on their titles and URLs
+-   Opening web pages:
+    -   `w` opens URLs in new windows
+    -   `o` in the current tab
+    -   `t` in a new tab
+    -   Using a capital letter in place of any of the previous commands opens the command with the current URL pasted into it, i.e, `W`,`O`,`T`
+    -   `s` lets you search easily
+    -   in general, you can search many search engines straight from these prompts by simply starting your query with the search engine, such as `bing` `duckduckgo` or `scholar`
+-   Navigate history with `H` and `L`
+-   `yy` copies the current URL to your clipboard
+-   `p` opens the clipboard contents as a web page, or searches for it, in the current tab. `P` opens it in a new tab
+    -   Protip: quickly search for the source of a quote by using `;p` to copy a paragraph, and `P` to search the internet for it
+-   `zi`,`zo`,`zz` zoom in, out and return to the default zoom
+-   Search text with Firefox's standard `/` binding, jump from match to match with `<C-g>` or `<C-G>` (note that it isn't possible to rebind searching/jumping between matches for now). If you want to use Firefox's `<C-f>` search you'll have to run `unbind <C-f>`.
+
+*   `<C-v>` sends the next keystroke to the current website, bypassing bindings
 
 All the keys in normal mode are bound to commands; for example, `j` is bound to `scrolline 10`. If you are ever curious as to what a key sequence does in normal mode, you can simply use `:bind [keys]` and the command line will tell you to which command they are bound.
+
+## Browser-wide binds
+
+By default, there are three browser "mode" binds: `<C-,>` to `:escapehatch`, and `<C-6>` and `<CS-6>` to `:tab #`. These binds are accessible in all modes and anywhere within Firefox - even on pages where Tridactyl cannot run. New browser mode binds can be added with `:bind --mode=browser [ex command]`. Note that any ex-commands which require access to the page you are on will fail to run if Tridactyl does not have access to that page. The best thing to do is to try it and see.
+
+There are quite a few caveats with these binds - see `:help bind` for more details.
+
+Unbind the binds with `unbind --mode=browser [key]`.
+
+---
 
 The [next page](./3-hint_mode.html) will explain how to use some of the various hint modes. This time try `]]` (guess the next page) to follow the link.
 

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -29,8 +29,8 @@ REPLACE_ME_WITH_THE_CHANGE_LOG_USING_SED
 -   `t`/`T` — open a URL in a new tab (`T` to pre-load current URL).
 -   `gt`/`gT` — go to the next/previous tab.
 -   `d` — close the current tab.
+-   `<C-,>` — "escape hatch": get to a place where you can use Tridactyl. Works anywhere in the browser.
 -   `/` — open the find search box. Use <kbd>ctrl</kbd> + g/G to cycle through search results.
--   `A` — bookmark the current page
 -   `b` — bring up a list of open tabs in the current window.
 -   `s` — if you want to search for something that looks like a domain name or URL.
 -   `gi` — scroll to and focus the last-used input on the page.

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -4,7 +4,7 @@
 
 Tridactyl has to override your new tab page due to WebExtension limitations. You can learn how to change it at the bottom of the page, otherwise please read on for some tips and tricks.
 
--   _Breaking change_: when you select text in normal mode, you will now enter our experimental visual mode. Press `<Esc>` to leave it. `:set visualenterauto false` to disable it.
+-   _Breaking change_: `<C-6>` and `<CS-6>` now work browser-wide. If you have previously unbound them, you'll need to unbind them again with `unbind --mode=browser <C-6>`, etc.
 
 -   You can view the main help page by typing [`:help`][help], and access the tutorial with [`:tutor`][tutor]. There's a [wiki](https://github.com/tridactyl/tridactyl/wiki) too - feel free to add to it. You may find `:apropos` useful for finding relevant settings and commands.
 

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -214,3 +214,8 @@ declare namespace jest {
         toBeAll: any
     }
 }
+
+// jest-webextension-mock doesn't know about this Firefox specific API
+declare namespace browser.commands {
+    function update(details)
+}


### PR DESCRIPTION
Fixes #2576

Todo:

- [x] unbind
- [x] implement mapstrToMozMap in bind
- [x] docs (probably room for improvement, esp to explain how to unbind Ctrl+6 and the background ex-command weirdness)
- [ ] read from config and set `browser.commands.update` at startup to ensure sync between browsers?

Limitations:
- can have at most N binds active at the same time
- can only use background ex-strings on inaccessible pages which do not internally call content ex-commands - not sure how to tell users which is which other than "use common sense" + "trial and error" (edit: after more thought this isn't true - it's ex-commands that are and only call background ex-commands unless you know that you are on a tab where Tridactyl can run and then they can call content ex-commands)
- binds must be Mozilla/Chromium approved - need one or two modifiers (no more, no less) and a reasonably vanilla key.
- if users change a bind in "Manage extension shortcuts", behaviour is undefined