### PR TITLE
Add tabclosepinned option to config tabclose on pinned tabs

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2511,7 +2511,6 @@ export async function fullscreen() {
 */
 //#background
 export async function tabclose(...indexes: string[]) {
-    let done
     async function maybeWinTabToTabId(id: string) {
         if (id.includes(".")) {
             const [winid, tabindex_number] = await parseWinTabIndex(id)
@@ -2519,14 +2518,7 @@ export async function tabclose(...indexes: string[]) {
         }
         return idFromIndex(id)
     }
-    let ids
-    if (indexes.length > 0) {
-        // Request to close multiple tabs
-        ids = await Promise.all(indexes.map(index => maybeWinTabToTabId(index)))
-    } else {
-        // Request to close the current tab
-        ids = [await activeTabId()]
-    }
+    const ids = await Promise.all(indexes.length > 0 ? indexes.map(maybeWinTabToTabId) : [activeTabId()])
     const tabclosepinned = (await config.getAsync("tabclosepinned") === "true")
     if (!tabclosepinned) {
         // Pinned tabs should not be closed, abort if one of the tabs is pinned

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2528,10 +2528,13 @@ export async function tabclose(...indexes: string[]) {
         ids = [await activeTabId()]
     }
     const tabclosepinned = (await config.getAsync("tabclosepinned") === "true")
-    for (let tab_id of ids) {
-        const tab = (await browser.tabs.query({index: tab_id}))[0]
-        if (tab.pinned && !tabclosepinned) {
-            throw new Error(`Tab $tab_id is pinned and tabclosepinned is false, aborting tabclose`)
+    if (!tabclosepinned) {
+        // Pinned tabs should not be closed
+        for (let tab_id of ids) {
+            const tab = (await browser.tabs.query({index: tab_id}))[0]
+            if (tab.pinned) {
+                throw new Error(`Tab $tab_id is pinned and tabclosepinned is false, aborting tabclose`)
+            }
         }
     }
     return browser.tabs.remove(ids)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2534,7 +2534,7 @@ export async function tabclose(...indexes: string[]) {
         // Pinned tabs should not be closed, abort if one of the tabs is pinned
         for (const tab of tabs) {
             if (tab.pinned) {
-                throw new Error(`Tab ${tab.windowId}:${tab.index} is pinned and tabclosepinned is false, aborting tabclose`)
+                throw new Error(`Tab ${tab.windowId}:${tab.index + 1} is pinned and tabclosepinned is false, aborting tabclose`)
             }
         }
     }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2521,14 +2521,14 @@ export async function fullscreen() {
 */
 //#background
 export async function tabclose(...indexes: string[]) {
-    async function maybeWinTabToTabId(id: string) {
+    async function maybeWinTabToTab(id: string) {
         if (id.includes(".")) {
             const [winid, tabindex_number] = await parseWinTabIndex(id)
             return (await browser.tabs.query({ windowId: winid, index: tabindex_number }))[0]
         }
         return tabFromIndex(id)
     }
-    const tabs = await Promise.all(indexes.length > 0 ? indexes.map(maybeWinTabToTabId) : [activeTab()])
+    const tabs = await Promise.all(indexes.length > 0 ? indexes.map(maybeWinTabToTab) : [activeTab()])
     const tabclosepinned = (await config.getAsync("tabclosepinned")) === "true"
     if (!tabclosepinned) {
         // Pinned tabs should not be closed, abort if one of the tabs is pinned

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2529,7 +2529,7 @@ export async function tabclose(...indexes: string[]) {
     }
     const tabclosepinned = (await config.getAsync("tabclosepinned") === "true")
     if (!tabclosepinned) {
-        // Pinned tabs should not be closed
+        // Pinned tabs should not be closed, abort if one of the tabs is pinned
         for (let tab_id of ids) {
             const tab = (await browser.tabs.query({index: tab_id}))[0]
             if (tab.pinned) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -767,6 +767,11 @@ export class default_config {
     tabopenpos: "next" | "last" | "related" = "next"
 
     /**
+     * When enabled (the default), running tabclose will close the tabs whether they are pinned or not. When disabled, tabclose will fail with an error if a tab is pinned.
+     */
+    tabclosepinned: "true" | "false" = "true"
+
+    /**
      * Controls which tab order to use when opening the tab/buffer list. Either mru = sort by most recent tab or default = by tab index
      */
     tabsort: "mru" | "default" = "default"


### PR DESCRIPTION
:warning: NOT TESTED

Solves #344 

---
NOTE: Another implementation possibility would be to change the function `idFromIndex` to `tabFromIndex` and return a Tab object, which would make it more generic.

And then in tabclose we'd return tabs from `maybeWinTabToTabId` (changing its name to `maybeWinTabToTab`) and make the pinned check earlier.