### PR TITLE
Fix #3097 : add hintautoselect option

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -467,11 +467,12 @@ export function hintPage(
         )
 
     if (
-        modeState.hints.length == 1 ||
-        (firstTargetIsSelectable() && allTargetsAreEqual())
+        (modeState.hints.length == 1 ||
+            (firstTargetIsSelectable() && allTargetsAreEqual())) &&
+        config.get("hintautoselect") === "true"
     ) {
         // There is just a single link or all the links point to the same
-        // place. Select it.
+        // place. Select it unless `hintautoselect` is set to `false`.
         modeState.cleanUpHints()
         modeState.hints[0].select()
         reset()
@@ -859,7 +860,7 @@ function filterHintsSimple(fstr) {
             active.push(h)
         }
     }
-    if (active.length === 1) {
+    if (active.length === 1 && config.get("hintautoselect") === "true") {
         selectFocusedHint()
     }
 }
@@ -945,8 +946,8 @@ function filterHintsVimperator(query: string, reflow = false) {
         modeState.focusedHint.focused = true
     }
 
-    // Select focused hint if it's the only match
-    if (active.length === 1) {
+    // Select focused hint if it's the only match unless turned off in config
+    if (active.length === 1 && config.get("hintautoselect") === "true") {
         selectFocusedHint(true)
     }
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -451,7 +451,7 @@ export async function loadtheme(themename: string) {
     // remove the "tridactylrc" bit so that we're left with the directory
     const path = (await Native.getrcpath()).split(separator).slice(0, -1).join(separator) + separator + "themes" + separator + themename + ".css"
     const file = await Native.read(path)
-    if (file.code !== 0)  {
+    if (file.code !== 0) {
         if (Object.keys(await config.get("customthemes")).includes(themename)) return
         throw new Error("Couldn't read theme " + path)
     }
@@ -4184,6 +4184,9 @@ const KILL_STACK: Element[] = []
         - "relatedopenpos": "related" | "next" | "last"
         - "hintuppercase": "true" | "false"
         - "hintnames": "short" | "uniform" | "numeric"
+        - "hintdelay": 300
+        - "hintshift": "true" | "false"
+        - "hintautoselect": "true" | "false"
 
           With "short" names, Tridactyl will generate short hints that
           are never prefixes of each other. With "uniform", Tridactyl

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -731,6 +731,13 @@ export class default_config {
     hintshift: "true" | "false" = "false"
 
     /**
+     * Controls whether hints should be followed automatically.
+     *
+     * If set to `false`, hints will only be followed upon confirmation. This applies to cases when there is only a single match or only one link on the page.
+     */
+    hintautoselect: "true" | "false" = "true"
+
+    /**
      * Controls whether the page can focus elements for you via js
      *
      * NB: will break fancy editors such as CodeMirror on Jupyter. Simply use `seturl` to whitelist pages you need it on.


### PR DESCRIPTION
Fix #3097: This adds a boolean option `hintautoselect` (default:`true`) like @bovine3dom suggested. If set to `false`, hints won't be followed automatically even if there is only one link on the page or only one matched hint left.