### PR TITLE
Prevent setURL from setting invalid RegEx patterns

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1142,8 +1142,10 @@ const platform_defaults = {
     },
     linux: {
         nmaps: {
-            ";x": 'hint -F e => { const pos = tri.dom.getAbsoluteCentre(e); tri.excmds.exclaim_quiet("xdotool mousemove --sync " + pos.x + " " + pos.y + "; xdotool click 1")}',
-            ";X": 'hint -F e => { const pos = tri.dom.getAbsoluteCentre(e); tri.excmds.exclaim_quiet("xdotool mousemove --sync " + pos.x + " " + pos.y + "; xdotool keydown ctrl+shift; xdotool click 1; xdotool keyup ctrl+shift")}',
+            ";x":
+                'hint -F e => { const pos = tri.dom.getAbsoluteCentre(e); tri.excmds.exclaim_quiet("xdotool mousemove --sync " + pos.x + " " + pos.y + "; xdotool click 1")}',
+            ";X":
+                'hint -F e => { const pos = tri.dom.getAbsoluteCentre(e); tri.excmds.exclaim_quiet("xdotool mousemove --sync " + pos.x + " " + pos.y + "; xdotool keydown ctrl+shift; xdotool click 1; xdotool keyup ctrl+shift")}',
         } as unknown,
     },
 } as Record<browser.runtime.PlatformOs, default_config>
@@ -1356,7 +1358,14 @@ export async function pull() {
  * Like set(), but for a specific pattern.
  */
 export function setURL(pattern, ...args) {
-    return set("subconfigs", pattern, ...args)
+    try {
+        new RegExp(pattern)
+        return set("subconfigs", pattern, ...args)
+    } catch (err) {
+        if (err instanceof SyntaxError)
+            throw new SyntaxError(`invalid pattern: ${err.message}`)
+        throw err
+    }
 }
 /** Full target specification, then value
 


### PR DESCRIPTION
Addresses the immediate problem with #3131 by preventing users from setting sub-configs with syntactically incorrect RegEx patterns. The more architectural issue of a broken config still remains. 

I figured throwing from `config.setURL` would be better than from the excmds. This way, we not only prevent the screwing over of oneself using `:seturl` and `:bindurl`, but also when using `config.setURL` in a `:js` alias. Of course, `config.set` or `browser.storage.local.set` can still insert invalid RegEx, but, at that point, you're probably doing it on purpose.

Lastly, the completely unrelated change in the platform defaults for Linux is because Prettier said so.