### PR TITLE
WIP: add keyfake command

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5098,6 +5098,15 @@ export async function keyfeed(mapstr: string) {
     }
 }
 
+//#content
+export async function keyfake(mapstr: string) {
+    const keyseq = mapstrToKeyseq(mapstr)
+    for (const k of keyseq) {
+        window.dispatchEvent(new KeyboardEvent("keydown", k))
+        await sleep(10)
+    }
+}
+
 /**  Open a welcome page on first install.
  *
  * @hidden


### PR DESCRIPTION
Inspired by

> FYI: bind <A-e> js window.dispatchEvent(new KeyboardEvent("keydown", {key: "Escape"})) worked for me! I had issues mapping <A-Escape> for some reason (maybe related to my local autohotkey setup though..), I'll use that in the meantime will test it a few days

from @bew on Matrix.

It doesn't seem to work though. Tested via `:keyfake ga` on GitHub to go to the actions tab and `:keyfake <Esc>` on Squarespace sites (e.g. the Adam Smith Institute) which should take you to the login page. Also tested via the same `:je window.dispatchEvent...` that bew was using.

Perhaps bew just found a very rare website which doesn't check to see if the events are real or fake?