### PR TITLE
Allow users to specify which commands get Tab completions

### DIFF
--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -68,7 +68,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
 
     constructor(private _parent) {
         super(
-            ["tab", "tabclose", "tabdetach", "tabduplicate", "tabmove"],
+            config.get("completions","Tab","excmds").split(" "),
             "BufferCompletionSource",
             "Tabs",
         )

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1005,6 +1005,7 @@ export class default_config {
              * Whether to automatically select the closest matching completion
              */
             autoselect: "true",
+            excmds: "tab tabclose tabdetach tabduplicate tabmove",
         },
         Rss: {
             autoselect: "true",


### PR DESCRIPTION
1) this was outrageously simple, why didn't we do this earlier?
2) I don't like the fact that setting is a space separated string. I'd like to fix #2918 and then update it to be an array. Probably have a `setappend` convenience command for appending to an array, too.
3) will add equivalent for other completions