### PR TITLE
Fix logging of excmd

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -114,7 +114,7 @@ import { generator as KEY_MUNCHER } from "@src/content/controller_content"
 export const cmd_params = new Map<string, Map<string, string>>()
 
 /** @hidden */
-const logger = new Logging.Logger("excmds")
+const logger = new Logging.Logger("excmd")
 
 /** @hidden **/
 const TRI_VERSION = getTriVersion()


### PR DESCRIPTION
The logging module name of excmd does not match the logging config.
As a result, excmd does not log.

The involved commit is 53e5149.
