### PR TITLE
Fix #1651

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -694,7 +694,7 @@ export async function nativeinstall() {
     if ((await browser.runtime.getPlatformInfo()).os === "win") {
         const installstr = (await config.get("win_nativeinstallcmd")).replace("%WINTAG", "-Tag " + tag)
         await yank(installstr)
-        done = fillcmdline("# Installation command copied to clipboard. Please paste and run it in PowerShell (other shells won't work) to install the native messenger.")
+        done = fillcmdline("# Installation command copied to clipboard. Please paste and run it in cmd.exe (other shells won't work) to install the native messenger.")
     } else {
         const installstr = (await config.get("nativeinstallcmd")).replace("%TAG", tag)
         await yank(installstr)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -694,7 +694,7 @@ export async function nativeinstall() {
     if ((await browser.runtime.getPlatformInfo()).os === "win") {
         const installstr = (await config.get("win_nativeinstallcmd")).replace("%WINTAG", "-Tag " + tag)
         await yank(installstr)
-        done = fillcmdline("# Installation command copied to clipboard. Please paste and run it from cmd.exe, PowerShell, or MinTTY to install the native messenger.")
+        done = fillcmdline("# Installation command copied to clipboard. Please paste and run it in PowerShell (other shells won't work) to install the native messenger.")
     } else {
         const installstr = (await config.get("nativeinstallcmd")).replace("%TAG", tag)
         await yank(installstr)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -933,7 +933,7 @@ export class default_config {
      *
      * Replaces %WINTAG with "-Tag $TRI_VERSION", similarly to [[nativeinstallcmd]].
      */
-    win_nativeinstallcmd = `powershell -NoProfile -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/win_install.ps1', """$env:temp/tridactyl_installnative.ps1"")" & powershell -NoProfile -File %temp%\\tridactyl_installnative.ps1 %WINTAG & del %temp%\\tridactyl_installnative.ps1`
+    win_nativeinstallcmd = `powershell -NoProfile -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/win_install.ps1', """$env:temp/tridactyl_installnative.ps1""")" & powershell -NoProfile -File %temp%\\tridactyl_installnative.ps1 %WINTAG & del %temp%\\tridactyl_installnative.ps1`
 
     /**
      * Used by :updatecheck and related built-in functionality to automatically check for updates and prompt users to upgrade.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -933,7 +933,7 @@ export class default_config {
      *
      * Replaces %WINTAG with "-Tag $TRI_VERSION", similarly to [[nativeinstallcmd]].
      */
-    win_nativeinstallcmd = `powershell -NoProfile -Command {(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/win_install.ps1', "$env:temp/tridactyl_installnative.ps1"); & "$env:temp/tridactyl_installnative.ps1" %WINTAG; rm "$env:temp/tridactyl_installnative.ps1";}`
+    win_nativeinstallcmd = `powershell -NoProfile -Command "(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/win_install.ps1', """$env:temp/tridactyl_installnative.ps1"")" & powershell -NoProfile -File %temp%\\tridactyl_installnative.ps1 %WINTAG & del %temp%\\tridactyl_installnative.ps1`
 
     /**
      * Used by :updatecheck and related built-in functionality to automatically check for updates and prompt users to upgrade.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -933,7 +933,7 @@ export class default_config {
      *
      * Replaces %WINTAG with "-Tag $TRI_VERSION", similarly to [[nativeinstallcmd]].
      */
-    win_nativeinstallcmd = `powershell -NoProfile -InputFormat None -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/cmcaine/tridactyl/master/native/win_install.ps1'))"`
+    win_nativeinstallcmd = `powershell -NoProfile -Command {(New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/tridactyl/master/native/win_install.ps1', "$env:temp/tridactyl_installnative.ps1"); & "$env:temp/tridactyl_installnative.ps1" %WINTAG; rm "$env:temp/tridactyl_installnative.ps1";}`
 
     /**
      * Used by :updatecheck and related built-in functionality to automatically check for updates and prompt users to upgrade.


### PR DESCRIPTION
Because PowerShell's syntax is weird, I wasn't able to find a way to properly escape a `-Command` in string form, so I decided to use a `ScriptBlock` instead, which has the slight disadvantage of only working when pasted into PowerShell.