### PR TITLE
Fix credits crawl and clean up authors.css

### DIFF
--- a/src/static/css/authors.css
+++ b/src/static/css/authors.css
@@ -1,4 +1,4 @@
-/* From https://css-tricks.com/snippets/css/star-wars-crawl-text/ */
+/* Adapted from https://css-tricks.com/snippets/css/star-wars-crawl-text/ */
 body {
     width: 100%;
     height: 100%;
@@ -7,7 +7,7 @@ body {
 }
 
 * {
-    text-align: left !important;
+    text-align: center !important;
 }
 
 .fade {
@@ -30,34 +30,21 @@ body {
     font-weight: 600;
     letter-spacing: 6px;
     line-height: 150%;
-    perspective: 400px;
+    transform: perspective(400px) rotateX(20deg);
     text-align: justify;
 }
 
 .crawl {
     position: relative;
-    top: 9999px;
-    transform-origin: 50% 100%;
-    animation: crawl 90s linear;
-}
-
-.crawl > .title {
-    font-size: 90%;
-    text-align: center;
-}
-
-.crawl > .title h1 {
-    margin: 0 0 100px;
-    text-transform: uppercase;
+    top: 300px;
+    animation: crawl 180s linear;
 }
 
 @keyframes crawl {
     0% {
-        top: 0;
-        transform: rotateX(20deg) translateZ(0);
+        top: 300px;
     }
     100% {
-        top: -25000px;
-        transform: rotateX(25deg) translateZ(-10000px);
+        top: -50000px;
     }
 }


### PR DESCRIPTION
Fixes #665
The crawl is now long enough to fit all names, but the length is still hard-coded. So as the number of contributors increases, we eventually will have to adjust it again. Ideally, the crawl length should be set dynamically based on the number of contributors, but that goes beyond my ability.
Removed unused CSS selectors to simplify authors.css.