### PR TITLE
Remove Windows Terminal from default Windows terminals again

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -156,7 +156,7 @@ export async function getBestEditor(): Promise<string> {
         }
         if (os === "win") {
             term_emulators.push(
-                ...["wt", "conemu -run", "mintty --class tridactyl_editor -e"],
+                ...["conemu -run", "mintty --class tridactyl_editor -e"],
             )
         }
         // These terminal emulators are cross-platform.


### PR DESCRIPTION
Turns out WT, when run, apparently spawns another instance of itself and then immediately exits, with the newly spawned instance being the one that's actually displayed. Or something like that. That makes it not suited as a terminal for `:editor` after all, because once the first process exits, Tridactyl will think the user is finished writing and read the file, resulting in an empty text box. There doesn't seem to exist any option to pass to wt.exe to make it not do that, so we can't use it.