### PR TITLE
Make Tridactyl reload pages on dev rebuilds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -73,7 +73,10 @@ if [ "$QUICK_BUILD" != "1" ]; then
 else
 
     echo "Warning: dirty rebuild. Skipping docs, metadata and type checking..."
+    mkdir -p buildtemp
     node scripts/esbuild.js
+    mv buildtemp/* build/
+    rmdir buildtemp
 
 fi
 

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -6,6 +6,6 @@ for (let f of ["content", "background", "help", "newtab", "commandline_frame"]) 
         bundle: true,
         sourcemap: true,
         target: "firefox68",
-        outfile: `build/${f}.js`,
+        outfile: `buildtemp/${f}.js`,
     }).catch(() => process.exit(1))
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5235,8 +5235,8 @@ browser.runtime.onInstalled.addListener(details => {
             updatenative(false)
         } else {
             // Temporary extension has been updated in place
-            // Reload all pages so Tridactyl can work in them
-            reloadall()
+            // Open a new tab where Tridactyl will work for convenience
+            tabopen()
         }
     }
 })

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5230,8 +5230,15 @@ export async function keyfeed(mapstr: string) {
 //#background_helper
 browser.runtime.onInstalled.addListener(details => {
     if (details.reason === "install") tutor("newtab")
-    else if ((details as any).temporary !== true && details.reason === "update") updatenative(false)
-    // could add elif "update" and show a changelog. Hide it behind a setting to make it less annoying?
+    else if (details.reason === "update") {
+        if ((details as any).temporary !== true) {
+            updatenative(false)
+        } else {
+            // Temporary extension has been updated in place
+            // Reload all pages so Tridactyl can work in them
+            reloadall()
+        }
+    }
 })
 
 /** Opens optionsUrl for the selected extension in a popup window.


### PR DESCRIPTION
At the moment this is more confusing than anything else - Firefox reloads itself too early, before all the scripts have updated, so you end up with a page reload but running old code.

Have to go back to the CLI and press `R` to force a reload.

I'm thinking that we probably need to wait until all the files have compiled before we copy them to `build/`.