### PR TITLE
Explicitly annotate state.getAsync

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -279,9 +279,7 @@ async function history(n) {
 
     // Check for matches in history, removing duplicates
     const matches = R.reverse(
-        // for some reason ramda loses the type information here
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        R.uniq(R.reverse((await State.getAsync("cmdHistory")) as string[])),
+        R.uniq(R.reverse(await State.getAsync("cmdHistory"))),
     ).filter(key => key.startsWith(HISTORY_SEARCH_STRING))
     if (commandline_state.cmdline_history_position === 0) {
         cmdline_history_current = commandline_state.clInput.value

--- a/src/state.ts
+++ b/src/state.ts
@@ -91,7 +91,7 @@ const state = new Proxy(overlay, {
     },
 })
 
-export async function getAsync(property) {
+export async function getAsync<K extends keyof State>(property: K): Promise<State[K]> {
     if (notBackground())
         return browser.runtime.sendMessage({
             type: "state",


### PR DESCRIPTION
cf. 0fb5430 and its comments.
I had to look up how to do this, and while it looks a bit weird, this does what we want here, allowing different return types for `getAsync` based on what the argument is.
On the topic of explicit annotations, I'd like to do some more annotating elsewhere in the codebase as well once this PR is done, because I've encountered quite a number of `any`s that could be avoided, which somewhat defeats the purpose of using types in the first place.