### PR TITLE
WIP: fix #1449 - stack themes

### DIFF
--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -48,46 +48,49 @@ export async function theme(element) {
         insertedCSS = false
     }
 
-    const newTheme = await config.getAsync("theme")
+    const newThemes = await config.getAsync("themes")
+    if (newThemes.length == 0) newThemes.push(await config.getAsync("theme"))
 
-    /**
-     * DEPRECATED
-     *
-     * You don't need to add weird classnames to your themes any more, but you can if you want.
-     *
-     * Retained for backwards compatibility.
-     **/
-    if (newTheme !== "default") {
-        element.classList.add(prefixTheme(newTheme))
-    }
-    // DEPRECATION ENDS
-
-    // Insert custom css if needed
-    if (newTheme !== "default") {
-        customCss.code = THEMES.includes(newTheme)
-            ? "@import url('" +
-              browser.runtime.getURL(
-                  "static/themes/" + newTheme + "/" + newTheme + ".css",
-              ) +
-              "');"
-            : await config.getAsync("customthemes", newTheme)
-        if (customCss.code) {
-            await browserBg.tabs.insertCSS(await ownTabId(), customCss)
-            insertedCSS = true
-        } else {
-            logger.error("Theme " + newTheme + " couldn't be found.")
+    for (const newTheme of newThemes) {
+        /**
+         * DEPRECATED
+         *
+         * You don't need to add weird classnames to your themes any more, but you can if you want.
+         *
+         * Retained for backwards compatibility.
+         **/
+        if (newTheme !== "default") {
+            element.classList.add(prefixTheme(newTheme))
         }
-    }
+        // DEPRECATION ENDS
 
-    // Record for re-theming
-    // considering only elements :root (page and cmdline_iframe)
-    // TODO:
-    //     - Find ways to check if element is already pushed
-    if (
-        THEMED_ELEMENTS.length < 2 &&
-        element.tagName.toUpperCase() === "HTML"
-    ) {
-        THEMED_ELEMENTS.push(element)
+        // Insert custom css if needed
+        if (newTheme !== "default") {
+            customCss.code = THEMES.includes(newTheme)
+                ? "@import url('" +
+                  browser.runtime.getURL(
+                      "static/themes/" + newTheme + "/" + newTheme + ".css",
+                  ) +
+                  "');"
+                : await config.getAsync("customthemes", newTheme)
+            if (customCss.code) {
+                await browserBg.tabs.insertCSS(await ownTabId(), customCss)
+                insertedCSS = true
+            } else {
+                logger.error("Theme " + newTheme + " couldn't be found.")
+            }
+        }
+
+        // Record for re-theming
+        // considering only elements :root (page and cmdline_iframe)
+        // TODO:
+        //     - Find ways to check if element is already pushed
+        if (
+            THEMED_ELEMENTS.length < 2 &&
+            element.tagName.toUpperCase() === "HTML"
+        ) {
+            THEMED_ELEMENTS.push(element)
+        }
     }
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -805,6 +805,11 @@ export class default_config {
     theme = "default"
 
     /**
+     * The themes to use.
+     */
+    themes: string[] = []
+
+    /**
      * Storage for custom themes
      *
      * Maps theme names to CSS. Predominantly used automatically by [[colourscheme]] to store themes read from disk, as documented by [[colourscheme]]. Setting this manually is untested but might work provided that [[colourscheme]] is then used to change the theme to the right theme name.


### PR DESCRIPTION
Usage: `:set themes ["themebase", "thememiddle", "themetop"]`

`:set themes ["dark", "quakelight"]` works well already.

Todo: documentation and user-friendliness (e.g. how do we want `:colours` to work? Need to add a "themes" change listener. Existence of :colours, :set theme and :set themes will 100% confuse users. Should document clearly that :set theme (and therefore :colours) will be ignored if `themes` exists)

@noctuid if you still use Tridactyl, how did you imagine this working?