### PR TITLE
Updated matrix links (riot.im to element.io)

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -140,7 +140,7 @@ You can run Tridactyl easily in a temporary Firefox profile with `yarn run run`.
 
 [Queensberry rules](https://en.oxforddictionaries.com/definition/queensberry_rules).
 
-[matrix]: https://riot.im/app/#/room/#tridactyl:matrix.org
+[matrix]: https://app.element.io/#/room/#tridactyl:matrix.org
 [issues]: https://github.com/tridactyl/tridactyl/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+
 [easyissues]: https://github.com/tridactyl/tridactyl/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [helpus]: https://github.com/tridactyl/tridactyl/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Tridactyl
 
 <p align="center">
 <a href="https://travis-ci.org/tridactyl/tridactyl"><img src="https://travis-ci.org/tridactyl/tridactyl.svg?branch=master" alt="Build Status"></a>
-<a href="https://riot.im/app/#/room/#tridactyl:matrix.org"><img src="https://img.shields.io/badge/matrix-join%20chat-green" alt="Matrix Chat"></a>
+<a href="https://app.element.io/#/room/#tridactyl:matrix.org"><img src="https://img.shields.io/badge/matrix-join%20chat-green" alt="Matrix Chat"></a>
 <a href="https://gitter.im/tridactyl/Lobby"><img src="https://badges.gitter.im/Join%20Chat.svg" alt="Join Gitter Chat"></a>
 <a href="https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/"><img src="https://img.shields.io/amo/rating/tridactyl-vim" alt="Mozilla Addon Store"></a>
 </p>
@@ -366,7 +366,7 @@ The logo was designed by Jake Beazley using free vector art by <a target="_blank
 [gitter-badge]: /static/badges/gitter-badge.svg
 [gitter-link]: https://gitter.im/tridactyl/Lobby
 [matrix-badge]: /static/badges/matrix-badge.svg
-[matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
+[matrix-link]: https://app.element.io/#/room/#tridactyl:matrix.org
 [betas]: https://tridactyl.cmcaine.co.uk/betas/?sort=time&order=desc
 [riskyclick]: https://tridactyl.cmcaine.co.uk/betas/tridactyl-latest.xpi
 [nonewtablink]: https://tridactyl.cmcaine.co.uk/betas/nonewtab/tridactyl_no_new_tab_beta-latest.xpi

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -66,7 +66,7 @@
     [freenode-badge]: /static/badges/freenode-badge.svg
     [freenode-link]: ircs://chat.freenode.net/tridactyl
     [matrix-badge]: /static/badges/matrix-badge.svg
-    [matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
+    [matrix-link]: https://app.element.io/#/room/#tridactyl:matrix.org
 */
 /** ignore this line */
 

--- a/src/static/newtab.md
+++ b/src/static/newtab.md
@@ -73,7 +73,7 @@ You have more questions? Have a look at our [FAQ][faq-link] or search our [issue
 [freenode-badge]: /static/badges/freenode-badge.svg
 [freenode-link]: ircs://chat.freenode.net/tridactyl
 [matrix-badge]: /static/badges/matrix-badge.svg
-[matrix-link]: https://riot.im/app/#/room/#tridactyl:matrix.org
+[matrix-link]: https://app.element.io/#/room/#tridactyl:matrix.org
 [amo]: https://addons.mozilla.org/en-US/firefox/addon/tridactyl-vim/reviews/
 [nonewtablink]: https://tridactyl.cmcaine.co.uk/betas/nonewtab/tridactyl_no_new_tab_beta-latest.xpi
 [migratelink]: https://github.com/tridactyl/tridactyl/issues/79#issuecomment-351132451


### PR DESCRIPTION
Updated matrix links from the old riot.im app to the new element.io.