### PR TITLE
WIP: first go at change list jumping again

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2070,6 +2070,7 @@ export async function changelistjump() {
     const tail = state.prevInputs[state.prevInputs.length - 1]
     const jumppos = tail.jumppos ? tail.jumppos : state.prevInputs.length - 1
     const input = state.prevInputs[jumppos]
+    state.storeNextInput = "false"
     await browser.tabs.update(input.tab, { active: true })
     const id = input.inputId
     // Not all elements have an ID, so this will do for now.

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -533,11 +533,15 @@ function onPageFocus(elem: HTMLElement): boolean {
 
 async function setInput(el) {
     const tab = await activeTabId()
-    // store maximum of 10 elements to stop this getting bonkers huge
+    if ((await State.getAsync("storeNextInput")) === "false") {
+        state.storeNextInput = "true"
+        return
+    }
     const arr = (await State.getAsync("prevInputs")).concat({
         tab,
         inputId: el.id,
     })
+    // store maximum of 10 elements to stop this getting bonkers huge
     state.prevInputs = arr.slice(Math.max(arr.length - 10, 0))
 }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -20,6 +20,10 @@ const logger = new Logger("state")
 class State {
     lastSearchQuery: string = undefined
     cmdHistory: string[] = []
+    // How should this work?
+    // - if I jump to a prevInput, then I leave that input and stay on that tab, then invoke the command again, jump to the previous prevInput
+    // - if I'm on a different tab, jump to the same prevInput <!-- don't bother doing this yet -->
+        // - unless a new one has been activated, then jump to that
     prevInputs: Array<{ inputId: string; tab: number; jumppos?: number }> = [
         {
             inputId: undefined,
@@ -27,6 +31,8 @@ class State {
             jumppos: undefined,
         },
     ]
+    // For some reason `: boolean` doesn't work here
+    storeNextInput: "true" | "false" = "true"
     last_ex_str = "echo"
 }
 


### PR DESCRIPTION
Related: #2677

Currently breaks `g;` - it just does `focusinput -l` every time