### PR TITLE
Fix completion for bmark when -t is given

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -76,6 +76,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
             .slice(0, 10)
             .map(page => new BmarkCompletionOption(option + page.url, page))
 
+        this.lastExstr = prefix + query
         return this.updateChain()
     }
 


### PR DESCRIPTION
When -t is given on the ex cli with bmarks, completions don't seem to
pop up in the same way as they do without -t.

Not sure if prefix+query is needed, as prefix is just thrown away in the next fn anyway

I also left the first set to lastExStr in case the fn exits early.

I'm not sure what -c is for in bmarks, I couldn't find any docs for that. 