### PR TITLE
Fix #3298: Prevent words starting with '.' from being treated as a URL.

### DIFF
--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -238,7 +238,7 @@ export async function queryAndURLwrangler(
     try {
         const url = new URL("http://" + address)
         // Ignore unlikely domains
-        if (url.hostname.includes(".") || url.port || url.password) {
+        if (url.hostname.indexOf(".") > 0 || url.port || url.password) {
             return url.href
         }
     } catch (e) {}


### PR DESCRIPTION
Current logic treats queries that can be made into a URL object as a URL if it contains `.` (e.g. `google.com`) this pr changes the logic to ignore cases where the string starts with `.` (e.g. `.thing`).