### PR TITLE
Allow visability of modeindicator to be configured for each mode

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -345,7 +345,9 @@ config.getAsync("modeindicator").then(mode => {
         statusIndicator.className +=
             " TridactylMode" + statusIndicator.textContent
 
-        if (config.get("modeindicator") !== "true") statusIndicator.remove()
+        if ((config.get("modeindicator") !== "true") || (config.get("modeindicatormodes",mode) !== "true")) {
+            statusIndicator.remove()
+        }
     })
 })
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -805,6 +805,19 @@ export class default_config {
     modeindicator: "true" | "false" = "true"
 
     /**
+     * Whether to display the mode indicator in various modes. Ignored if modeindicator set to false.
+     */
+    modeindicatormodes: { [key: string]: "true" | "false" } = {
+        normal: "true",
+        insert: "true",
+        input: "true",
+        ignore: "true",
+        ex: "true",
+        hint: "true",
+        visual: "true"
+    }
+
+    /**
      * Milliseconds before registering a scroll in the jumplist
      */
     jumpdelay = 3000


### PR DESCRIPTION
Issue #2690 
This introduces a new setting ```modeindicatormodes``` that allows toggling whether the modeindicator is displayed or hidden for each mode separately. The setting is ignored, if ```modeindicator``` is set to ```false```. By default the modeindicator is displayed in every mode.

For example, if we ```:set modeindicatormodes {"hint":"false"}```, it hides the modeindicator when entering hint mode with ```f```.
Exiting hint mode does not display the modeindicator for normal mode - only after reloading the page. (I don't see yet, why that is.)

