### PR TITLE
Make git hooks work on MinGW etc.

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,6 +2,8 @@
 
 # stolen from https://gist.github.com/sindresorhus/7996717
 
+echo "Running post-checkout hook..."
+
 changed_files="$(git diff-tree -r --name-only --no-commit-id $1 $2)"
 
 

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -2,6 +2,8 @@
 
 # stolen from https://gist.github.com/sindresorhus/7996717
 
+echo "Running post-merge hook..."
+
 changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+case $(uname) in
+    *CYGWIN*|*MINGW*|*MSYS*)
+        echo "Cygwin/MinGW/MSYS detected, skipping pre-commit hook"
+        exit 0
+        ;;
+esac
+
+echo "Running pre-commit hook..."
+
 source ./scripts/common.sh
 
 jsfiles=$(cachedTSLintFiles)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "nearley": "^2.19.8",
     "prettier": "^2.2.0",
     "selenium-webdriver": "^4.0.0-alpha.7",
-    "shared-git-hooks": "^1.2.1",
     "source-map-loader": "^1.1.2",
     "ts-jest": "^25.5.1",
     "ts-loader": "^8.0.11",
@@ -69,7 +68,8 @@
     "run": "web-ext run -s build/ -u 'txti.es'",
     "test": "yarn run build && web-ext build --source-dir ./build --overwrite-dest && jest --silent",
     "update-buildsystem": "rm -rf src/node_modules; yarn run clean",
-    "watch": "echo 'watch is broken, use build instead'; exit 0;"
+    "watch": "echo 'watch is broken, use build instead'; exit 0;",
+    "install": "git config core.hookspath hooks/"
   },
   "author": "Colin Caine",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,11 +8200,6 @@ sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shared-git-hooks@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/shared-git-hooks/-/shared-git-hooks-1.2.1.tgz#f17f59677cbf8fc3ee8ee71934a9de70a0920cce"
-  integrity sha1-8X9ZZ3y/j8PujucZNKnecKCSDM4=
-
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
This pull request deals with #3022 in the following ways:
1. Replace shared-git-hooks:
    * with the package.json lifecycle script "install", which locally sets the git hooks search directory to `<working_directory>/hooks` when `yarn install` is run
    * with an `echo` in each of the scripts that informs the user when the hook runs.
1. Add a check to the pre-commit hook that just skips it when on MinGW, MSYS, or Cygwin<sup>1</sup>.

[1] I'm fairly certain it'll be broken on pure MSYS, which, as far as I know, MinGW and in turn Git Bash are based on, as well. I'm not sure about Cygwin, so we *could* leave out that check for now – but I don't think it matters. Either it turns out it would've worked, leading to marginally less prettified code, or it turns out it doesn't work either, leading to a Cygwin user getting slightly confused, then finding #3022 and this PR and adding that check as well. Both are rather minuscule dangers.