### PR TITLE
Windows: add `start /wait` as a terminal emulator to getBestEditor()

### DIFF
--- a/src/lib/native.ts
+++ b/src/lib/native.ts
@@ -167,6 +167,9 @@ export async function getBestEditor(): Promise<string> {
             term_emulators.push(
                 ...["conemu -run", "mintty --class tridactyl_editor -e"],
             )
+            if (await nativegate("0.2.1", false)) {
+                term_emulators.push("start /wait")
+            }
         }
         // These terminal emulators are cross-platform.
         term_emulators.push(


### PR DESCRIPTION
This gives Windows users a fighting chance at having a working default
for `:editor` by making it not dependent on them using a custom terminal
emulator.

Addresses part of #3150