### PR TITLE
Source matrix and gitter badges locally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -420,9 +420,9 @@ Other objectives:
 
 The logo was designed by Jake Beazley using free vector art by <a target="_blank" href="https://www.Vecteezy.com">www.Vecteezy.com</a>
 
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
+[gitter-badge]: /static/badges/gitter-badge.svg
 [gitter-link]: https://gitter.im/tridactyl/Lobby
-[matrix-badge]: https://matrix.to/img/matrix-badge.svg
+[matrix-badge]: /static/badges/matrix-badge.svg
 [matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
 [betas]: https://tridactyl.cmcaine.co.uk/betas/?sort=time&order=desc
 [riskyclick]: https://tridactyl.cmcaine.co.uk/betas/tridactyl-latest.xpi

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -65,7 +65,7 @@
     [gitter-link]: https://gitter.im/tridactyl/Lobby
     [freenode-badge]: /static/badges/freenode-badge.svg
     [freenode-link]: ircs://chat.freenode.net/tridactyl
-    [matrix-badge]: https://matrix.to/img/matrix-badge.svg
+    [matrix-badge]: /static/badges/matrix-badge.svg
     [matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
 */
 /** ignore this line */

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -71,7 +71,7 @@ You have more questions? Have a look at our [FAQ][faq-link] or search our [issue
 [gitter-link]: https://gitter.im/tridactyl/Lobby
 [freenode-badge]: /static/badges/freenode-badge.svg
 [freenode-link]: ircs://chat.freenode.net/tridactyl
-[matrix-badge]: https://matrix.to/img/matrix-badge.svg
+[matrix-badge]: /static/badges/matrix-badge.svg
 [matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/reviews/
 [nonewtablink]: https://tridactyl.cmcaine.co.uk/betas/nonewtab/tridactyl_no_new_tab_beta-latest.xpi


### PR DESCRIPTION
Issue #2906
Easy fix. The matrix badge does not seem to be available at that URL currently anyhow. Replaces one gitter URL with local source as well.