### PR TITLE
Refactor :hint

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1135,33 +1135,6 @@ export function killables(includeInvisible = false) {
     ])
 }
 
-/** HintPage wrapper, accepts CSS selectors to build a list of elements
- * @hidden
- * */
-export function pipe(
-    selectors = DOM.HINTTAGS_selectors,
-    action: HintSelectedCallback = _ => _,
-    rapid = false,
-    jshints = true,
-): Promise<[Element, number]> {
-    return new Promise((resolve, reject) => {
-        hintPage(hintables(selectors, jshints), action, resolve, reject, rapid)
-    })
-}
-
-/** HintPage wrapper, accepts array of elements to hint
- * @hidden
- * */
-export function pipe_elements(
-    elements: Element[] | Hintables[] = DOM.elementsWithText(),
-    action: HintSelectedCallback = _ => _,
-    rapid = false,
-): Promise<[Element, number]> {
-    return new Promise((resolve, reject) => {
-        hintPage(toHintablesArray(elements), action, resolve, reject, rapid)
-    })
-}
-
 // Multiple dispatch? who needs it
 /** Returns an array of hintable objects from an array of elements
  * @hidden

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1113,8 +1113,7 @@ export function hintByTextFilter(match: string | RegExp): HintSelectedCallback {
     return hint => {
         let text
         if (hint instanceof HTMLInputElement) {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-            text = (hint as HTMLInputElement).value
+            text = hint.value
         } else {
             text = hint.textContent
         }

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -668,6 +668,10 @@ class Hint {
         this.hidden = false
     }
 
+    public static isHintable(target: Element): boolean {
+        return target.getClientRects().length > 0
+    }
+
     setName(n: string) {
         this.name = n
         this.flag.textContent = this.name
@@ -749,7 +753,7 @@ function buildHintsSimple(
     hintables: Hintables,
     onSelect: HintSelectedCallback,
 ) {
-    const els = hintables.elements
+    const els = hintables.elements.filter((el) => Hint.isHintable(el))
     const names = Array.from(
         hintnames(els.length + modeState.hints.length),
     ).slice(modeState.hints.length)
@@ -800,7 +804,7 @@ function buildHintsVimperator(
     hintables: Hintables,
     onSelect: HintSelectedCallback,
 ) {
-    const els = hintables.elements
+    const els = hintables.elements.filter((el) => Hint.isHintable(el))
     const names = Array.from(
         hintnames(els.length + modeState.hints.length),
     ).slice(modeState.hints.length)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4308,6 +4308,7 @@ const KILL_STACK: Element[] = []
         - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
         - -J* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
           - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
+        - -br deprecated, use `-qb` instead
         - -F [callback] - run a custom callback on the selected hint, e.g. `hint -JF e => {tri.excmds.tabopen("-b",e.href); e.remove()}`.
         - -V create hints for invisible elements. By default, elements outside the viewport when calling :hint are not hinted, this includes them anyways.
         - -! perform action immediately. This effectively selects every hinted element in sequence

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4311,10 +4311,10 @@ const KILL_STACK: Element[] = []
         - -br deprecated, use `-qb` instead
         - -F [callback] - run a custom callback on the selected hint, e.g. `hint -JF e => {tri.excmds.tabopen("-b",e.href); e.remove()}`.
         - -V create hints for invisible elements. By default, elements outside the viewport when calling :hint are not hinted, this includes them anyways.
-        - -! perform action immediately. This effectively selects every hinted element in sequence
+        - -! execute all hints without waiting for a selection
           - For example, `hint -!bf Comments` opens in background tabs all visible links whose text matches `Comments`
 
-    Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.
+    Excepting the custom selector mode, background hint mode and the "immediate" modifier, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.
 
     To open a hint in the background, the default bind is `F`.
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4544,7 +4544,11 @@ export async function hint(...args: string[]): Promise<any> {
     }).then(value => {
         // Fix #1374 for all types of yanks: join returned results
         if (config.isYank) {
-            yank((value as string[]).join("\n"))
+            if (Array.isArray(value)) {
+                yank(value.join("\n"))
+            } else {
+                yank(value as string)
+            }
         }
 
         return value

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -94,6 +94,7 @@ import * as escape from "@src/lib/escape"
 import * as R from "ramda"
 import semverCompare from "semver-compare"
 import * as hint_util from "@src/lib/hint_util"
+import { OpenMode } from "@src/lib/hint_util"
 
 /**
  * This is used to drive some excmd handling in `composite`.
@@ -4365,9 +4366,6 @@ const KILL_STACK: Element[] = []
 */
 //#content
 export async function hint(...args: string[]): Promise<any> {
-    // Alias to save some typing
-    const OpenMode = hint_util.OpenMode
-
     // Parse configuration and print parsing warnings
     const config = hint_util.HintConfig.parse(args)
     config.printWarnings(logger)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4275,7 +4275,11 @@ const KILL_STACK: Element[] = []
 
 /** Hint a page.
 
-    @param args
+    @param args Arguments to the `:hint` command. Multiple flags can be combined as long as they don't conflict.
+    Selectors can be specified either standalone (without a flag preceding them) or with the `-c` option. Arguments that
+    take callbacks (`-F` or `-W`) should be specified last, as they consume the rest of the command line.
+
+    Hinting action flags (only one can be specified):
         - -t open in a new foreground tab
         - -b open in background
         - -y copy (yank) link's target to clipboard
@@ -4293,6 +4297,14 @@ const KILL_STACK: Element[] = []
         - -A save-as the linked image
         - -; focus an element and set it as the element or the child of the element to scroll
         - -# yank an element's anchor URL to clipboard
+        - -w open in new window
+        - -wp open in new private window
+        - -z scroll an element to the top of the viewport
+        - `-pipe selector key` e.g, `-pipe a href` returns the URL of the chosen link on a page. Only makes sense with `composite`, e.g, `composite hint -pipe .some-class>a textContent | yank`. If you don't select a hint (i.e. press <Esc>), will return an empty string. Most useful when used like `-c` to do things other than opening links. NB: the query selector cannot contain any spaces.
+        - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W mpvsafe` to open YouTube videos. NB: appending to bare [[exclaim]] is dangerous - see `get exaliases.mpvsafe` for an example of how to to it safely. If you need to use a query selector, use `-pipe` instead.
+        - -F [callback] - run a custom callback on the selected hint, e.g. `hint -JF e => {tri.excmds.tabopen("-b",e.href); e.remove()}`.
+
+    Element selection flags:
         - -c [selector] hint links that match the css selector
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
           - this works with most other hint modes, with the caveat that if other hint mode takes arguments your selector must contain no spaces, i.e. `hint -c[yourOtherFlag] [selector] [your other flag's arguments, which may contain spaces]`
@@ -4300,19 +4312,17 @@ const KILL_STACK: Element[] = []
           - `bind <c-e> hint -f Edit`
           - Backslashes can escape spaces: `bind <c-s> hint -f Save\ as`
         - -fr [text] use RegExp to hint the links and inputs
-        - -w open in new window
-        - -wp open in new private window
-        - -z scroll an element to the top of the viewport
-        - `-pipe selector key` e.g, `-pipe a href` returns the URL of the chosen link on a page. Only makes sense with `composite`, e.g, `composite hint -pipe .some-class>a textContent | yank`. If you don't select a hint (i.e. press <Esc>), will return an empty string. Most useful when used like `-c` to do things other than opening links. NB: the query selector cannot contain any spaces.
-        - `-W excmd...` append hint href to excmd and execute, e.g, `hint -W mpvsafe` to open YouTube videos. NB: appending to bare [[exclaim]] is dangerous - see `get exaliases.mpvsafe` for an example of how to to it safely. If you need to use a query selector, use `-pipe` instead.
-        - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
         - -J* disable javascript hints. Don't generate hints related to javascript events. This is particularly useful when used with the `-c` option when you want to generate only hints for the specified css selectors. Also useful on sites with plenty of useless javascript elements such as google.com
-          - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
-        - -br deprecated, use `-qb` instead
-        - -F [callback] - run a custom callback on the selected hint, e.g. `hint -JF e => {tri.excmds.tabopen("-b",e.href); e.remove()}`.
         - -V create hints for invisible elements. By default, elements outside the viewport when calling :hint are not hinted, this includes them anyways.
+
+    Hinting mode selection:
+        - -q* quick (or rapid) hints mode. Stay in hint mode until you press <Esc>, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
+          - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
         - -! execute all hints without waiting for a selection
           - For example, `hint -!bf Comments` opens in background tabs all visible links whose text matches `Comments`
+
+    Deprecated options:
+        - -br deprecated, use `-qb` instead
 
     Excepting the custom selector mode, background hint mode and the "immediate" modifier, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4447,7 +4447,7 @@ export async function hint(...args: string[]): Promise<any> {
                           elem.scrollIntoView(true)
                           return elem
 
-                      case OpenMode.Semicolon:
+                      case OpenMode.ScrollFocus:
                           let tabindexAdded = false
                           // img can only be focused when they have the tabindex attribute
                           if (elem instanceof HTMLImageElement && !elem.getAttribute("tabindex")) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4456,6 +4456,7 @@ export async function hint(...args: string[]): Promise<any> {
                                 break
                             case "c":
                                 state = State.ExpectSelector
+                                break
                             case "!":
                                 immediate = true
                                 break

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4631,46 +4631,48 @@ export async function hint(...args: string[]): Promise<any> {
     return new Promise((resolve, reject) => {
         let hintables
 
-        // Use the selectors to find hintable elements
-        switch (openMode) {
-            case OpenMode.YankText:
-            case OpenMode.Highlight:
-            case OpenMode.Scroll:
-                // For text-based opens, look for elements with text by default
-                hintables = hinting.toHintablesArray(DOM.elementsWithText(includeInvisible))
-                break
+        // User selectors always override default built-ins
+        if (positionals.length > 0) {
+            hintables = hinting.hintables(positionals.join(" "), jshints, includeInvisible)
+        } else {
+            // Use the default selectors to find hintable elements
+            switch (openMode) {
+                case OpenMode.YankText:
+                case OpenMode.Highlight:
+                case OpenMode.Scroll:
+                    // For text-based opens, look for elements with text by default
+                    hintables = hinting.toHintablesArray(DOM.elementsWithText(includeInvisible))
+                    break
 
-            case OpenMode.YankAlt:
-                hintables = hinting.toHintablesArray(DOM.getElemsBySelector("[title],[alt]", [DOM.isVisibleFilter(includeInvisible)]))
-                break
+                case OpenMode.YankAlt:
+                    hintables = hinting.toHintablesArray(DOM.getElemsBySelector("[title],[alt]", [DOM.isVisibleFilter(includeInvisible)]))
+                    break
 
-            case OpenMode.YankAnchor:
-                hintables = hinting.toHintablesArray(DOM.anchors(includeInvisible))
-                break
+                case OpenMode.YankAnchor:
+                    hintables = hinting.toHintablesArray(DOM.anchors(includeInvisible))
+                    break
 
-            case OpenMode.Images:
-            case OpenMode.ImagesTab:
-            case OpenMode.SaveImage:
-            case OpenMode.SaveAsImage:
-                // TODO: Support custom image selectors?
-                hintables = hinting.toHintablesArray(hinting.hintableImages(includeInvisible))
-                break
+                case OpenMode.Images:
+                case OpenMode.ImagesTab:
+                case OpenMode.SaveImage:
+                case OpenMode.SaveAsImage:
+                    hintables = hinting.toHintablesArray(hinting.hintableImages(includeInvisible))
+                    break
 
-            case OpenMode.Kill:
-            case OpenMode.KillTridactyl:
-                // TODO: Support custom killable selectors?
-                hintables = hinting.toHintablesArray(hinting.killables(includeInvisible))
-                break
+                case OpenMode.Kill:
+                case OpenMode.KillTridactyl:
+                    hintables = hinting.toHintablesArray(hinting.killables(includeInvisible))
+                    break
 
-            case OpenMode.SaveResource:
-            case OpenMode.SaveAsResource:
-                // TODO: Support custom saveable selectors?
-                hintables = hinting.toHintablesArray(hinting.saveableElements(includeInvisible))
-                break
+                case OpenMode.SaveResource:
+                case OpenMode.SaveAsResource:
+                    hintables = hinting.toHintablesArray(hinting.saveableElements(includeInvisible))
+                    break
 
-            default:
-                hintables = hinting.hintables(positionals.length ? positionals.join(" ") : DOM.HINTTAGS_selectors, jshints, includeInvisible)
-                break
+                default:
+                    hintables = hinting.hintables(DOM.HINTTAGS_selectors, jshints, includeInvisible)
+                    break
+            }
         }
 
         // Do we have text filters to refine this?

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4572,10 +4572,14 @@ export async function hint(...args: string[]): Promise<any> {
             case State.ExpectExcmd:
                 // Collect all the remaining arguments into a excmd callback
                 excmd = args.slice(argI).join(" ")
+                // Reset state to initial, parsing was successful
+                state = State.Initial
                 break outer
             case State.ExpectCallback:
                 // Collect all the remaining arguments into a Javascript callback
                 callback = args.slice(argI).join(" ")
+                // Reset state to initial, parsing was successful
+                state = State.Initial
                 break outer
             case State.ExpectSelector:
                 // -c, expect a single selector
@@ -4583,6 +4587,11 @@ export async function hint(...args: string[]): Promise<any> {
                 state = State.Initial
                 break
         }
+    }
+
+    if (state !== State.Initial) {
+        // If we didn't return to the initial state, we were expecting an option value
+        logger.warning("error parsing options: expected a value")
     }
 
     const hintTabOpen = async (href, active = !rapid) => {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4292,6 +4292,9 @@ const KILL_STACK: Element[] = []
         - -A save-as the linked image
         - -; focus an element and set it as the element or the child of the element to scroll
         - -# yank an element's anchor URL to clipboard
+        - -c [selector] hint links that match the css selector
+          - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
+          - this works with most other hint modes, with the caveat that if other hint mode takes arguments your selector must contain no spaces, i.e. `hint -c[yourOtherFlag] [selector] [your other flag's arguments, which may contain spaces]`
         - -f [text] hint links and inputs that display the given text
           - `bind <c-e> hint -f Edit`
           - Backslashes can escape spaces: `bind <c-s> hint -f Save\ as`
@@ -4308,8 +4311,6 @@ const KILL_STACK: Element[] = []
         - -V create hints for invisible elements. By default, elements outside the viewport when calling :hint are not hinted, this includes them anyways.
         - -! perform action immediately. This effectively selects every hinted element in sequence
           - For example, `hint -!bf Comments` opens in background tabs all visible links whose text matches `Comments`
-        - [selector] hint links that match the css selector
-          - `bind ;c hint [class*="expand"],[class="togg"]` works particularly well on reddit and HN
 
     Excepting the custom selector mode and background hint mode, each of these hint modes is available by default as `;<option character>`, so e.g. `;y` to yank a link's target; `;g<option character>` starts rapid hint mode for all modes where it makes sense, and some others.
 
@@ -4359,6 +4360,7 @@ export async function hint(...args: string[]): Promise<any> {
         ExpectFR,
         ExpectCallback,
         ExpectExcmd,
+        ExpectSelector,
     }
 
     // Open mode: how to act on the selected hintable element
@@ -4446,6 +4448,8 @@ export async function hint(...args: string[]): Promise<any> {
                             case "W":
                                 state = State.ExpectExcmd
                                 break
+                            case "c":
+                                state = State.ExpectSelector
                             case "!":
                                 immediate = true
                                 break
@@ -4573,6 +4577,11 @@ export async function hint(...args: string[]): Promise<any> {
                 // Collect all the remaining arguments into a Javascript callback
                 callback = args.slice(argI).join(" ")
                 break outer
+            case State.ExpectSelector:
+                // -c, expect a single selector
+                positionals.push(arg)
+                state = State.Initial
+                break
         }
     }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -298,6 +298,7 @@ export class default_config {
         ";;": "hint -; *",
         ";#": "hint -#",
         ";v": "hint -W mpvsafe",
+        ";V": "hint -V",
         ";w": "hint -w",
         ";t": "hint -W tabopen",
         ";O": "hint -W fillcmdline_notrail open ",

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -119,8 +119,11 @@ export function mouseEvent(
     })
 }
 
-export function elementsWithText() {
-    return getElemsBySelector("*", [isVisible, hint => hint.textContent !== ""])
+export function elementsWithText(includeInvisible = false) {
+    return getElemsBySelector("*", [
+        isVisibleFilter(includeInvisible),
+        hint => hint.textContent !== "",
+    ])
 }
 
 /** Iterable of elements that match xpath.
@@ -200,6 +203,12 @@ export function widthMatters(style: CSSStyleDeclaration) {
             return false
     }
     return true
+}
+
+export function isVisibleFilter(
+    includeInvisible: boolean,
+): (_: Element) => boolean {
+    return (elem: Element) => includeInvisible || isVisible(elem)
 }
 
 // Saka-key caches getComputedStyle. Maybe it's a good idea!
@@ -651,8 +660,10 @@ export const HINTTAGS_saveable = `
 /** Get array of "anchors": elements which have id or name and can be addressed
  * with the hash/fragment in the URL
  */
-export function anchors() {
-    return getElemsBySelector(HINTTAGS_anchor_selectors, [isVisible])
+export function anchors(includeInvisible = false) {
+    return getElemsBySelector(HINTTAGS_anchor_selectors, [
+        isVisibleFilter(includeInvisible),
+    ])
 }
 
 /** if `target === _blank` clicking the link is treated as opening a popup and is blocked. Use webext API to avoid that. */

--- a/src/lib/hint_util.test.ts
+++ b/src/lib/hint_util.test.ts
@@ -1,0 +1,157 @@
+/** Testing the new argument parser for :hint */
+
+import { OpenMode, HintConfig } from "@src/lib/hint_util"
+
+expect.extend({
+    toMatchOptions(received: HintConfig, expected: any) {
+        const errors = []
+
+        // For each key in the expected object, check the parsed option matches the value
+        for (const [key, value] of Object.entries(expected)) {
+            let result: boolean
+
+            if (Array.isArray(value)) {
+                // Arrays need special handling instead of ===
+                result =
+                    value.length == received[key].length &&
+                    value.every((val, i) => received[key][i] === val)
+            } else {
+                result = received[key] === value
+            }
+
+            if (!result) {
+                // Add to error list when the comparison fails
+                errors.push(
+                    `expected ${key} === ${JSON.stringify(
+                        value,
+                    )}, got ${JSON.stringify(received[key])}`,
+                )
+            }
+        }
+
+        if (errors.length > 0) {
+            return { message: () => errors.join("\n"), pass: false }
+        } else {
+            return {
+                message: () =>
+                    `expected ${JSON.stringify(
+                        received,
+                    )} to not match ${JSON.stringify(expected)}`,
+                pass: true,
+            }
+        }
+    },
+})
+
+// Add this type definition so Jest/TypeScript doesn't complain
+declare global {
+    namespace jest {
+        interface Matchers<R> {
+            toMatchOptions(expected: any): CustomMatcherResult
+        }
+    }
+}
+
+// Most test cases are from GitHub advanced search:
+// https://github.com/search?q=hint+filename%3Atridactylrc+filename%3A.tridactylrc&type=Code&ref=advsearch&l=&l=
+//
+// Expected results are written based on what the doc (spec) specifies, and the
+// new parser should observe those options correctly.
+const testCases = [
+    {
+        sources: ["-b"],
+        expected: {
+            openMode: OpenMode.BackgroundTab,
+            warnings: [],
+        },
+    },
+    {
+        sources: ["-br", "-qb"],
+        expected: {
+            rapid: true,
+            openMode: OpenMode.BackgroundTab,
+            warnings: [],
+        },
+    },
+    {
+        sources: ["-i"],
+        expected: {
+            openMode: OpenMode.Images,
+            warnings: [],
+        },
+    },
+    {
+        sources: ['-c [class*="expand"],[class="togg"]'],
+        expected: {
+            selectors: ['[class*="expand"],[class="togg"]'],
+            warnings: [],
+        },
+    },
+    {
+        sources: [
+            "-cF img i => tri.excmds.yankimage(tri.urlutils.getAbsoluteURL(i.src))",
+        ],
+        expected: {
+            selectors: ["img"],
+            callback:
+                "i => tri.excmds.yankimage(tri.urlutils.getAbsoluteURL(i.src))",
+            warnings: [],
+        },
+    },
+    {
+        sources: [
+            "-qW js -p tri.excmds.shellescape(JS_ARG).then(url => tri.excmds.exclaim_quiet('~/scripts/mpv/append ' + url))",
+        ],
+        expected: {
+            rapid: true,
+            excmd:
+                "js -p tri.excmds.shellescape(JS_ARG).then(url => tri.excmds.exclaim_quiet('~/scripts/mpv/append ' + url))",
+            warnings: [],
+        },
+    },
+    {
+        sources: ["-Jbc [data-test-id=post-content] a,.Comment a"],
+        expected: {
+            jshints: false,
+            openMode: OpenMode.BackgroundTab,
+            selectors: ["[data-test-id=post-content]", "a,.Comment", "a"],
+            warnings: [],
+        },
+    },
+    {
+        sources: ["-Jc .rc > .r > a"],
+        expected: {
+            jshints: false,
+            selectors: [".rc", ">", ".r", ">", "a"],
+            warnings: [],
+        },
+    },
+    {
+        sources: [
+            "-Jcb ul:not(#duckbar_dropdowns) .zcm__item .zcm__link,.result__a,.result--more",
+        ],
+        expected: {
+            jshints: false,
+            openMode: OpenMode.BackgroundTab,
+            selectors: [
+                "ul:not(#duckbar_dropdowns)",
+                ".zcm__item",
+                ".zcm__link,.result__a,.result--more",
+            ],
+            warnings: [],
+        },
+    },
+]
+
+// Check all test cases
+for (const { sources, expected } of testCases) {
+    for (const source of sources) {
+        // Split the command line into arguments
+        const args = source.split(" ")
+
+        // Parse and compare
+        test(source, () =>
+            expect(HintConfig.parse(args)).toMatchOptions(expected),
+        )
+    }
+}

--- a/src/lib/hint_util.test.ts
+++ b/src/lib/hint_util.test.ts
@@ -141,6 +141,15 @@ const testCases = [
             warnings: [],
         },
     },
+    {
+        sources: ["-qpipe a href"],
+        expected: {
+            rapid: true,
+            pipeAttribute: "href",
+            selectors: ["a"],
+            warnings: [],
+        },
+    },
 ]
 
 // Check all test cases

