### PR TITLE
Fix #3257: ignore modifiers for counts and hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1214,16 +1214,14 @@ export function parser(keys: keyseq.KeyEventLike[]) {
     if (parsed.isMatch === true) {
         return parsed
     }
-    // Ignore modifiers since they can't match text
-    const simplekeys = keys.filter(key => !keyseq.hasModifiers(key))
     let exstr
-    if (simplekeys.length > 1) {
-        exstr = simplekeys.reduce(
+    if (keys.length > 1) {
+        exstr = keys.reduce(
             (acc, key) => `hint.pushKey ${key.key};`,
             "composite ",
         )
-    } else if (simplekeys.length === 1) {
-        exstr = `hint.pushKeyCodePoint ${simplekeys[0].key.codePointAt(0)}`
+    } else if (keys.length === 1) {
+        exstr = `hint.pushKeyCodePoint ${keys[0].key.codePointAt(0)}`
     } else {
         return { keys: [], isMatch: false }
     }

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -121,16 +121,10 @@ function splitNumericPrefix(
     keyseq: KeyEventLike[],
 ): [KeyEventLike[], KeyEventLike[]] {
     // If the first key is in 1:9, partition all numbers until you reach a non-number.
-    if (
-        !hasModifiers(keyseq[0]) &&
-        [1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(keyseq[0].key))
-    ) {
+    if ([1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(keyseq[0].key))) {
         const prefix = [keyseq[0]]
         for (const ke of keyseq.slice(1)) {
-            if (
-                !hasModifiers(ke) &&
-                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(ke.key))
-            )
+            if ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9].includes(Number(ke.key)))
                 prefix.push(ke)
             else break
         }
@@ -505,7 +499,7 @@ export function translateKeysUsingKeyTranslateMap(
 
 // }}}
 
-browser.storage.onChanged.addListener((changes) => {
+browser.storage.onChanged.addListener(changes => {
     if ("userconfig" in changes) {
         KEYMAP_CACHE = {}
     }


### PR DESCRIPTION
Small bug:

1. press `<C-6>` # tab changes as expected
2. press `:` # command line is prefilled with "6"

Tempted to swap the removed !hasModifiers to !hasShift instead