### PR TITLE
Add container support for winopen

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2771,7 +2771,8 @@ export async function winopen(...args: string[]) {
         if (firefoxArgs === "--private-window") {
             throw new Error("Can't open a container in a private browsing window.")
         } else {
-            return composite(`tabopen -c ${address} ; sleep 100 ; tabdetach`)
+            args.unshift("-c")
+            return tabopen(...args).then(() => tabdetach())
         }
     }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2291,6 +2291,7 @@ export async function tabopen(...addressarr: string[]): Promise<browser.tabs.Tab
             args.shift()
             argParse(args)
         } else if (args[0] === "-c") {
+            if (args.length < 2) throw new Error(`You must provide a container name!`)
             // Ignore the -c flag if incognito as containers are disabled.
             if (!win.incognito) {
                 if (args[1] === "firefox-default" || args[1].toLowerCase() === "none") {
@@ -2729,6 +2730,8 @@ export async function mute(...muteArgs: string[]): Promise<void> {
  *
  * `winopen -popup [...]` will open it in a popup window. You can combine the two for a private popup.
  *
+ * `winopen -c containername [...]` will open the result in a container while ignoring other options given. See [[tabopen]] for more details on containers.
+ *
  * Example: `winopen -popup -private ddg.gg`
  */
 //#background
@@ -2740,14 +2743,19 @@ export async function winopen(...args: string[]) {
         switch (args[0]) {
             case "-private":
                 createData.incognito = true
-                args = args.slice(1, args.length)
+                args.shift()
                 firefoxArgs = "--private-window"
                 break
 
             case "-popup":
                 createData.type = "popup"
-                args = args.slice(1, args.length)
+                args.shift()
                 break
+
+            case "-c":
+                if (args.length < 2) throw new Error(`You must provide a container name!`)
+                args.shift()
+                return composite(`tabopen -c ${args.join(" ")} | sleep 100 | tabdetach`)
 
             default:
                 done = true

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2739,6 +2739,7 @@ export async function winopen(...args: string[]) {
     const createData = {} as any
     let firefoxArgs = "--new-window"
     let done = false
+    let useContainer = false
     while (!done) {
         switch (args[0]) {
             case "-private":
@@ -2755,7 +2756,8 @@ export async function winopen(...args: string[]) {
             case "-c":
                 if (args.length < 2) throw new Error(`You must provide a container name!`)
                 args.shift()
-                return composite(`tabopen -c ${args.join(" ")} | sleep 100 | tabdetach`)
+                useContainer = true
+                break
 
             default:
                 done = true
@@ -2764,6 +2766,15 @@ export async function winopen(...args: string[]) {
     }
 
     const address = args.join(" ")
+
+    if (useContainer) {
+        if (firefoxArgs === "--private-window") {
+            throw new Error("Can't open a container in a private browsing window.")
+        } else {
+            return composite(`tabopen -c ${address} ; sleep 100 ; tabdetach`)
+        }
+    }
+
     if (!ABOUT_WHITELIST.includes(address) && /^(about|file):.*/.exec(address)) {
         return nativeopen(firefoxArgs, address)
     }

--- a/src/static/clippy/6-containers.md
+++ b/src/static/clippy/6-containers.md
@@ -9,8 +9,10 @@ The perceived benefits of this feature are as described by the Firefox Test Pilo
 
 ### Container related commands
 * `containercreate name [color] [icon]` Creates a new container. Supplying `name` only will create a container called `name`, a random color and the fingerprint icon.
-* `containerupdate name newname color icon` Updates the container. 
+* `containerupdate name newname color icon` Updates the container.
 * `containerclose name` Closes all tabs in a specified container.
 * `containerdelete name` Deletes a container, calls `containerclose` before deletion
+* `tabopen -c name [url]` Opens a new tab in the container called `name`
+* `winopen -c name [url]` Opens a new window in the container called `name`
 
 The <a href='./7-native_messenger.html' rel='next'>next page</a> is about the native messenger. <a href='./5-settings.html' rel="prev"></a>


### PR DESCRIPTION
Fixes #1126. ```winopen``` now supports ```-c containername``` option. Any additional options like ```-private``` or ```-popup``` are incompatible and therefore ignored. Also catching error for ```tabopen``` if no container name is given.