### PR TITLE
Prevent TypeError caused by hint -#

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1149,11 +1149,12 @@ export function pipe_elements(
 function toHintablesArray(
     hintablesOrElements: Element[] | Hintables[],
 ): Hintables[] {
+    if (!hintablesOrElements.length) return []
     return "className" in hintablesOrElements[0]
         ? [{ elements: hintablesOrElements } as Hintables]
         : "elements" in hintablesOrElements[0]
-        ? (hintablesOrElements as Hintables[])
-        : undefined
+            ? (hintablesOrElements as Hintables[])
+            : []
 }
 
 function selectFocusedHint(delay = false) {

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1150,11 +1150,11 @@ function toHintablesArray(
     hintablesOrElements: Element[] | Hintables[],
 ): Hintables[] {
     if (!hintablesOrElements.length) return []
-    return "className" in hintablesOrElements[0]
-        ? [{ elements: hintablesOrElements } as Hintables]
-        : "elements" in hintablesOrElements[0]
-            ? (hintablesOrElements as Hintables[])
-            : []
+    if ("className" in hintablesOrElements[0])
+        return [{ elements: hintablesOrElements } as Hintables]
+    if ("elements" in hintablesOrElements[0])
+        return hintablesOrElements as Hintables[]
+    return []
 }
 
 function selectFocusedHint(delay = false) {


### PR DESCRIPTION
Fixes #2964.
As somewhat expected, `toHintablesArray` returning `undefined` *did* cause issues (who'd'a thunk a function with that name maybe shouldn't return things that aren't arrays🤔), so now it returns `[]` if there isn't anything hintable. I've tested it a bit and everything seems to still work the same – except, of course, pages where `-#` was broken before. On those pages, `-#` now behaves like all other hint modes I'm aware of when there isn't anything to hint and just does nothing.