### PR TITLE
<S-Del> closes highlighted tab in tab/taball commandline_frame

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -80,6 +80,12 @@ browser.tabs.onActivated.addListener(ev => {
         }
     })
 })
+
+// If a tab is deleted notify all tabs
+browser.tabs.onRemoved.addListener(tabId => {
+    messaging.messageAllTabs("tab_changes", "tabclose", [tabId])
+})
+
 // Update on navigation too (but remember that sometimes people open tabs in the background :) )
 browser.webNavigation.onDOMContentLoaded.addListener(() => {
     browser.tabs.query({ currentWindow: true, active: true }).then(t => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -81,9 +81,27 @@ browser.tabs.onActivated.addListener(ev => {
     })
 })
 
-// If a tab is deleted notify all tabs
-browser.tabs.onRemoved.addListener(tabId => {
-    messaging.messageAllTabs("tab_changes", "tabclose", [tabId])
+/**
+ * Declare Tab Event Listeners
+ */
+browser.tabs.onRemoved.addListener((tabId) => {
+    messaging.messageAllTabs("tab_changes", "tab_close", [tabId])
+})
+// Fired when a tab is attached to a window, for example because it was moved between windows.
+browser.tabs.onAttached.addListener((tabId) => {
+    messaging.messageAllTabs("tab_changes", "tab_attached", [tabId])
+})
+// Fired when a tab is created. Note that the tab's URL may not be set at the time this event fired.
+browser.tabs.onCreated.addListener((tabId) => {
+    messaging.messageAllTabs("tab_changes", "tab_created", [tabId])
+})
+// Fired when a tab is detached from a window, for example because it is being moved between windows.
+browser.tabs.onDetached.addListener((tabId) => {
+    messaging.messageAllTabs("tab_changes", "tab_detached", [tabId])
+})
+// Fired when a tab is moved within a window.
+browser.tabs.onMoved.addListener((tabId) => {
+    messaging.messageAllTabs("tab_changes", "tab_moved", [tabId])
 })
 
 // Update on navigation too (but remember that sometimes people open tabs in the background :) )

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -194,7 +194,7 @@ commandline_state.clInput.addEventListener(
                 if (args.length === 0) {
                     commandline_state.fns[funcname]()
                 } else {
-                    commandline_state.fns[funcname](args)
+                    commandline_state.fns[funcname](args.join(" "))
                 }
 
                 prev_cmd_called_history = history_called

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -189,8 +189,14 @@ commandline_state.clInput.addEventListener(
             // This is definitely a hack. Should expand aliases with exmode, etc.
             // but this whole thing should be scrapped soon, so whatever.
             if (response.value.startsWith("ex.")) {
-                const funcname = response.value.slice(3)
-                commandline_state.fns[funcname]()
+                const [funcname, ...args] = response.value.slice(3).split(/\s+/)
+
+                if (args.length === 0) {
+                    commandline_state.fns[funcname]()
+                } else {
+                    commandline_state.fns[funcname](args)
+                }
+
                 prev_cmd_called_history = history_called
             } else {
                 // Send excmds directly to our own tab, which fixes the

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -91,12 +91,12 @@ function resizeArea() {
  * This is a bit loosely defined at the moment.
  * Should work so long as there's only one completion source per prefix.
  */
-function getCompletion() {
+function getCompletion(args_only = false) {
     if (!commandline_state.activeCompletions) return undefined
 
     for (const comp of commandline_state.activeCompletions) {
         if (comp.state === "normal" && comp.completion !== undefined) {
-            return comp.completion
+            return args_only ? comp.args : comp.completion
         }
     }
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -35,6 +35,7 @@ export abstract class CompletionSource {
     readonly options: CompletionOption[]
     node: HTMLElement
     public completion: string
+    public args: string
     protected prefixes: string[] = []
     protected lastFocused: CompletionOption
     private _state: OptionState
@@ -221,6 +222,7 @@ export abstract class CompletionSourceFuse extends CompletionSource {
         if (this.lastExstr !== undefined && option !== undefined) {
             const [prefix] = this.splitOnPrefix(this.lastExstr)
             this.completion = prefix + option.value
+            this.args = option.value
             option.state = "focused"
             this.lastFocused = option
         } else {

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -1,7 +1,8 @@
 import { messageOwnTab } from "@src/lib/messaging"
 import * as State from "@src/state"
 
-export function getCommandlineFns(cmdline_state) {
+// One day we'll use typeof commandline_state from commandline_frame.ts
+export function getCommandlineFns(cmdline_state: { [otherStuff: string]: any, fns: ReturnType<typeof getCommandlineFns> }) {
     return {
         /**
          * Insert the first command line history line that starts with the content of the command line in the command line.

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -179,16 +179,9 @@ export function getCommandlineFns(cmdline_state: {
             return messageOwnTab("controller_content", "acceptExCmd", [command])
         },
 
-        execute_ex_on_completion_args: (excmd: string) => {
-            const args = cmdline_state.getCompletion(true)
+        execute_ex_on_completion_args: (excmd: string) => execute_ex_on_x(true, cmdline_state, excmd),
 
-            const cmdToExec = excmd + " " + args
-            cmdline_state.fns.store_ex_string(cmdToExec)
-
-            return messageOwnTab("controller_content", "acceptExCmd", [
-                cmdToExec,
-            ])
-        },
+        execute_ex_on_completion: (excmd: string) => execute_ex_on_x(false, cmdline_state, excmd),
 
         copy_completion: () => {
             const command = cmdline_state.getCompletion()
@@ -198,4 +191,15 @@ export function getCommandlineFns(cmdline_state: {
             ])
         },
     }
+}
+
+function execute_ex_on_x(args_only: boolean, cmdline_state, excmd: string){
+    const args = cmdline_state.getCompletion(args_only) || cmdline_state.clInput.value
+
+    const cmdToExec = (excmd ? excmd : "") + " " + args
+    cmdline_state.fns.store_ex_string(cmdToExec)
+
+    return messageOwnTab("controller_content", "acceptExCmd", [
+        cmdToExec,
+    ])
 }

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -2,7 +2,10 @@ import { messageOwnTab } from "@src/lib/messaging"
 import * as State from "@src/state"
 
 // One day we'll use typeof commandline_state from commandline_frame.ts
-export function getCommandlineFns(cmdline_state: { [otherStuff: string]: any, fns: ReturnType<typeof getCommandlineFns> }) {
+export function getCommandlineFns(cmdline_state: {
+    [otherStuff: string]: any
+    fns: ReturnType<typeof getCommandlineFns>
+}) {
     return {
         /**
          * Insert the first command line history line that starts with the content of the command line in the command line.
@@ -160,7 +163,8 @@ export function getCommandlineFns(cmdline_state: { [otherStuff: string]: any, fn
 
             cmdline_state.fns.hide_and_clear()
 
-            if (cmdline_state.fns.is_valid_commandline(command) === false) return
+            if (cmdline_state.fns.is_valid_commandline(command) === false)
+                return
 
             cmdline_state.fns.store_ex_string(command)
 
@@ -175,26 +179,15 @@ export function getCommandlineFns(cmdline_state: { [otherStuff: string]: any, fn
             return messageOwnTab("controller_content", "acceptExCmd", [command])
         },
 
-        execute_ex_on_completion: (excmd: string) => {
-            const command = cmdline_state.getCompletion()
+        execute_ex_on_completion_args: (excmd: string) => {
+            const args = cmdline_state.getCompletion(true)
 
-            if (cmdline_state.fns.is_valid_commandline(command) === false) return
-
-            const args = command.trim().split(/\s+/)
-            args.shift()
-
-            let cmdToExec
-            if (excmd === "tabclose" && args.length !== 0) {
-                // Drop "tab" because "tabclose tab \d+" fails
-                // but "tabclose \d+" succeeds
-                cmdToExec = excmd + " " + args.join(" ")
-            } else {
-                cmdToExec = excmd + " " + command
-            }
-
+            const cmdToExec = excmd + " " + args
             cmdline_state.fns.store_ex_string(cmdToExec)
 
-            return messageOwnTab("controller_content", "acceptExCmd", [cmdToExec])
+            return messageOwnTab("controller_content", "acceptExCmd", [
+                cmdToExec,
+            ])
         },
 
         copy_completion: () => {

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -177,8 +177,6 @@ export function getCommandlineFns(cmdline_state) {
         execute_ex_on_completion: (excmd: string) => {
             const command = cmdline_state.getCompletion()
 
-            cmdline_state.fns.hide_and_clear()
-
             if (cmdline_state.fns.is_valid_commandline(command) === false) return
 
             const args = command.trim().split(/\s+/)
@@ -186,11 +184,11 @@ export function getCommandlineFns(cmdline_state) {
 
             let cmdToExec
             if (excmd === "tabclose" && args.length !== 0) {
-              // Drop "tab" because "tabclose tab \d+" fails
-              // but "tabclose \d+" succeeds
-              cmdToExec = excmd + " " + args.join(" ")
+                // Drop "tab" because "tabclose tab \d+" fails
+                // but "tabclose \d+" succeeds
+                cmdToExec = excmd + " " + args.join(" ")
             } else {
-              cmdToExec = excmd + " " + command
+                cmdToExec = excmd + " " + command
             }
 
             cmdline_state.fns.store_ex_string(cmdToExec)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -122,7 +122,7 @@ export class default_config {
         "<S-Tab>": "ex.prev_completion",
         "<Space>": "ex.insert_space_or_completion",
 
-        "<C-o>yy": "ex.copy_completion",
+        "<C-o>yy": "ex.execute_ex_on_completion clipboard yank",
     }
 
     /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -105,6 +105,7 @@ export class default_config {
         "<Escape>": "ex.hide_and_clear",
         "<ArrowUp>": "ex.prev_history",
         "<ArrowDown>": "ex.next_history",
+        "<S-Del>": "ex.execute_ex_on_completion tabclose",
 
         "<A-b>": "text.backward_word",
         "<A-f>": "text.forward_word",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -105,7 +105,7 @@ export class default_config {
         "<Escape>": "ex.hide_and_clear",
         "<ArrowUp>": "ex.prev_history",
         "<ArrowDown>": "ex.next_history",
-        "<S-Del>": "ex.execute_ex_on_completion tabclose",
+        "<S-Del>": "ex.execute_ex_on_completion_args tabclose",
 
         "<A-b>": "text.backward_word",
         "<A-f>": "text.forward_word",
@@ -122,7 +122,7 @@ export class default_config {
         "<S-Tab>": "ex.prev_completion",
         "<Space>": "ex.insert_space_or_completion",
 
-        "<C-o>yy": "ex.execute_ex_on_completion clipboard yank",
+        "<C-o>yy": "ex.execute_ex_on_completion_args clipboard yank",
     }
 
     /**
@@ -1082,14 +1082,16 @@ const platform_defaults = {
     },
 } as Record<browser.runtime.PlatformOs, default_config>
 
-
 /** @hidden
  * Merges two objects and removes all keys with null values at all levels
  */
 export const mergeDeepCull = R.pipe(mergeDeep, removeNull)
 
 /** @hidden */
-export const DEFAULTS = mergeDeepCull(o(new default_config()), platform_defaults[platform.getPlatformOs()])
+export const DEFAULTS = mergeDeepCull(
+    o(new default_config()),
+    platform_defaults[platform.getPlatformOs()],
+)
 
 /** Given an object and a target, extract the target if it exists, else return undefined
 
@@ -1523,7 +1525,11 @@ export async function update() {
             unset("autocontain")
             if (autocontain !== undefined) {
                 Object.entries(autocontain).forEach(([domain, container]) => {
-                    set("autocontain", `^https?://([^/]*\\.|)*${domain}/`, container)
+                    set(
+                        "autocontain",
+                        `^https?://([^/]*\\.|)*${domain}/`,
+                        container,
+                    )
                 })
             }
             set("configversion", "1.8")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -100,6 +100,7 @@ export class default_config {
      */
     exmaps = {
         "<Enter>": "ex.accept_line",
+        "<C-Enter>": "ex.execute_ex_on_completion",
         "<C-j>": "ex.accept_line",
         "<C-m>": "ex.accept_line",
         "<Escape>": "ex.hide_and_clear",

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -14,6 +14,7 @@ export type TabMessageType =
     | "state"
     | "lock"
     | "alive"
+    | "tab_changes"
 
 export type NonTabMessageType =
     | "owntab_background"


### PR DESCRIPTION
Resolve Issue: https://github.com/tridactyl/tridactyl/issues/1815

`<S-Del>` in the "Tabs" an "All Tabs" buffer closes the highlighted tab and the commandline frame closes.  

The usefulness of this command is limited because if the users wishes to close multiple tabs in the Tab / All Tabs buffer, then the user needs to reopen the tab buffer (`b` or `B`) after each `<S-Del>` command.  

I can update the PR for the commandline frame to persist, if desirable.

