### PR TITLE
Fix #2839: parse keys iff user config loaded

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,7 +37,7 @@ const CONFIGNAME = "userconfig"
 /** @hidden */
 const WAITERS = []
 /** @hidden */
-let INITIALISED = false
+export let INITIALISED = false
 
 /** @hidden */
 // make a naked object

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -418,6 +418,9 @@ export function translateKeysInPlace(keys, conf): void {
 export function keyMap(conf): KeyMap {
     if (KEYMAP_CACHE[conf]) return KEYMAP_CACHE[conf]
 
+    // Fail silently and pass keys through to page if Tridactyl hasn't loaded yet
+    if (!config.INITIALISED) return new Map()
+
     const mapobj: { [keyseq: string]: string } = config.get(conf)
     if (mapobj === undefined)
         throw new Error(


### PR DESCRIPTION
@maricn could you see if this PR fixes your issue? The bind should just not do anything until your config has loaded. I can't replicate the issue so I'm not 100% sure I've fixed it.

1. clone this branch
2. `yarn run install` and `yarn run build`
3. In Firefox, go to about:addons, disable Tridactyl
4. Go to about:debugging, click "This Firefox", load temporary addon, choose build/manifest.json
5. On a tab Tridactyl can access run `:source` and wait a bit
6. Try to reproduce #2839 

Thanks : )