### PR TITLE
Jumble text

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ You can try `:help key` to know more about `key`. If it is an existing binding, 
 -   `zi`/`zo`/`zz` — zoom in/out/reset zoom
 -   `<C-f>`/`<C-b>` — jump to the next/previous part of the page
 -   `g?` — Apply Caesar cipher to page (run `g?` again to switch back)
+-   `g!` — Jumble words on page
 
 #### Find mode
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -129,7 +129,7 @@ import * as DOM from "@src/lib/dom"
 import * as CommandLineContent from "@src/content/commandline_content"
 import * as scrolling from "@src/content/scrolling"
 import { ownTab } from "@src/lib/webext"
-import { wrap_input, getLineAndColNumber, rot13_helper } from "@src/lib/editor_utils"
+import { wrap_input, getLineAndColNumber, rot13_helper, jumble_helper } from "@src/lib/editor_utils"
 import * as finding from "@src/content/finding"
 import * as toys from "./content/toys"
 import * as hinting from "@src/content/hinting"
@@ -4361,6 +4361,23 @@ export function rot13(n: number) {
     while (body.nextNode()) {
         const t = body.currentNode.textContent
         body.currentNode.textContent = rot13_helper(t, n)
+    }
+}
+/**
+ * Perform text jumbling (reibadailty).
+ *
+ * Shuffles letters except for first and last in all words in text nodes in the current tab. Only characters in
+ * the ASCII range are considered.
+ *
+ * Inspired by: https://www.newscientist.com/letter/mg16221887-600-reibadailty/
+ */
+//#content
+export function jumble() {
+    const body = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, { acceptNode: node => NodeFilter.FILTER_ACCEPT })
+
+    while (body.nextNode()) {
+        const t = body.currentNode.textContent
+        body.currentNode.textContent = jumble_helper(t)
     }
 }
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -239,6 +239,7 @@ export class default_config {
         x: "stop",
         gi: "focusinput -l",
         "g?": "rot13",
+        "g!": "jumble",
         "g;": "changelistjump -1",
         J: "tabprev",
         K: "tabnext",
@@ -603,6 +604,7 @@ export class default_config {
         prefremove: "removepref",
         tabclosealltoright: "tabcloseallto right",
         tabclosealltoleft: "tabcloseallto left",
+        reibadailty: "jumble",
     }
 
     /**

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -25,6 +25,7 @@ import {
     getWordBoundaries,
     wordAfterPos,
     rot13_helper,
+    jumble_helper
 } from "@src/lib/editor_utils"
 
 /**
@@ -400,6 +401,12 @@ export const insert_text = wrap_input(
 
 export const rot13 = wrap_input((text, selectionStart, selectionEnd) => [
     rot13_helper(text.slice(0, selectionStart) + text.slice(selectionEnd)),
+    selectionStart,
+    null,
+])
+
+export const jumble = wrap_input((text, selectionStart, selectionEnd) => [
+    jumble_helper(text.slice(0, selectionStart) + text.slice(selectionEnd)),
     selectionStart,
     null,
 ])

--- a/src/lib/editor_utils.ts
+++ b/src/lib/editor_utils.ts
@@ -292,3 +292,40 @@ export const charesar = (c: string, n = 13): string => {
         return String.fromCharCode(((cn - 97 + n) % 26) + 97)
     return c
 }
+
+/** @hidden
+ * Shuffles only letters except for the first and last letter in a word, where "word"
+ * is a sequence of one of: only lowercase letters OR 5 or more uppercase letters OR an uppercase letter followed
+ * by only lowercase letters.
+ */
+export const jumble_helper = (text: string): string => {
+    const wordSplitRegex = new RegExp("([^a-zA-Z]|[A-Z][a-z]+)")
+    return text.split(wordSplitRegex).map(jumbleWord).join("")
+}
+
+function jumbleWord(word: string): string {
+    if (word.length < 4 || isAcronym()) {
+        return word
+    }
+    const innerText = word.slice(1, -1)
+    return word.charAt(0) + shuffle(innerText) + word.charAt(word.length - 1)
+
+    function isAcronym() {
+        return word.length < 5 && word.toUpperCase() === word
+    }
+}
+
+/**
+ * Shuffles input string
+ * @param text string to be shuffled
+ */
+export const shuffle = (text: string): string => {
+    const arr = text.split("")
+    for (let i = arr.length - 1; i >= 0; i--) {
+        const j = Math.floor(Math.random() * i + 1)
+        const t = arr[i]
+        arr[i] = arr[j]
+        arr[j] = t
+    }
+    return arr.join("")
+}


### PR DESCRIPTION
I'm creating this PR to implement a text shuffler https://github.com/tridactyl/tridactyl/issues/2733 (I called it "jumble").
I decided to treat a word as a sequence of one of: only lowercase letters or only uppercase letters or an uppercase letter followed by only lowercase letters (word or WORD or Word). For example, a variable in code may be named "someVariableName" and it makes little sense to treat it like one word so it's treated like 3 words ("some", "Variable" and "Name") and the letters are shuffled separately in each one. The same goes for company names and other things written in camelCase/PascalCase. Characters that are not letters are never shuffled.
I do this by splitting the text using this regex: ([^a-zA-Z]|[A-Z][a-z]+).
I based the solution on rot13_helper.
I'm attaching a few screenshots of websites with the text shuffled.
![image](https://user-images.githubusercontent.com/33603097/96307185-76dae200-1001-11eb-86e7-891dbf1824f9.png)
![image](https://user-images.githubusercontent.com/33603097/96307207-835f3a80-1001-11eb-865c-73adad45b66e.png)
![image](https://user-images.githubusercontent.com/33603097/96307241-98d46480-1001-11eb-9361-0928fd966c4a.png)

Just for fun.
