### PR TITLE
mpvsafe: Allow mpv to keep running after Firefox quits

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -607,7 +607,7 @@ export class default_config {
         "mkt!": "mktridactylrc -f",
         "mktridactylrc!": "mktridactylrc -f",
         mpvsafe:
-            "js -p tri.excmds.shellescape(JS_ARG).then(url => tri.excmds.exclaim_quiet('mpv ' + url))",
+            "js -p tri.excmds.shellescape(JS_ARG).then(url => tri.excmds.exclaim_quiet('mpv --no-terminal ' + url))",
         exto: "extoptions",
         extpreferences: "extoptions",
         extp: "extpreferences",


### PR DESCRIPTION
Detach the mpv process after starting it. This prevents it from terminating with SIGPIPE after Firefox quits.

I think this should be the sensible behaviour. There's no use it terminating all the mpv instances after user closes Firefox.