### PR TITLE
Throw errors with throw new Error("string") rather than throw "string"

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -342,7 +342,7 @@ export async function setClipboard(content: string) {
         if (document.execCommand("Copy")) {
             // // todo: Maybe we can consider to using some logger and show it with status bar in the future
             logger.info("set clipboard:", scratchpad.value)
-        } else throw "Failed to copy!"
+        } else throw new Error("Failed to copy!")
     })
     // Return focus to the document
     await Messaging.messageOwnTab("commandline_content", "hide")

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -352,7 +352,7 @@ export async function editor() {
             logger.debug(`Editor terminated with non-zero exit code: ${exec.code}`)
         }
     } catch (e) {
-        throw `:editor failed: ${e}`
+        throw new Error(`:editor failed: ${e}`)
     } finally {
         return removeTridactylEditorClass(selector)
     }
@@ -582,7 +582,7 @@ export async function nativeopen(...args: string[]) {
         try {
             if ((await browser.runtime.getPlatformInfo()).os === "mac") {
                 if ((await browser.windows.getCurrent()).incognito) {
-                    throw "nativeopen isn't supported in private mode on OSX. Consider installing Linux or Windows :)."
+                    throw new Error("nativeopen isn't supported in private mode on OSX. Consider installing Linux or Windows :).")
                 }
                 const osascriptArgs = ["-e 'on run argv'", "-e 'tell application \"Firefox\" to open location item 1 of argv'", "-e 'end run'"]
                 await Native.run("osascript " + osascriptArgs.join(" ") + " " + url)
@@ -2396,7 +2396,7 @@ export async function tabclose(...indexes: string[]) {
 //#background
 export async function tabcloseallto(side: string) {
     if (!["left", "right"].includes(side)) {
-        throw "side argument must be left or right"
+        throw new Error("side argument must be left or right")
     }
     const tabs = await browser.tabs.query({
         pinned: false,
@@ -3250,7 +3250,7 @@ export function command(name: string, ...definition: string[]) {
         return config.set("exaliases", name, def)
     } catch (e) {
         config.unset("exaliases", name)
-        throw `Alias not set. ${e}`
+        throw new Error(`Alias not set. ${e}`)
     }
 }
 
@@ -3366,7 +3366,7 @@ export function keymap(source: string, target: string) {
  */
 //#background
 export function searchsetkeyword() {
-    throw ":searchsetkeyword has been deprecated. Use `set searchurls.KEYWORD URL` instead."
+    throw new Error(":searchsetkeyword has been deprecated. Use `set searchurls.KEYWORD URL` instead.")
 }
 
 /**
@@ -3397,7 +3397,7 @@ function validateSetArgs(key: string, values: string[]) {
         } else if (currentValue === undefined || typeof currentValue === "string") {
             value = values.join(" ")
         } else {
-            throw "Unsupported setting type!"
+            throw new Error("Unsupported setting type!")
         }
     }
 
@@ -3429,7 +3429,7 @@ export function seturl(pattern: string, key: string, ...values: string[]) {
     }
 
     if (!pattern || !key || !values.length) {
-        throw "seturl syntax: [pattern] key value"
+        throw new Error("seturl syntax: [pattern] key value")
     }
 
     return config.setURL(pattern, ...validateSetArgs(key, values))
@@ -3452,7 +3452,7 @@ export function seturl(pattern: string, key: string, ...values: string[]) {
 //#background
 export function set(key: string, ...values: string[]) {
     if (!key) {
-        throw "Key must be provided!"
+        throw new Error("Key must be provided!")
     } else if (!values[0]) {
         return get(key)
     }
@@ -3465,7 +3465,7 @@ export function set(key: string, ...values: string[]) {
         values.forEach(url => seturl(url, "noiframe", "true"))
         // save as deprecated setting for compatibility
         config.set("noiframeon", values)
-        throw "Warning: `noiframeon $url1 $url2` has been deprecated in favor of `:seturl $url1 noiframe true`. The right seturl calls have been made for you but from now on please use `:seturl`."
+        throw new Error("Warning: `noiframeon $url1 $url2` has been deprecated in favor of `:seturl $url1 noiframe true`. The right seturl calls have been made for you but from now on please use `:seturl`.")
     }
 
     if (key === "csp" && values[0] === "clobber") {
@@ -3849,7 +3849,7 @@ export function unseturl(pattern: string, key: string) {
 //#background
 export function unset(...keys: string[]) {
     const target = keys.join(".").split(".")
-    if (target === undefined) throw "You must define a target!"
+    if (target === undefined) throw new Error("You must define a target!")
     return config.unset(...target)
 }
 
@@ -3859,7 +3859,7 @@ export function unset(...keys: string[]) {
 //#background
 export function setnull(...keys: string[]) {
     const target = keys.join(".").split(".")
-    if (target === undefined) throw "You must define a target!"
+    if (target === undefined) throw new Error("You must define a target!")
     return config.set(...target, null)
 }
 
@@ -4347,10 +4347,10 @@ export async function ttsread(mode: "-t" | "-c", ...args: string[]) {
         if (args.length > 0) {
             tssReadFromCss(args[0])
         } else {
-            throw "Error: no CSS selector supplied"
+            throw new Error("Error: no CSS selector supplied")
         }
     } else {
-        throw "Unknown mode for ttsread command: " + mode
+        throw new Error("Unknown mode for ttsread command: " + mode)
     }
 }
 

--- a/src/lib/aliases.ts
+++ b/src/lib/aliases.ts
@@ -21,7 +21,9 @@ export function expandExstr(
 
     // Infinite loop detected
     if (prevExpansions.includes(command)) {
-        throw `Infinite loop detected while expanding aliases. Stack: ${prevExpansions}.`
+        throw new Error(
+            `Infinite loop detected while expanding aliases. Stack: ${prevExpansions}.`,
+        )
     }
 
     // Add command to expansions used so far

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1271,7 +1271,7 @@ export function setURL(pattern, ...args) {
  */
 export async function set(...args) {
     if (args.length < 2) {
-        throw "You must provide at least two arguments!"
+        throw new Error("You must provide at least two arguments!")
     }
 
     const target = args.slice(0, args.length - 1)

--- a/src/lib/convert.ts
+++ b/src/lib/convert.ts
@@ -1,11 +1,11 @@
 export function toBoolean(s: string) {
     if (s === "true") return true
     else if (s === "false") return false
-    else throw "Not a boolean"
+    else throw new Error("Not a boolean")
 }
 
 export function toNumber(s: string) {
     const n = Number(s)
-    if (isNaN(n)) throw "Not a number! " + s
+    if (isNaN(n)) throw new Error("Not a number! " + s)
     else return n
 }

--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -84,7 +84,7 @@ export async function getNativeMessengerVersion(
     const res = await sendNativeMsg("version", {}, quiet)
     if (res === undefined) {
         if (quiet) return undefined
-        throw `Error retrieving version: ${res.error}`
+        throw new Error(`Error retrieving version: ${res.error}`)
     }
     if (res.version && !res.error) {
         logger.info(`Native version: ${res.version}`)
@@ -277,43 +277,45 @@ export async function editor(
 
 export async function read(file: string) {
     return sendNativeMsg("read", { file }).catch(e => {
-        throw `Failed to read ${file}. ${e}`
+        throw new Error(`Failed to read ${file}. ${e}`)
     })
 }
 
 export async function write(file: string, content: string) {
     return sendNativeMsg("write", { file, content }).catch(e => {
-        throw `Failed to write '${content}' to '${file}'. ${e}`
+        throw new Error(`Failed to write '${content}' to '${file}'. ${e}`)
     })
 }
 
 export async function writerc(file: string, force: boolean, content: string) {
     return sendNativeMsg("writerc", { file, force, content }).catch(e => {
-        throw `Failed to write '${content}' to '${file}'. ${e}`
+        throw new Error(`Failed to write '${content}' to '${file}'. ${e}`)
     })
 }
 
 export async function mkdir(dir: string, exist_ok: boolean) {
     return sendNativeMsg("mkdir", { dir, exist_ok }).catch(e => {
-        throw `Failed to create directory '${dir}'. ${e}`
+        throw new Error(`Failed to create directory '${dir}'. ${e}`)
     })
 }
 
 export async function temp(content: string, prefix: string) {
     return sendNativeMsg("temp", { content, prefix }).catch(e => {
-        throw `Failed to write '${content}' to temp file '${prefix}'. ${e}`
+        throw new Error(
+            `Failed to write '${content}' to temp file '${prefix}'. ${e}`,
+        )
     })
 }
 
 export async function move(from: string, to: string) {
     return sendNativeMsg("move", { from, to }).catch(e => {
-        throw `Failed to move '${from}' to '${to}'. ${e}.`
+        throw new Error(`Failed to move '${from}' to '${to}'. ${e}.`)
     })
 }
 
 export async function listDir(dir: string) {
     return sendNativeMsg("list_dir", { path: dir }).catch(e => {
-        throw `Failed to read directory '${dir}'. ${e}`
+        throw new Error(`Failed to read directory '${dir}'. ${e}`)
     })
 }
 
@@ -324,7 +326,9 @@ export async function winFirefoxRestart(
     const required_version = "0.1.6"
 
     if (!(await nativegate(required_version, false))) {
-        throw `'restart' on Windows needs native messenger version >= ${required_version}.`
+        throw new Error(
+            `'restart' on Windows needs native messenger version >= ${required_version}.`,
+        )
     }
 
     return sendNativeMsg("win_firefox_restart", { profiledir, browsercmd })
@@ -347,7 +351,9 @@ export async function getenv(variable: string) {
     const required_version = "0.1.2"
 
     if (!(await nativegate(required_version, false))) {
-        throw `'getenv' needs native messenger version >= ${required_version}.`
+        throw new Error(
+            `'getenv' needs native messenger version >= ${required_version}.`,
+        )
     }
 
     return (await sendNativeMsg("env", { var: variable })).content
@@ -411,7 +417,9 @@ export async function clipboard(
 export async function ff_cmdline(): Promise<string[]> {
     // Using ' and + rather that ` because we don't want newlines
     if ((await browserBg.runtime.getPlatformInfo()).os === "win") {
-        throw `Error: "ff_cmdline() is currently broken on Windows and should be avoided."`
+        throw new Error(
+            `Error: "ff_cmdline() is currently broken on Windows and should be avoided."`,
+        )
     } else {
         const output = await pyeval(
             'handleMessage({"cmd": "run", ' +

--- a/src/lib/nearley_utils.ts
+++ b/src/lib/nearley_utils.ts
@@ -24,7 +24,7 @@ export class Parser {
         } finally {
             this.reset()
             if (lastResult === undefined) {
-                throw "Error: no result!"
+                throw new Error("Error: no result!")
             } else {
                 return [lastResult, input.slice(consumedIndex)]
             }

--- a/src/parsers/exmode.ts
+++ b/src/parsers/exmode.ts
@@ -70,7 +70,7 @@ export function parser(exstr: string, all_excmds: any): any[] {
 
     if (excmds[funcName] === undefined) {
         logger.error("Not an excmd:", exstr)
-        throw `Not an excmd: ${func}`
+        throw new Error(`Not an excmd: ${func}`)
     }
 
     return [excmds[funcName], converted_args]

--- a/src/state.ts
+++ b/src/state.ts
@@ -51,7 +51,9 @@ const state = new Proxy(overlay, {
     /** Give defaults if overlay doesn't have the key */
     get(target, property) {
         if (notBackground())
-            throw "State object must be accessed with getAsync in content"
+            throw new Error(
+                "State object must be accessed with getAsync in content",
+            )
         if (property in target) {
             return target[property]
         } else {
@@ -111,7 +113,10 @@ notBackground &&
             state[property] = value
         } else if (message.command == "stateGet") {
             sendResponse(state[message.args[0].prop])
-        } else throw "Unsupported message to state, type " + message.command
+        } else
+            throw new Error(
+                "Unsupported message to state, type " + message.command,
+            )
     })
 
 export { state as default }


### PR DESCRIPTION
Fix issue https://github.com/tridactyl/tridactyl/issues/2580.

Change all occurrences of `throw "string"` or `` throw `string` `` in the src directory and all of its sub-directories to `throw new Error("string")` or `` throw new Error(`string`) `` respectively.