### PR TITLE
Use a MutationObserver to set up event handlers in content frames

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -279,9 +279,8 @@ export function isVisible(element: Element) {
  */
 export function getAllDocumentFrames(doc = document) {
     if (!(doc instanceof HTMLDocument)) return []
-    const frames = (Array.from(
-        doc.getElementsByTagName("iframe"),
-    ) as HTMLIFrameElement[] & HTMLFrameElement[])
+    const frames = Array
+        .from<HTMLIFrameElement | HTMLFrameElement>(doc.getElementsByTagName("iframe"))
         .concat(Array.from(doc.getElementsByTagName("frame")))
         .filter(frame => !frame.src.startsWith("moz-extension://"))
     return frames.concat(


### PR DESCRIPTION
This allows tridactyl to catch events in nested document trees,
like those in Google Docs for example. Protecting slashes is also
done in every nested document tree now.