### PR TITLE
Fix source_quiet parameter

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -777,7 +777,7 @@ export async function source(...args: string[]) {
  * Same as [[source]] but suppresses all errors
  */
 //#background
-export async function source_quiet(args: string[]) {
+export async function source_quiet(...args: string[]) {
     try {
         await source(...args)
     } catch (e) {


### PR DESCRIPTION
`source_quiet` function parameter does not match the command arguments.
This causes `tridactylrc` loading at `TriStart` to fail.

The involved commit is 4781ac1.