--- a/src/lib/hint_util.ts
+++ b/src/lib/hint_util.ts
@@ -25,8 +25,7 @@ export enum OpenMode {
     SaveImage = "-S",
     SaveAsResource = "-a",
     SaveAsImage = "-A",
-    // TODO: What does this actually do? The doc is unclear
-    Semicolon = "-;",
+    ScrollFocus = "-;",
     TTSRead = "-r",
     YankAlt = "-P",
     YankAnchor = "-#",
@@ -187,7 +186,7 @@ export class HintConfig implements HintOptions {
                                     newOpenMode = OpenMode.SaveAsImage
                                     break
                                 case ";":
-                                    newOpenMode = OpenMode.Semicolon
+                                    newOpenMode = OpenMode.ScrollFocus
                                     break
                                 case "r":
                                     newOpenMode = OpenMode.TTSRead

--- a/src/lib/hint_util.ts
+++ b/src/lib/hint_util.ts
@@ -412,4 +412,13 @@ export class HintConfig implements HintOptions {
 
         return hintables
     }
+
+    public get isYank() {
+        return (
+            this.openMode === OpenMode.YankAnchor ||
+            this.openMode === OpenMode.YankAlt ||
+            this.openMode === OpenMode.YankLink ||
+            this.openMode === OpenMode.YankText
+        )
+    }
 }

--- a/src/lib/hint_util.ts
+++ b/src/lib/hint_util.ts
@@ -1,0 +1,392 @@
+/**
+ * Helper types for :hint
+ */
+
+import Logger from "@src/lib/logging"
+import * as DOM from "@src/lib/dom"
+import * as hinting from "@src/content/hinting"
+
+/**
+ * Open mode: how to act on the selected hintable element
+ */
+export enum OpenMode {
+    Default = "",
+    Tab = "-t",
+    BackgroundTab = "-b",
+    Window = "-w",
+    WindowPrivate = "-wp",
+    Highlight = "-h",
+    Images = "-i",
+    ImagesTab = "-I",
+    Kill = "-k",
+    KillTridactyl = "-K",
+    Scroll = "-z",
+    SaveResource = "-s",
+    SaveImage = "-S",
+    SaveAsResource = "-a",
+    SaveAsImage = "-A",
+    // TODO: What does this actually do? The doc is unclear
+    Semicolon = "-;",
+    TTSRead = "-r",
+    YankAlt = "-P",
+    YankAnchor = "-#",
+    YankLink = "-y",
+    YankText = "-p",
+}
+
+/**
+ * Hinting parameters interface
+ */
+export interface HintOptions {
+    rapid: boolean
+    textFilter: null | string | RegExp
+    openMode: OpenMode
+    includeInvisible: boolean
+    immediate: boolean
+    jshints: boolean
+    callback: null | string
+    excmd: null | string
+    pipeAttribute: null | string
+    selectors: string[]
+    warnings: string[]
+}
+
+/**
+ * Hinting parameters class for parsing
+ */
+export class HintConfig implements HintOptions {
+    public rapid = false
+    public textFilter = null
+    public openMode = OpenMode.Default
+    public includeInvisible = false
+    public immediate = false
+    public jshints = true
+    public callback = null
+    public excmd = null
+    public pipeAttribute = null
+    public selectors = []
+    public warnings = []
+
+    public static parse(args: string[]): HintConfig {
+        // Argument parser state
+        enum State {
+            Initial,
+            ExpectF,
+            ExpectFR,
+            ExpectCallback,
+            ExpectExcmd,
+            ExpectSelector,
+            ExpectPipeSelector,
+            ExpectPipeAttribute,
+        }
+
+        const result = new HintConfig()
+
+        // Parser state
+        let state = State.Initial
+
+        outer: for (let argI = 0; argI < args.length; ++argI) {
+            const arg = args[argI]
+
+            switch (state) {
+                case State.Initial:
+                    if (arg == "-pipe") {
+                        // Special case for -pipe, which is not a |1,2]-letter argument
+                        state = State.ExpectPipeSelector
+                    } else if (
+                        arg.length >= 2 &&
+                        arg[0] === "-" &&
+                        arg[1] !== "-"
+                    ) {
+                        // Parse short arguments, i.e. - followed by (mostly) single-letter arguments,
+                        // and some two-letter arguments.
+
+                        let last = ""
+                        for (let i = 1; i < arg.length; ++i) {
+                            const letter = arg[i]
+                            let flag = letter
+
+                            // Fix two-letter flags like fr
+                            if (
+                                (last === "f" && letter === "r") ||
+                                (last === "w" && letter === "p")
+                            ) {
+                                flag = last + letter
+                            }
+
+                            // Process flag
+                            let newOpenMode: undefined | OpenMode
+                            switch (flag) {
+                                case "q":
+                                    result.rapid = true
+                                    break
+                                case "f":
+                                    state = State.ExpectF
+                                    break
+                                case "fr":
+                                    state = State.ExpectFR
+                                    break
+                                case "V":
+                                    result.includeInvisible = true
+                                    break
+                                case "J":
+                                    result.jshints = false
+                                    break
+                                case "F":
+                                    state = State.ExpectCallback
+                                    break
+                                case "W":
+                                    state = State.ExpectExcmd
+                                    break
+                                case "c":
+                                    state = State.ExpectSelector
+                                    break
+                                case "!":
+                                    result.immediate = true
+                                    break
+                                case "t":
+                                    newOpenMode = OpenMode.Tab
+                                    break
+                                case "b":
+                                    newOpenMode = OpenMode.BackgroundTab
+                                    break
+                                case "w":
+                                    newOpenMode = OpenMode.Window
+                                    break
+                                case "wp":
+                                    newOpenMode = OpenMode.WindowPrivate
+                                    break
+                                case "h":
+                                    newOpenMode = OpenMode.Highlight
+                                    break
+                                case "i":
+                                    newOpenMode = OpenMode.Images
+                                    break
+                                case "I":
+                                    newOpenMode = OpenMode.ImagesTab
+                                    break
+                                case "k":
+                                    newOpenMode = OpenMode.Kill
+                                    break
+                                case "K":
+                                    newOpenMode = OpenMode.KillTridactyl
+                                    break
+                                case "z":
+                                    newOpenMode = OpenMode.Scroll
+                                    break
+                                case "s":
+                                    newOpenMode = OpenMode.SaveResource
+                                    break
+                                case "S":
+                                    newOpenMode = OpenMode.SaveImage
+                                    break
+                                case "a":
+                                    newOpenMode = OpenMode.SaveAsResource
+                                    break
+                                case "A":
+                                    newOpenMode = OpenMode.SaveAsImage
+                                    break
+                                case ";":
+                                    newOpenMode = OpenMode.Semicolon
+                                    break
+                                case "r":
+                                    newOpenMode = OpenMode.TTSRead
+                                    break
+                                case "P":
+                                    newOpenMode = OpenMode.YankAlt
+                                    break
+                                case "#":
+                                    newOpenMode = OpenMode.YankAnchor
+                                    break
+                                case "y":
+                                    newOpenMode = OpenMode.YankLink
+                                    break
+                                case "p":
+                                    newOpenMode = OpenMode.YankText
+                                    break
+                                default:
+                                    result.warnings.push(
+                                        `unknown flag -${flag}`,
+                                    )
+                                    break
+                            }
+
+                            if (newOpenMode !== undefined) {
+                                if (result.openMode !== OpenMode.Default) {
+                                    // Notify that multiple open modes doesn't make sense
+                                    result.warnings.push(
+                                        "multiple open mode flags specified, overriding the previous ones",
+                                    )
+                                }
+
+                                result.openMode = newOpenMode
+                            }
+
+                            // If we are now expecting a value, check that this is the last flag
+                            if (state !== State.Initial && i < arg.length - 1) {
+                                const remaining = arg.substring(i + 1)
+
+                                if (
+                                    (flag === "f" && remaining !== "r") ||
+                                    (flag === "w" && remaining !== "p")
+                                ) {
+                                    result.warnings.push(
+                                        `-${flag} expects a value, so it should be the last flag in a combined option. The following flags (${remaining}) were ignored`,
+                                    )
+                                    break
+                                }
+                            }
+
+                            last = letter
+                        }
+                    } else {
+                        // Not something that looks like an argument, add it to positionals for later processing
+                        result.selectors.push(arg)
+                    }
+                    break
+                case State.ExpectF:
+                case State.ExpectFR:
+                    // Collect arguments using escapes
+                    let filter = arg
+                    while (filter.endsWith("\\")) {
+                        filter = filter.substring(0, filter.length - 1)
+
+                        if (argI + 1 < args.length) {
+                            filter += " " + args[++argI]
+                        } else {
+                            break
+                        }
+                    }
+
+                    if (state == State.ExpectF) {
+                        // -f
+                        result.textFilter = filter
+                    } else {
+                        // -fr
+                        result.textFilter = new RegExp(filter)
+                    }
+
+                    state = State.Initial
+
+                    break
+                case State.ExpectExcmd:
+                    // Collect all the remaining arguments into a excmd callback
+                    result.excmd = args.slice(argI).join(" ")
+                    // Reset state to initial, parsing was successful
+                    state = State.Initial
+                    break outer
+                case State.ExpectCallback:
+                    // Collect all the remaining arguments into a Javascript callback
+                    result.callback = args.slice(argI).join(" ")
+                    // Reset state to initial, parsing was successful
+                    state = State.Initial
+                    break outer
+                case State.ExpectSelector:
+                    // -c, expect a single selector
+                    result.selectors.push(arg)
+                    state = State.Initial
+                    break
+                case State.ExpectPipeSelector:
+                    // -pipe, first expect a selector
+                    result.selectors.push(arg)
+                    // Then, expect the attribute
+                    state = State.ExpectPipeAttribute
+                    break
+                case State.ExpectPipeAttribute:
+                    // -pipe, second argument
+                    result.pipeAttribute = arg
+                    // Keep parsing options when we're done
+                    state = State.Initial
+                    break
+            }
+        }
+
+        if (state !== State.Initial) {
+            // If we didn't return to the initial state, we were expecting an option value
+            result.warnings.push("error parsing options: expected a value")
+        }
+
+        return result
+    }
+
+    public printWarnings(logger: Logger) {
+        for (const warning of this.warnings) {
+            logger.warning(warning)
+        }
+    }
+
+    defaultHintables() {
+        // Use the default selectors to find hintable elements
+        switch (this.openMode) {
+            case OpenMode.YankText:
+            case OpenMode.Highlight:
+            case OpenMode.Scroll:
+                // For text-based opens, look for elements with text by default
+                return hinting.toHintablesArray(
+                    DOM.elementsWithText(this.includeInvisible),
+                )
+
+            case OpenMode.YankAlt:
+                return hinting.toHintablesArray(
+                    DOM.getElemsBySelector("[title],[alt]", [
+                        DOM.isVisibleFilter(this.includeInvisible),
+                    ]),
+                )
+
+            case OpenMode.YankAnchor:
+                return hinting.toHintablesArray(
+                    DOM.anchors(this.includeInvisible),
+                )
+
+            case OpenMode.Images:
+            case OpenMode.ImagesTab:
+            case OpenMode.SaveImage:
+            case OpenMode.SaveAsImage:
+                return hinting.toHintablesArray(
+                    hinting.hintableImages(this.includeInvisible),
+                )
+
+            case OpenMode.Kill:
+            case OpenMode.KillTridactyl:
+                return hinting.toHintablesArray(
+                    hinting.killables(this.includeInvisible),
+                )
+
+            case OpenMode.SaveResource:
+            case OpenMode.SaveAsResource:
+                return hinting.toHintablesArray(
+                    hinting.saveableElements(this.includeInvisible),
+                )
+
+            default:
+                return hinting.hintables(
+                    DOM.HINTTAGS_selectors,
+                    this.jshints,
+                    this.includeInvisible,
+                )
+        }
+    }
+
+    public hintables() {
+        // User selectors always override default built-ins
+        const hintables =
+            this.selectors.length > 0
+                ? hinting.hintables(
+                      this.selectors.join(" "),
+                      this.jshints,
+                      this.includeInvisible,
+                  )
+                : this.defaultHintables()
+
+        // Do we have text filters to refine this?
+        if (this.textFilter !== null) {
+            for (const elements of hintables) {
+                elements.elements = elements.elements.filter(
+                    hinting.hintByTextFilter(this.textFilter),
+                )
+            }
+        }
+
+        return hintables
+    }
+}

--- a/src/lib/hint_util.ts
+++ b/src/lib/hint_util.ts
@@ -140,6 +140,9 @@ export class HintConfig implements HintOptions {
                                 case "J":
                                     result.jshints = false
                                     break
+                                case "!":
+                                    result.immediate = true
+                                    break
                                 case "F":
                                     newState = State.ExpectCallback
                                     break
@@ -148,9 +151,6 @@ export class HintConfig implements HintOptions {
                                     break
                                 case "c":
                                     newState = State.ExpectSelector
-                                    break
-                                case "!":
-                                    result.immediate = true
                                     break
                                 case "t":
                                     newOpenMode = OpenMode.Tab


### PR DESCRIPTION
## Summary
This commit refactors the `hint` ex command with the following:

### Internals
* Introduce an argument parser based on a state machine. We can now properly handle flags, combined short flags, and flags with optional arguments.
* Keeps backwards compatibility: all current flags are supported, but the ability to parse multiple options may introduce new behaviors (which would fail before silently).

### Added
* Add a `-!` flag: perform the default action on every hint
* Add a `-V` flag: consider elements out of the viewport for hinting

### Changed
* Changes `-f/-fr` to refine results from the default selectors
* Allow `-f/-fr` to read patterns containing spaces, if they are escaped with `\`

## Rationale
The hinting command already goes well beyond simply showing hints for clickable links. It makes sense that 'common' operations should have easier shortcuts than defaulting to JavaScript callbacks. This does make the code for `hint` slightly longer, but with the refactored control flow this doesn't seem significant.

## State
This is a first draft and comments are welcomed, as I am not familiar with the project. Most notably the following questions should be considered before merging:
* [x] Should users be able to refine selectors for non-default open modes? I could want to select images that have the .thumbnail class, so `:hint -S img.thumbnail` should work
* [x] `-;` option: I failed to understand the docs on what it does, maybe it should be made clearer? The implementation stayed the same but I might be wrong
* [ ] Some hintTabOpen calls had an async/await block, but others did not. Is this expected?
* [x] `-!` (new) immediate option: from early manual testing, this implementation seems to work, but I might be missing something?
* [ ] Error reporting: the argument parser can easily detect wrong argument combinations. How should they be reported to the user?
* [ ] Automated tests? What should be changed?