### PR TITLE
Abandon automatic sync with Firefox Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
     -   `<C-,>` browser-wide bind added to new ex-command, `:escapehatch` which returns focus to the page and returns you to a tab where Tridactyl can run.
     -   User-configurable browser-wide binds added with lots of caveats. See `:help bind` and `:bind --mode=browser` for more details.
-        -   `<C-6>` and `<CS-6>` are now bound to `:tab #` browser-wide.
+        -   `<C-6>` and `<CS-6>` are now bound to `:tab #` browser-wide, except on Windows, where the previous behaviour remains, with a new `<A-6>` bind instead.
     -   Autocommands now support `WebRequest` events - see `:help autocmd` for more details. Particularly useful for e.g. redirecting sites.
     -   Callback hintmode on `hint -F` added for running arbitrary JS on an element you select. ([#2552](https://github.com/tridactyl/tridactyl/issues/2552))
     -   `:blacklistdelete` alias added as the inverse of `:blacklistadd`
@@ -18,9 +18,20 @@
     -   `:tabopen` now never puts focus in the address bar ([#2490](https://github.com/tridactyl/tridactyl/issues/2490))
     -   The little pop-up telling you the address of a link you are hovering over is now hidden when the command line is opened ([#1896](https://github.com/tridactyl/tridactyl/issues/1896))
     -   `:tabopen -c firefox-default` opens a new tab in the default container (handy with `set tabopencontaineraware true`)
+    -   `<S-Delete>` closes the tab corresponding to the highlighted completion in the commandline ([#2617](https://github.com/tridactyl/tridactyl/issues/2617))
+    -   `<C-Enter>` executes the highlighted completion and keeps the window open (useful for, e.g. `:winopen` or `:tabopen -b`)
+    -   `:set downloadsskiphistory true` prevents downloads via Tridactyl (e.g. `;s` hint mode) from being stored in your download history
+        -   NB: Tridactyl must be allowed to run in private mode for this to work
+    -   `:autocontain -s [url] [container]` added with a bug fix - `:autocontain` with no flags is deprecated ([#2629](https://github.com/tridactyl/tridactyl/issues/2629))
+
+-   Removed features
+-   We no longer use Firefox sync automatically ([#2665](https://github.com/tridactyl/tridactyl/issues/2665))
+    -   Use `:firefoxsync{push,pull}` to synchronise manually if you wish
+-   Broken setting `newtabfocus` removed ([#2632](https://github.com/tridactyl/tridactyl/issues/2632))
 
 -   Bug fixes
 
+    -   `:tabopen` works again in FF80+ ([#2695](https://github.com/tridactyl/tridactyl/issues/2695))
     -   Scrolling should now work on more pages ([#2583](https://github.com/tridactyl/tridactyl/issues/2583))
     -   Some errors should be more informative ([#2585](https://github.com/tridactyl/tridactyl/issues/2585))
     -   Ex-aliases now have correct help text in completions ([#2483](https://github.com/tridactyl/tridactyl/issues/2483))
@@ -28,6 +39,10 @@
     -   Pressing `<Tab>` in completions is now a bit more reliable (but not much :))
     -   `:find` now works in private windows ([#2520](https://github.com/tridactyl/tridactyl/issues/2520))
     -   `:containerdelete` with no arguments is now a no-op ([#2239](https://github.com/tridactyl/tridactyl/issues/2239))
+    -   `insert` mode now works better on some sites ([#2696](https://github.com/tridactyl/tridactyl/issues/2696))
+    -   `text.` functions are now more readline compliant ([#2679](https://github.com/tridactyl/tridactyl/issues/2679))
+    -   Form labels may now be clicked ([#2646](https://github.com/tridactyl/tridactyl/issues/2646))
+    -   `yy` should no longer give spurious errors ([#1239](https://github.com/tridactyl/tridactyl/issues/1239))
 
 -   Miscellaneous
 
@@ -35,6 +50,9 @@
     -   Our E2E tests now actually work most of the time
     -   Unit tests for our excmds added ([#2449](https://github.com/tridactyl/tridactyl/issues/2449))
     -   There should be slightly less latency on keypresses ([#2440](https://github.com/tridactyl/tridactyl/issues/2440))
+    -   Our settings tutorial is slightly more comprehensive ([#2465](https://github.com/tridactyl/tridactyl/issues/2465))
+    -   Default settings can now be platform specific ([#2664](https://github.com/tridactyl/tridactyl/issues/2664))
+    -   It is now easier to replicate CI tests locally ([#2591](https://github.com/tridactyl/tridactyl/issues/2591))
 
 ## Release 1.19.1 / 29-05-2020
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -269,6 +269,9 @@ omnibox.init()
 
 // }}}
 
+
+setTimeout(config.update, 5000)
+
 commands.updateListener()
 
 // {{{ Obey Mozilla's orders https://github.com/tridactyl/tridactyl/issues/1800

--- a/src/background.ts
+++ b/src/background.ts
@@ -270,7 +270,7 @@ omnibox.init()
 // }}}
 
 
-setTimeout(config.update, 500)
+setTimeout(config.update, 5000)
 
 commands.updateListener()
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -270,7 +270,7 @@ omnibox.init()
 // }}}
 
 
-setTimeout(config.update, 5000)
+setTimeout(config.update, 500)
 
 commands.updateListener()
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3485,6 +3485,32 @@ export function set(key: string, ...values: string[]) {
     return config.set(...validateSetArgs(key, values))
 }
 
+/**
+ * Replaces your local configuration with that stored in the Firefox Sync area.
+ *
+ * It does not merge your configurations: it overwrites.
+ *
+ * Also see [[firefoxsyncpush]].
+ */
+//#background
+export function firefoxsyncpull() {
+    return config.pull()
+}
+
+/**
+ * Pushes your local configuration to the Firefox Sync area.
+ *
+ * It does not merge your configurations: it overwrites.
+ *
+ * NB: [[unset]] and [[reset]] settings cannot be synchronised. You may instead use [[sanitise]]: `sanitise tridactylsync` then `firefoxsyncpush`.
+ *
+ * Also see [[firefoxsyncpull]].
+ */
+//#background
+export function firefoxsyncpush() {
+    return config.push()
+}
+
 /** @hidden */
 //#background_helper
 const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLeft", "FullscreenChange", "FullscreenEnter", "FullscreenLeft"].concat(webrequests.requestEvents)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3502,8 +3502,6 @@ export function firefoxsyncpull() {
  *
  * It does not merge your configurations: it overwrites.
  *
- * NB: [[unset]] and [[reset]] settings cannot be synchronised. You may instead use [[sanitise]]: `sanitise tridactylsync` then `firefoxsyncpush`.
- *
  * Also see [[firefoxsyncpull]].
  */
 //#background

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1767,7 +1767,6 @@ browser.storage.onChanged.addListener((changes, areaname) => {
         }
 
         if (areaname === "sync") {
-            // storageloc=local means ignoring changes that aren't set by us
             // Probably do something here with push/pull?
         } else if (newValue !== undefined) {
             // A key has been :unset if it exists in USERCONFIG and doesn't in changes and if its value in USERCONFIG is different from the one it has in default_config

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1553,8 +1553,8 @@ export async function update() {
             set("configversion", "1.9")
         }
         case "1.9": {
-            const local = (await browser.storage.local.get(CONFIGNAME))[CONFIGNAME]
-            const sync = (await browser.storage.sync.get(CONFIGNAME))[CONFIGNAME]
+            const local = (await browser.storage.local.get(CONFIGNAME))[CONFIGNAME] as {storageloc?: "local" | "sync"}
+            const sync = (await browser.storage.sync.get(CONFIGNAME))[CONFIGNAME] as {storageloc?: "local" | "sync"}
             // Possible combinations:
             // storage:storageloc_setting => winning storageloc setting
             // l:l, s:* => l

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1344,14 +1344,10 @@ export function unset(...target) {
 
     @hidden
  */
-export async function save(storage: "local" | "sync" = "local") {
-    // let storageobj = storage === "local" ? browser.storage.local : browser.storage.sync
-    // storageobj.set({CONFIGNAME: USERCONFIG})
+export async function save() {
     const settingsobj = o({})
     settingsobj[CONFIGNAME] = USERCONFIG
-    return storage === "local"
-        ? browser.storage.local.set(settingsobj)
-        : browser.storage.sync.set(settingsobj)
+    return browser.storage.local.set(settingsobj)
 }
 
 /** Updates the config to the latest version.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1571,7 +1571,7 @@ export async function update() {
             } else if (current_storageloc != "local") {
                 throw new Error("storageloc was set to something weird: " + current_storageloc + ", automatic migration of settings was not possible.")
             }
-            set("configversion", "1.10")
+            set("configversion", "2.0")
             updated = true // NB: when adding a new updater, move this line to the end of it
         }
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1587,9 +1587,6 @@ async function init() {
     const localConfig = await browser.storage.local.get(CONFIGNAME)
     schlepp(localConfig[CONFIGNAME])
 
-    const configUpdated = await update()
-    if (configUpdated) await save()
-
     INITIALISED = true
     for (const waiter of WAITERS) {
         waiter()

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1551,6 +1551,24 @@ export async function update() {
                 "vmaps",
             ].forEach(settingName => updateAll([settingName], updateSetting))
             set("configversion", "1.9")
+        }
+        case "1.9": {
+            const local = (await browser.storage.local.get(CONFIGNAME))[CONFIGNAME]
+            const sync = (await browser.storage.sync.get(CONFIGNAME))[CONFIGNAME]
+            // Possible combinations:
+            // storage:storageloc_setting => winning storageloc setting
+            // l:l, s:* => l
+            // l:undefined, s:l =>  l
+            // l:undefined, s:s => s
+            // l: undefined, s:undefined => s
+            // l:s, s:* =>  s
+            const current_storageloc = local?.storageloc !== undefined ? local.storageloc : sync?.storageloc !== undefined ? sync.storageloc : "sync"
+            if (current_storageloc == "sync") {
+                await pull()
+            } else if (current_storageloc != "local") {
+                throw new Error("storageloc was set to something weird: " + current_storageloc + ", automatic migration of settings was not possible.")
+            }
+            set("configversion", "1.10")
             updated = true // NB: when adding a new updater, move this line to the end of it
         }
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1275,6 +1275,20 @@ export async function getAsync(
     }
 }
 
+/*
+ * Replaces the sync storage with your current userconfig. Does not merge: it overwrites.
+ */
+export async function push() {
+    return browser.storage.sync.set(await browser.storage.local.get(CONFIGNAME))
+}
+
+/*
+ * Replaces the local storage with your sync storage. Does not merge: it overwrites.
+ */
+export async function pull() {
+    return browser.storage.local.set(await browser.storage.sync.get(CONFIGNAME))
+}
+
 /** @hidden
  * Like set(), but for a specific pattern.
  */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1562,7 +1562,10 @@ export async function update() {
             // l:undefined, s:s => s
             // l: undefined, s:undefined => s
             // l:s, s:* =>  s
-            const current_storageloc = local?.storageloc !== undefined ? local.storageloc : sync?.storageloc !== undefined ? sync.storageloc : "sync"
+            const current_storageloc =
+                local?.storageloc !== undefined ? local.storageloc :
+                sync?.storageloc !== undefined ? sync.storageloc :
+                "sync"
             if (current_storageloc == "sync") {
                 await pull()
             } else if (current_storageloc != "local") {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1276,14 +1276,14 @@ export async function getAsync(
 }
 
 /*
- * Replaces the sync storage with your current userconfig. Does not merge: it overwrites.
+ * Replaces the configuration in your sync storage with your current configuration. Does not merge: it overwrites.
  */
 export async function push() {
     return browser.storage.sync.set(await browser.storage.local.get(CONFIGNAME))
 }
 
 /*
- * Replaces the local storage with your sync storage. Does not merge: it overwrites.
+ * Replaces the local configuration with the configuration from your sync storage. Does not merge: it overwrites.
  */
 export async function pull() {
     return browser.storage.local.set(await browser.storage.sync.get(CONFIGNAME))

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -4,6 +4,8 @@
 
 Tridactyl has to override your new tab page due to WebExtension limitations. You can learn how to change it at the bottom of the page, otherwise please read on for some tips and tricks.
 
+-   _Breaking change_: Tridactyl no longer tries to keep its configuration in sync automatically with the Firefox Sync storage. The `storageloc` setting has been removed. If you wish to synchronise your configurations, you can use the new `:firefoxsync{push,pull}` manually.
+
 -   _Breaking change_: `<C-6>` and `<CS-6>` now work browser-wide. If you have previously unbound them, you'll need to unbind them again with `unbind --mode=browser <C-6>`, etc.
 
 -   You can view the main help page by typing [`:help`][help], and access the tutorial with [`:tutor`][tutor]. There's a [wiki](https://github.com/tridactyl/tridactyl/wiki) too - feel free to add to it. You may find `:apropos` useful for finding relevant settings and commands.


### PR DESCRIPTION
Closes #2655 and #2699  and adds manual syncing with `:firefoxsyncpu{sh,ll}`.

I've grown fed up with Windows-specific settings leaking onto my Linux machine. I can't imagine I'm the only one.

If anyone absolutely relies on the automatic synchronisation feature, they should let me know :)