### PR TITLE
Make w in visual mode behave like in vim

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -364,7 +364,7 @@ export class default_config {
         h: 'js document.getSelection().modify("extend","backward","character")',
         e: 'js document.getSelection().modify("extend","forward","word")',
         w:
-            'js document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","forward","character")',
+            'js document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","backward","word"); document.getSelection().modify("extend","forward","character")',
         b:
             'js document.getSelection().modify("extend","backward","character"); document.getSelection().modify("extend","backward","word"); document.getSelection().modify("extend","forward","character")',
         j: 'js document.getSelection().modify("extend","forward","line")',


### PR DESCRIPTION
Issue #3408. 
Not the most straight forward way, but this way ```w``` behaves like in vim even with multiple white space characters or tabs between words.