### PR TITLE
Fix #2810: run shellcheck if it is installed

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd ${0%/*}/..
-if ! [ -x "$(command -v shellcheck)" ]; then
+if [ -x "$(command -v shellcheck)" ]; then
 	GLOBIGNORE="node_modules" shellcheck -e2012 **/*.sh
 else
 	echo "Warning: shellcheck is not installed, skipping shell scripts"

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-cd ${0%/*}/..
+cd "${0%/*}"/.. || exit 1
 if [ -x "$(command -v shellcheck)" ]; then
-	GLOBIGNORE="node_modules" shellcheck -e2012 **/*.sh
+	GLOBIGNORE="node_modules" shellcheck -e2012 ./**/*.sh
 else
 	echo "Warning: shellcheck is not installed, skipping shell scripts"
 fi

--- a/ci/mozilla.sh
+++ b/ci/mozilla.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 yarn run build --no-native
-cd ${0%/*}/../build
+cd "${0%/*}"/../build || exit 1
 "$(yarn bin)/web-ext" lint

--- a/ci/unit.sh
+++ b/ci/unit.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
-cd ${0%/*}
+cd "${0%/*}" || exit
 yarn run build --no-native
 "$(yarn bin)/jest" src


### PR DESCRIPTION
I suspect #!/bin/sh doesn't support `command -v` or something. Need to check that ci/lint actually runs shellcheck for real.