### PR TITLE
Remove blue outline from commandline on MacOS

### DIFF
--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -32,6 +32,10 @@ input {
     /* border-top: solid 1px lightgray; */
 }
 
+input:focus {
+    outline: none;
+}
+
 #tridactyl-colon::before {
     content: ":";
 }


### PR DESCRIPTION
## before
#### default
![image](https://user-images.githubusercontent.com/25518211/102793155-7ea76180-4377-11eb-8e75-dce7b4511de7.png)

#### shydactyl
![image](https://user-images.githubusercontent.com/25518211/102793121-6f281880-4377-11eb-81c7-4012327ebec7.png)

## after
#### default
![image](https://user-images.githubusercontent.com/25518211/102792852-0b9deb00-4377-11eb-9380-7e2d9bfe0cb9.png)
#### shydactyl
![image](https://user-images.githubusercontent.com/25518211/102792966-30925e00-4377-11eb-868c-4efda301bad5.png)
