### PR TITLE
Update yank to use Clipboard API

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -321,28 +321,6 @@ export function fillcmdline(
     return result
 }
 
-/** @hidden
- * Create a temporary textarea and give it to fn. Remove the textarea afterwards
- *
- * Useful for document.execCommand
- **/
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function applyWithTmpTextArea(fn) {
-    let textarea
-    try {
-        textarea = document.createElement("textarea")
-        // Scratchpad must be `display`ed, but can be tiny and invisible.
-        // Being tiny and invisible means it won't make the parent page move.
-        textarea.style.cssText =
-            "visible: invisible; width: 0; height: 0; position: fixed"
-        textarea.contentEditable = "true"
-        document.documentElement.appendChild(textarea)
-        return fn(textarea)
-    } finally {
-        document.documentElement.removeChild(textarea)
-    }
-}
-
 /** @hidden **/
 export function getContent() {
     return commandline_state.clInput.value

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -326,6 +326,7 @@ export function fillcmdline(
  *
  * Useful for document.execCommand
  **/
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function applyWithTmpTextArea(fn) {
     let textarea
     try {
@@ -340,35 +341,6 @@ function applyWithTmpTextArea(fn) {
     } finally {
         document.documentElement.removeChild(textarea)
     }
-}
-
-/** @hidden **/
-export async function setClipboard(content: string) {
-    await Messaging.messageOwnTab("commandline_content", "focus")
-    applyWithTmpTextArea(scratchpad => {
-        scratchpad.value = content
-        scratchpad.select()
-        // This can return false spuriously so just ignore its return value
-        document.execCommand("Copy")
-        logger.info("set clipboard:", scratchpad.value)
-    })
-    // Return focus to the document
-    await Messaging.messageOwnTab("commandline_content", "hide")
-    return Messaging.messageOwnTab("commandline_content", "blur")
-}
-
-/** @hidden **/
-export async function getClipboard() {
-    await Messaging.messageOwnTab("commandline_content", "focus")
-    const result = applyWithTmpTextArea(scratchpad => {
-        scratchpad.focus()
-        document.execCommand("Paste")
-        return scratchpad.textContent
-    })
-    // Return focus to the document
-    await Messaging.messageOwnTab("commandline_content", "hide")
-    await Messaging.messageOwnTab("commandline_content", "blur")
-    return result
 }
 
 /** @hidden **/

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3103,10 +3103,10 @@ async function setclip(data: string) {
             promises = [setclip_selection()]
             break
         case "clipboard":
-            promises = [setclip_api(data)]
+            promises = [setclip_webapi(data)]
             break
         case "both":
-            promises = [setclip_selection(), setclip_api(data)]
+            promises = [setclip_selection(), setclip_webapi(data)]
             break
     }
     return Promise.all(promises)
@@ -3117,7 +3117,7 @@ async function setclip(data: string) {
  * @hidden
  */
 //#background_helper
-async function setclip_api(data: string) {
+async function setclip_webapi(data: string) {
     return window.navigator.clipboard.writeText(data)
 }
 
@@ -3130,7 +3130,7 @@ async function setclip_api(data: string) {
 export async function getclip(from?: "clipboard" | "selection") {
     if (from === undefined) from = await config.getAsync("putfrom")
     if (from === "clipboard") {
-        return getclip_api()
+        return getclip_webapi()
     } else {
         return Native.clipboard("get", "")
     }
@@ -3141,7 +3141,7 @@ export async function getclip(from?: "clipboard" | "selection") {
  * @hidden
  */
 //#background_helper
-async function getclip_api() {
+async function getclip_webapi() {
     return window.navigator.clipboard.readText()
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3115,6 +3115,8 @@ async function setclip(data: string) {
 /**
  * Copies a string to the clipboard using the Clipboard API.
  * @hidden
+ *
+ * Has to be a background helper as it's only available on HTTPS and background pages. We want to be able to copy stuff to the clipboard from HTTP pages too.
  */
 //#background_helper
 async function setclip_webapi(data: string) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3095,18 +3095,18 @@ export function yank(...content: string[]) {
 //#background_helper
 async function setclip(data: string) {
     // Function to avoid retyping everything everywhere
-    const setclip_selection = () => Native.clipboard("set", data)
+    const setclip_selection = data => Native.clipboard("set", data)
 
-    let promises: Array<Promise<any>> = []
+    let promises: Promise<any>[]
     switch (await config.getAsync("yankto")) {
         case "selection":
-            promises = [setclip_selection()]
+            promises = [setclip_selection(data)]
             break
         case "clipboard":
             promises = [setclip_webapi(data)]
             break
         case "both":
-            promises = [setclip_selection(), setclip_webapi(data)]
+            promises = [setclip_selection(data), setclip_webapi(data)]
             break
     }
     return Promise.all(promises)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -154,7 +154,6 @@ import "@src/lib/number.mod"
 import * as BGSELF from "@src/.excmds_background.generated"
 import { CmdlineCmds as BgCmdlineCmds } from "@src/background/commandline_cmds"
 import { EditorCmds as BgEditorCmds } from "@src/background/editor"
-import { messageActiveTab } from "@src/lib/messaging"
 import { EditorCmds } from "@src/background/editor"
 import { firefoxVersionAtLeast } from "@src/lib/webext"
 import { parse_bind_args, modeMaps } from "@src/lib/binding"
@@ -3089,31 +3088,37 @@ export function yank(...content: string[]) {
 }
 
 /**
- * Copies a string to the clipboard/selection buffer depending on the user's preferences
+ * Copies a string to the clipboard/selection buffer depending on the user's preferences.
  *
  * @hidden
  */
 //#background_helper
-async function setclip(str) {
-    // Functions to avoid retyping everything everywhere
+async function setclip(data: string) {
+    // Function to avoid retyping everything everywhere
+    const setclip_selection = () => Native.clipboard("set", data)
 
-    // Note: We're using fillcmdline here because exceptions are somehow not caught. We're rethrowing because otherwise the error message will be overwritten with the "yank successful" message.
-    const s = () => Native.clipboard("set", str)
-    const c = () => messageActiveTab("commandline_frame", "setClipboard", [str])
-
-    let promises = []
+    let promises: Array<Promise<any>> = []
     switch (await config.getAsync("yankto")) {
         case "selection":
-            promises = [s()]
+            promises = [setclip_selection()]
             break
         case "clipboard":
-            promises = [c()]
+            promises = [setclip_api(data)]
             break
         case "both":
-            promises = [s(), c()]
+            promises = [setclip_selection(), setclip_api(data)]
             break
     }
     return Promise.all(promises)
+}
+
+/**
+ * Copies a string to the clipboard using the Clipboard API.
+ * @hidden
+ */
+//#background_helper
+async function setclip_api(data: string) {
+    return window.navigator.clipboard.writeText(data)
 }
 
 /**
@@ -3122,13 +3127,22 @@ async function setclip(str) {
  * Exposed for use with [[composite]], e.g. `composite getclip | fillcmdline`
  */
 //#background
-export async function getclip(fromm?: "clipboard" | "selection") {
-    if (fromm === undefined) fromm = await config.getAsync("putfrom")
-    if (fromm === "clipboard") {
-        return messageActiveTab("commandline_frame", "getClipboard")
+export async function getclip(from?: "clipboard" | "selection") {
+    if (from === undefined) from = await config.getAsync("putfrom")
+    if (from === "clipboard") {
+        return getclip_api()
     } else {
         return Native.clipboard("get", "")
     }
+}
+
+/**
+ * Gets the clipboard content using the Clipboard API.
+ * @hidden
+ */
+//#background_helper
+async function getclip_api() {
+    return window.navigator.clipboard.readText()
 }
 
 /** Use the system clipboard.


### PR DESCRIPTION
(Hopefully) resolves #2597 and a step forward regarding #2749. I haven't extensively tested this yet – though with how simple this code is, I don't think there is a lot to test here.
I've removed `commandline_frame`'s `setClipboard`, `getClipboard`, and `applyWithTmpTextArea`, which are now obsolete. I've also done a small bit of cleaning up in the existing clipboard manipulation functions.