### PR TITLE
'autocmd' provides a magic variable equal to Mozilla's tabId.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1884,6 +1884,21 @@ export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "T
         TRI_FIRED_MOZ_TABID: owntab.id,
         TRI_FIRED_TRI_TABINDEX: owntab.index + 1,
         TRI_FIRED_MOZ_WINID: owntab.windowId,
+        /* TRI_FIRED_TRI_WININDEX: owntab.windowId, */
+        TRI_FIRED_MOZ_OPENERTABID: owntab.openerTabId,
+        TRI_FIRED_ACTIVE: owntab.active,
+        TRI_FIRED_AUDIBLE: owntab.audible,
+        TRI_FIRED_MUTED: owntab.mutedInfo.muted,
+        TRI_FIRED_DISCARDED: owntab.discarded,
+        TRI_FIRED_HEIGHT: owntab.height,
+        TRI_FIRED_WIDTH: owntab.width,
+        TRI_FIRED_HIDDEN: owntab.hidden,
+        TRI_FIRED_INCOGNITO: owntab.incognito,
+        TRI_FIRED_ISARTICLE: owntab.isArticle,
+        TRI_FIRED_LASTACCESSED: owntab.lastAccessed,
+        TRI_FIRED_PINNED: owntab.pinned,
+        TRI_FIRED_TITLE: owntab.title,
+        TRI_FIRED_URL: owntab.url,
     }
     for (const aukey of aukeyarr) {
         for (const [k, v] of Object.entries(replacements)) {
@@ -3558,6 +3573,20 @@ const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLef
         - `TRI_FIRED_MOZ_TABID`: Provides Mozilla's `tabID` associated with the fired event.
         - `TRI_FIRED_TRI_TABINDEX`: Provides tridactyls internal tab index associated with the fired event.
         - `TRI_FIRED_MOZ_WINID`: Provides Mozilla's `windowId` associated with the fired event.
+        - `TRI_FIRED_MOZ_OPENERTABID`: The ID of the tab that opened this tab.
+        - `TRI_FIRED_ACTIVE`: Whether the tab is active in its window. This may be true even if the tab's window is not currently focused.
+        - `TRI_FIRED_AUDIBLE`: Indicates whether the tab is producing sound (even if muted).
+        - `TRI_FIRED_MUTED`: Indicates whether the tab is muted.
+        - `TRI_FIRED_DISCARDED`: Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory.
+        - `TRI_FIRED_HEIGHT`: The height of the tab in pixels. 
+        - `TRI_FIRED_WIDTH`: The width of the tab in pixels.
+        - `TRI_FIRED_HIDDEN`: Whether the tab is hidden.
+        - `TRI_FIRED_INCOGNITO`: Whether the tab is in a private browsing window.
+        - `TRI_FIRED_ISARTICLE`: True if the tab can be rendered in Reader Mode, false otherwise.
+        - `TRI_FIRED_LASTACCESSED`: Time at which the tab was last accessed, in milliseconds since the epoch.
+        - `TRI_FIRED_PINNED`: Whether the tab is pinned.
+        - `TRI_FIRED_TITLE`: The title of the tab.
+        - `TRI_FIRED_URL`: The URL of the document that the tab is displaying.
  *
  * For example: `autocmd DocStart .*example\.com.* zoom 150 false TRI_FIRED_MOZ_TABID`.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -74,7 +74,7 @@
 
 // Shared
 import * as Messaging from "@src/lib/messaging"
-import { getTriVersion, browserBg, activeTab, activeTabId, activeTabContainerId, openInNewTab, openInNewWindow, openInTab, queryAndURLwrangler } from "@src/lib/webext"
+import { ownWinTriIndex, getTriVersion, browserBg, activeTab, activeTabId, activeTabContainerId, openInNewTab, openInNewWindow, openInTab, queryAndURLwrangler } from "@src/lib/webext"
 import * as Container from "@src/lib/containers"
 import state from "@src/state"
 import { contentState, ModeName } from "@src/content/state_content"
@@ -1884,7 +1884,7 @@ export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "T
         TRI_FIRED_MOZ_TABID: owntab.id,
         TRI_FIRED_TRI_TABINDEX: owntab.index + 1,
         TRI_FIRED_MOZ_WINID: owntab.windowId,
-        /* TRI_FIRED_TRI_WININDEX: owntab.windowId, */
+        TRI_FIRED_TRI_WININDEX: await ownWinTriIndex(),
         TRI_FIRED_MOZ_OPENERTABID: owntab.openerTabId,
         TRI_FIRED_ACTIVE: owntab.active,
         TRI_FIRED_AUDIBLE: owntab.audible,

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3569,7 +3569,7 @@ const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLef
  *
  * For example: `autocmd BeforeRequest https://www.bbc.co.uk/* () => ({redirectUrl: "https://old.reddit.com"})`. Note the brackets which ensure JavaScript returns a blocking response object rather than interpreting it as a block statement.
  *
- * For DocStart, DocLoad, DocEnd, TabEnter, TabLeft, FullscreenEnter, FullscreenLeft and FullscreenChange: magic variables are available that provide information useful in some excmd's such as:
+ * For DocStart, DocLoad, DocEnd, TabEnter, TabLeft, FullscreenEnter, FullscreenLeft and FullscreenChange: magic variables are available which are replaced with the relevant string at runtime:
         - `TRI_FIRED_MOZ_TABID`: Provides Mozilla's `tabID` associated with the fired event.
         - `TRI_FIRED_TRI_TABINDEX`: Provides tridactyls internal tab index associated with the fired event.
         - `TRI_FIRED_MOZ_WINID`: Provides Mozilla's `windowId` associated with the fired event.
@@ -3578,7 +3578,7 @@ const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLef
         - `TRI_FIRED_AUDIBLE`: Indicates whether the tab is producing sound (even if muted).
         - `TRI_FIRED_MUTED`: Indicates whether the tab is muted.
         - `TRI_FIRED_DISCARDED`: Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory.
-        - `TRI_FIRED_HEIGHT`: The height of the tab in pixels. 
+        - `TRI_FIRED_HEIGHT`: The height of the tab in pixels.
         - `TRI_FIRED_WIDTH`: The width of the tab in pixels.
         - `TRI_FIRED_HIDDEN`: Whether the tab is hidden.
         - `TRI_FIRED_INCOGNITO`: Whether the tab is in a private browsing window.

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1883,6 +1883,7 @@ export async function loadaucmds(cmdType: "DocStart" | "DocLoad" | "DocEnd" | "T
     const replacements = {
         TRI_FIRED_MOZ_TABID: owntab.id,
         TRI_FIRED_TRI_TABINDEX: owntab.index + 1,
+        TRI_FIRED_MOZ_WINID: owntab.windowId,
     }
     for (const aukey of aukeyarr) {
         for (const [k, v] of Object.entries(replacements)) {
@@ -3556,6 +3557,7 @@ const AUCMDS = ["DocStart", "DocLoad", "DocEnd", "TriStart", "TabEnter", "TabLef
  * For DocStart, DocLoad, DocEnd, TabEnter, TabLeft, FullscreenEnter, FullscreenLeft and FullscreenChange: magic variables are available that provide information useful in some excmd's such as:
         - `TRI_FIRED_MOZ_TABID`: Provides Mozilla's `tabID` associated with the fired event.
         - `TRI_FIRED_TRI_TABINDEX`: Provides tridactyls internal tab index associated with the fired event.
+        - `TRI_FIRED_MOZ_WINID`: Provides Mozilla's `windowId` associated with the fired event.
  *
  * For example: `autocmd DocStart .*example\.com.* zoom 150 false TRI_FIRED_MOZ_TABID`.
  *

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -74,7 +74,11 @@ export async function ownTabId() {
     return (await ownTab()).id
 }
 
-async function windows () { return (await browser.windows.getAll()).map(w => w.id).sort((a, b) => a - b) }
+async function windows() {
+    return (await browserBg.windows.getAll())
+        .map(w => w.id)
+        .sort((a, b) => a - b)
+}
 
 /* Returns tridactyls window index. */
 export async function ownWinTriIndex() {

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -80,12 +80,12 @@ async function windows() {
         .sort((a, b) => a - b)
 }
 
-/* Returns tridactyls window index. */
+/* Returns Tridactyl's window index. */
 export async function ownWinTriIndex() {
     return (await windows()).indexOf((await ownTab()).windowId)
 }
 
-/* Returns mozilla's internal window id from tridactyls index. */
+/* Returns mozilla's internal window id from Tridactyl's index. */
 export async function getWinIdFromIndex(index: string) {
     return (await windows())[index]
 }

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -74,6 +74,18 @@ export async function ownTabId() {
     return (await ownTab()).id
 }
 
+async function windows () { return (await browser.windows.getAll()).map(w => w.id).sort((a, b) => a - b) }
+
+/* Returns tridactyls window index. */
+export async function ownWinTriIndex() {
+    return (await windows()).indexOf((await ownTab()).windowId)
+}
+
+/* Returns mozilla's internal window id from tridactyls index. */
+export async function getWinIdFromIndex(index: string) {
+    return (await windows())[index]
+}
+
 export async function ownTabContainer() {
     return browserBg.contextualIdentities.get((await ownTab()).cookieStoreId)
 }


### PR DESCRIPTION
Autocmd has a new magic variable called `TRI_FIRED_MOZ_TABID` which gets replaces with Mozilla's internal tabid.

Useful in combination with the zoom command.

bovine3dom edit: closes #2804.