### PR TITLE
Super ignore mode

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -38,6 +38,8 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
 // running from this entry point, which is to say, everything in the
 // content script, will use the excmds that we give to the module
 // here.
+
+if (TRI_DISABLE === "true") return
 const controller = await import("@src/lib/controller")
 const excmds_content = await import("@src/.excmds_content.generated")
 const hinting_content = await import("@src/content/hinting")
@@ -63,8 +65,6 @@ const scrolling = await import("@src/content/scrolling")
 const R = await import("ramda")
 const visual = await import("@src/lib/visual")
 const metadata = await import("@src/.metadata.generated")
-
-if (TRI_DISABLE === "true") return
 
 controller.setExCmds({
     "": excmds_content,

--- a/src/content.ts
+++ b/src/content.ts
@@ -33,6 +33,36 @@ import * as excmds_content from "@src/.excmds_content.generated"
 import { CmdlineCmds } from "@src/content/commandline_cmds"
 import { EditorCmds } from "@src/content/editor"
 import * as hinting_content from "@src/content/hinting"
+
+// Hook the keyboard up to the controller
+import * as ContentController from "@src/content/controller_content"
+import { getAllDocumentFrames } from "@src/lib/dom"
+
+// Add various useful modules to the window for debugging
+import * as commandline_content from "@src/content/commandline_content"
+import * as convert from "@src/lib/convert"
+import * as config from "@src/lib/config"
+import * as dom from "@src/lib/dom"
+import * as excmds from "@src/.excmds_content.generated"
+import * as finding_content from "@src/content/finding"
+import * as itertools from "@src/lib/itertools"
+import * as messaging from "@src/lib/messaging"
+import state from "@src/state"
+import * as State from "@src/state"
+import * as webext from "@src/lib/webext"
+import * as perf from "@src/perf"
+import * as keyseq from "@src/lib/keyseq"
+import * as native from "@src/lib/native"
+import * as styling from "@src/content/styling"
+import { EditorCmds as editor } from "@src/content/editor"
+import * as updates from "@src/lib/updates"
+import * as urlutils from "@src/lib/url_util"
+import * as scrolling from "@src/content/scrolling"
+import * as R from "ramda"
+import * as visual from "@src/lib/visual"
+import * as metadata from "@src/.metadata.generated"
+/* tslint:disable:import-spacing */
+
 controller.setExCmds({
     "": excmds_content,
     ex: CmdlineCmds,
@@ -50,10 +80,6 @@ messaging.addListener(
 
 // eslint-disable-next-line @typescript-eslint/require-await
 messaging.addListener("alive", async () => true)
-
-// Hook the keyboard up to the controller
-import * as ContentController from "@src/content/controller_content"
-import { getAllDocumentFrames } from "@src/lib/dom"
 
 const guardedAcceptKey = (keyevent: KeyboardEvent) => {
     if (!keyevent.isTrusted) return
@@ -131,31 +157,6 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
     }
     tryPreventAutoFocus()
 })
-
-// Add various useful modules to the window for debugging
-import * as commandline_content from "@src/content/commandline_content"
-import * as convert from "@src/lib/convert"
-import * as config from "@src/lib/config"
-import * as dom from "@src/lib/dom"
-import * as excmds from "@src/.excmds_content.generated"
-import * as finding_content from "@src/content/finding"
-import * as itertools from "@src/lib/itertools"
-import * as messaging from "@src/lib/messaging"
-import state from "@src/state"
-import * as State from "@src/state"
-import * as webext from "@src/lib/webext"
-import * as perf from "@src/perf"
-import * as keyseq from "@src/lib/keyseq"
-import * as native from "@src/lib/native"
-import * as styling from "@src/content/styling"
-import { EditorCmds as editor } from "@src/content/editor"
-import * as updates from "@src/lib/updates"
-import * as urlutils from "@src/lib/url_util"
-import * as scrolling from "@src/content/scrolling"
-import * as R from "ramda"
-import * as visual from "@src/lib/visual"
-import * as metadata from "@src/.metadata.generated"
-/* tslint:disable:import-spacing */
 ;(window as any).tri = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
     commandline_content,

--- a/src/content.ts
+++ b/src/content.ts
@@ -33,7 +33,7 @@ import state from "@src/state"
 import { EditorCmds as editor } from "@src/content/editor"
 /* tslint:disable:import-spacing */
 
-config.getAsync("disable").then(async TRI_DISABLE => {
+config.getAsync("superignore").then(async TRI_DISABLE => {
 // Set up our controller to execute content-mode excmds. All code
 // running from this entry point, which is to say, everything in the
 // content script, will use the excmds that we give to the module

--- a/src/content.ts
+++ b/src/content.ts
@@ -13,7 +13,7 @@ import "@src/lib/html-tagged-template"
 /* import "@src/content/commandline_content" */
 /* import "@src/excmds_content" */
 /* import "@src/content/hinting" */
-import * as Config from "@src/lib/config"
+import * as config from "@src/lib/config"
 import * as Logging from "@src/lib/logging"
 const logger = new Logging.Logger("content")
 logger.debug("Tridactyl content script loaded, boss!")
@@ -24,46 +24,45 @@ import {
     addContentStateChangedListener,
 } from "@src/content/state_content"
 
+import { CmdlineCmds } from "@src/content/commandline_cmds"
+import { EditorCmds } from "@src/content/editor"
+
+import { getAllDocumentFrames } from "@src/lib/dom"
+
+import state from "@src/state"
+import { EditorCmds as editor } from "@src/content/editor"
+/* tslint:disable:import-spacing */
+
+config.getAsync("disable").then(async TRI_DISABLE => {
 // Set up our controller to execute content-mode excmds. All code
 // running from this entry point, which is to say, everything in the
 // content script, will use the excmds that we give to the module
 // here.
-import * as controller from "@src/lib/controller"
-import * as excmds_content from "@src/.excmds_content.generated"
-import { CmdlineCmds } from "@src/content/commandline_cmds"
-import { EditorCmds } from "@src/content/editor"
-import * as hinting_content from "@src/content/hinting"
-
+const controller = await import("@src/lib/controller")
+const excmds_content = await import("@src/.excmds_content.generated")
+const hinting_content = await import("@src/content/hinting")
 // Hook the keyboard up to the controller
-import * as ContentController from "@src/content/controller_content"
-import { getAllDocumentFrames } from "@src/lib/dom"
-
+const ContentController = await import("@src/content/controller_content")
 // Add various useful modules to the window for debugging
-import * as commandline_content from "@src/content/commandline_content"
-import * as convert from "@src/lib/convert"
-import * as config from "@src/lib/config"
-import * as dom from "@src/lib/dom"
-import * as excmds from "@src/.excmds_content.generated"
-import * as finding_content from "@src/content/finding"
-import * as itertools from "@src/lib/itertools"
-import * as messaging from "@src/lib/messaging"
-import state from "@src/state"
-import * as State from "@src/state"
-import * as webext from "@src/lib/webext"
-import * as perf from "@src/perf"
-import * as keyseq from "@src/lib/keyseq"
-import * as native from "@src/lib/native"
-import * as styling from "@src/content/styling"
-import { EditorCmds as editor } from "@src/content/editor"
-import * as updates from "@src/lib/updates"
-import * as urlutils from "@src/lib/url_util"
-import * as scrolling from "@src/content/scrolling"
-import * as R from "ramda"
-import * as visual from "@src/lib/visual"
-import * as metadata from "@src/.metadata.generated"
-/* tslint:disable:import-spacing */
-
-config.getAsync("disable").then(TRI_DISABLE => {
+const commandline_content = await import("@src/content/commandline_content")
+const convert = await import("@src/lib/convert")
+const dom = await import("@src/lib/dom")
+const excmds = await import("@src/.excmds_content.generated")
+const finding_content = await import("@src/content/finding")
+const itertools = await import("@src/lib/itertools")
+const messaging = await import("@src/lib/messaging")
+const State = await import("@src/state")
+const webext = await import("@src/lib/webext")
+const perf = await import("@src/perf")
+const keyseq = await import("@src/lib/keyseq")
+const native = await import("@src/lib/native")
+const styling = await import("@src/content/styling")
+const updates = await import("@src/lib/updates")
+const urlutils = await import("@src/lib/url_util")
+const scrolling = await import("@src/content/scrolling")
+const R = await import("ramda")
+const visual = await import("@src/lib/visual")
+const metadata = await import("@src/.metadata.generated")
 
 if (TRI_DISABLE === "true") return
 
@@ -334,7 +333,7 @@ config.getAsync("modeindicator").then(mode => {
         } else {
             result = mode
         }
-        const modeindicatorshowkeys = Config.get("modeindicatorshowkeys")
+        const modeindicatorshowkeys = config.get("modeindicatorshowkeys")
         if (modeindicatorshowkeys === "true" && suffix !== "") {
             result = mode + " " + suffix
         }

--- a/src/content.ts
+++ b/src/content.ts
@@ -63,6 +63,10 @@ import * as visual from "@src/lib/visual"
 import * as metadata from "@src/.metadata.generated"
 /* tslint:disable:import-spacing */
 
+config.getAsync("disable").then(TRI_DISABLE => {
+
+if (TRI_DISABLE === "true") return
+
 controller.setExCmds({
     "": excmds_content,
     ex: CmdlineCmds,
@@ -415,3 +419,5 @@ document.addEventListener("selectionchange", () => {
 ;(window as any).tri = Object.assign(window.tri, {
     perfObserver: perf.listenForCounters(),
 })
+
+}) // End of maybe-disable-tridactyl-a-bit wrapper

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -34,7 +34,7 @@ let enabled = false
 /** Initialise the cmdline_iframe element unless the window location is included in a value of config/noiframe */
 async function init() {
     const noiframe = await config.getAsync("noiframe")
-    const notridactyl = await config.getAsync("disable")
+    const notridactyl = await config.getAsync("superignore")
     if (noiframe === "false" && notridactyl !== "true" && !enabled) {
         hide()
         document.documentElement.appendChild(cmdline_iframe)

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -34,7 +34,8 @@ let enabled = false
 /** Initialise the cmdline_iframe element unless the window location is included in a value of config/noiframe */
 async function init() {
     const noiframe = await config.getAsync("noiframe")
-    if (noiframe === "false" && !enabled) {
+    const notridactyl = await config.getAsync("disable")
+    if (noiframe === "false" && notridactyl !== "true" && !enabled) {
         hide()
         document.documentElement.appendChild(cmdline_iframe)
         enabled = true

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -181,6 +181,15 @@ export class default_config {
         "🕷🕷INHERITS🕷🕷": "imaps",
     }
 
+    /*
+     * Disable Tridactyl almost completely within a page, e.g. `seturl ^https?://mail.google.com disable true`. Only takes affect on page reload.
+     *
+     * You are usually better off using `blacklistadd` and `seturl [url] noiframe true` as you can then still use some Tridactyl binds.
+     *
+     * NB: you should only use this with `seturl`. If you get trapped with Tridactyl disabled everywhere just run `tri reset disable` in the Firefox address bar.
+     */
+    disable: "true" | "false" = "false"
+
     /**
      * nmaps contain all of the bindings for "normal mode".
      *

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -184,9 +184,9 @@ export class default_config {
     /*
      * Disable Tridactyl almost completely within a page, e.g. `seturl ^https?://mail.google.com disable true`. Only takes affect on page reload.
      *
-     * You are usually better off using `blacklistadd` and `seturl [url] noiframe true` as you can then still use some Tridactyl binds.
+     * You are usually better off using `blacklistadd` and `seturl [url] noiframe true` as you can then still use some Tridactyl binds, e.g. `shift-insert` for exiting ignore mode.
      *
-     * NB: you should only use this with `seturl`. If you get trapped with Tridactyl disabled everywhere just run `tri reset disable` in the Firefox address bar.
+     * NB: you should only use this with `seturl`. If you get trapped with Tridactyl disabled everywhere just run `tri reset superignore` in the Firefox address bar. If that still doesn't fix things, you can totally reset Tridactyl by running `tri help superignore` in the Firefox address bar, scrolling to the bottom of that page and then clicking "Reset Tridactyl config".
      */
     superignore: "true" | "false" = "false"
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -188,7 +188,7 @@ export class default_config {
      *
      * NB: you should only use this with `seturl`. If you get trapped with Tridactyl disabled everywhere just run `tri reset disable` in the Firefox address bar.
      */
-    disable: "true" | "false" = "false"
+    superignore: "true" | "false" = "false"
 
     /**
      * nmaps contain all of the bindings for "normal mode".

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
+    "module": "es2020",
     "esModuleInterop": true,
     "noImplicitAny": false,
     "noEmitOnError": true,
     "outDir": "build/tsc-out",
     "sourceMap": true,
     "target": "es2019",
-    "lib": ["es2019", "dom", "dom.iterable"],
+    "lib": ["es2020", "dom", "dom.iterable"],
     "experimentalDecorators": true,
     "alwaysStrict": true,
     "strictBindCallApply": true,


### PR DESCRIPTION
Fixes #2004. Related to #822

- Needs thorough testing to see if it breaks anything that needs to run quickly (e.g. DocStart autocmds)
- It looks like we can't prevent CSS from loading as we hardcode it in `manifest.json`. We could potentially switch to using `tabs.insertCSS` - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/insertCSS - but that could be a pain. I suspect it isn't worth delaying this PR for it
- Need better documentation. `disable` is a bad name for a setting IMO