### PR TITLE
Add "rebuild" package.json script that skips docs, new tab, and tutor

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lint": "bash hooks/pre-commit",
     "make-zip": "web-ext build --source-dir build --overwrite-dest",
     "pretty": "bash scripts/pretty.sh",
+    "rebuild": "sh scripts/build.sh --no-docs",
     "run": "web-ext run -s build/ -u 'txti.es'",
     "test": "yarn run build && web-ext build --source-dir ./build --overwrite-dest && jest --silent",
     "update-buildsystem": "rm -rf src/node_modules; yarn run clean",

--- a/readme.md
+++ b/readme.md
@@ -330,6 +330,9 @@ yarn run build & yarn run run
 
 You'll need to run `yarn run build` every time you edit the files, and press "r" in the `yarn run run` window to make sure that the files are properly reloaded.
 
+You can speed up the build process after your first build by using `yarn run rebuild` instead. This skips rebuilding the documentation, new tab page, and tutor,
+so don't use it if that's what you're trying to test.
+
 ### Committing
 
 A pre-commit hook is added by `yarn install` that simply runs `yarn test`. If you know that your commit doesn't break the tests you can commit with `git commit -n` to ignore the hooks. If you're making a PR, travis will check your build anyway.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,9 +47,14 @@ fi
           --themeDir src/static/themes \
           src/excmds.ts src/lib/config.ts
 
-scripts/newtab.md.sh
-scripts/make_tutorial.sh
-scripts/make_docs.sh
+# Skip docs to speed up build times. Only works on rebuilds.
+if [ "$1" = "--no-docs" ]; then
+  echo "Skipping docs..."
+else
+  scripts/newtab.md.sh
+  scripts/make_tutorial.sh
+  scripts/make_docs.sh
+fi
 
 webpack --stats errors-only --bail
 


### PR DESCRIPTION
On my setup, "rebuild" takes ca. 23s, while "build" is around 45s.