### PR TITLE
Avoid time paradox when undo tabs

### DIFF
--- a/src/completions/Sessions.ts
+++ b/src/completions/Sessions.ts
@@ -7,13 +7,13 @@ function computeDate(session) {
         ((new Date() as any) - session.lastModified) / 1000,
     )
     let qualifier = "s"
-    if (howLong > 60) {
+    if (Math.abs(howLong) > 60) {
         qualifier = "m"
         howLong = Math.round(howLong / 60)
-        if (howLong > 60) {
+        if (Math.abs(howLong) > 60) {
             qualifier = "h"
             howLong = Math.round(howLong / 60)
-            if (howLong > 24) {
+            if (Math.abs(howLong) > 24) {
                 qualifier = "d"
                 howLong = Math.round(howLong / 24)
             }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2579,6 +2579,7 @@ export async function undo(item = "recent"): Promise<number> {
             : () => {
                   throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
               } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
+    sessions.sort((a, b) => a.lastModified - b.lastModified)
     const session = sessions.find(predicate)
 
     if (session) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2579,7 +2579,6 @@ export async function undo(item = "recent"): Promise<number> {
             : () => {
                   throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
               } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
-    sessions.sort((a, b) => a.lastModified - b.lastModified)
     const session = sessions.find(predicate)
 
     if (session) {


### PR DESCRIPTION
Issue #3302. Sorting the recently closed tabs takes care of @glacambre's case, but there are still cases with three tabs or multiple time jumps where the order is wrong. Have to look at this again.