### PR TITLE
Make ff_cmdline work on Windows

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -425,17 +425,17 @@ export async function clipboard(
  * That's rather slow, so this function shouldn't be called unless really necessary.
  */
 export async function ff_cmdline(): Promise<string[]> {
+    let output: MessageResp
     if ((await browserBg.runtime.getPlatformInfo()).os === "win") {
-        const output = await run(
+        output = await run(
             "powershell -Command " +
                 '"$ppid = Get-CimInstance -Property ProcessId,ParentProcessId Win32_Process | Where-Object -Property ProcessId -EQ $PID | Select-Object -ExpandProperty ParentProcessId;' +
                 "$pproc = Get-CimInstance -Property ProcessId,ParentProcessId,Name,CommandLine Win32_Process | Where-Object -Property ProcessId -EQ $ppid;" +
                 "while ($pproc.Name -notmatch 'firefox') { $ppid = $pproc.ParentProcessId;" +
                 '$pproc = Get-CimInstance Win32_Process | Where-Object -Property ProcessId -EQ $ppid}; Write-Output $pproc.CommandLine"',
         )
-        return output.content.trim().split(" ")
     } else {
-        const output = await pyeval(
+        output = await pyeval(
             // Using ' and + rather than ` because we don't want newlines
             'handleMessage({"cmd": "run", ' +
                 '"command": "ps -p " + str(os.getppid()) + " -oargs="})["content"]',


### PR DESCRIPTION
It certainly ain't pretty, and it takes around 800ms to execute on my end, but since the native messenger isn't a direct descendant of the main Firefox process, we need to work our way up the tree.
Currently, this splits right through quoted arguments containing spaces. I've done it that way for now because the non-Windows part of the function does the same, so I figured it might not be a problem (and I really couldn't be bothered to try and wrestle with cmd's quoting rules again when I might not need to).
