### PR TITLE
Recursively resolve the current element through the Shadow DOM

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -3,6 +3,7 @@ import { contentState, ModeName } from "@src/content/state_content"
 import Logger from "@src/lib/logging"
 import * as controller from "@src/lib/controller"
 import { KeyEventLike, ParserResponse } from "@src/lib/keyseq"
+import { deepestShadowRoot } from "@src/lib/dom"
 
 import * as hinting from "@src/content/hinting"
 import * as gobblemode from "@src/parsers/gobblemode"
@@ -92,16 +93,6 @@ class KeyCanceller {
 }
 
 export const canceller = new KeyCanceller()
-
-/** Recursively resolves an active shadow DOM element. */
-function deepestShadowRoot(sr: ShadowRoot|null): ShadowRoot|null {
-	if (sr === null) return sr
-	let shadowRoot = sr
-	while (shadowRoot.activeElement.shadowRoot != null) {
-		shadowRoot = shadowRoot.activeElement.shadowRoot
-	}
-	return shadowRoot
-}
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
 function* ParserController() {

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -93,6 +93,16 @@ class KeyCanceller {
 
 export const canceller = new KeyCanceller()
 
+/** Recursively resolves an active shadow DOM element. */
+function deepestShadowRoot(sr: ShadowRoot|null): ShadowRoot|null {
+	if (sr === null) return sr
+	let shadowRoot = sr
+	while (shadowRoot.activeElement.shadowRoot != null) {
+		shadowRoot = shadowRoot.activeElement.shadowRoot
+	}
+	return shadowRoot
+}
+
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
 function* ParserController() {
     const parsers: {
@@ -118,7 +128,7 @@ function* ParserController() {
 
                 const shadowRoot =
                     keyevent instanceof KeyboardEvent
-                        ? (keyevent.target as Element).shadowRoot
+                        ? deepestShadowRoot((keyevent.target as Element).shadowRoot)
                         : null
 
                 // _just to be safe_, cache this to make the following

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -997,7 +997,7 @@ document.addEventListener("load", () => curJumps().then(() => jumpprev(0)))
 /** Blur (unfocus) the active element */
 //#content
 export function unfocus() {
-    document.activeElement.shadowRoot ? (document.activeElement.shadowRoot.activeElement as HTMLInputElement).blur() : (document.activeElement as HTMLInputElement).blur()
+    ;((document.activeElement.shadowRoot ? DOM.deepestShadowRoot(document.activeElement.shadowRoot) : document).activeElement as HTMLInputElement).blur()
     contentState.mode = "normal"
 }
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -683,3 +683,14 @@ export function simulateClick(target: HTMLElement) {
         focus(target)
     }
 }
+
+/** Recursively resolves an active shadow DOM element. */
+export function deepestShadowRoot(sr: ShadowRoot|null): ShadowRoot|null {
+	if (sr === null) return sr
+	let shadowRoot = sr
+	while (shadowRoot.activeElement.shadowRoot != null) {
+		shadowRoot = shadowRoot.activeElement.shadowRoot
+	}
+	return shadowRoot
+}
+


### PR DESCRIPTION
This fixes Tridactyl's interactions with Gerrit (e.g. the search box on https://gerrit-review.googlesource.com), where Tridactyl will not otherwise recognise that text boxes have focus and will eat all the inputs.