### PR TITLE
Hinting: improve hintables() performance by not using Ramda

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1017,22 +1017,17 @@ export function hintables(
     includeInvisible = false,
 ) {
     const visibleFilter = DOM.isVisibleFilter(includeInvisible)
-    const elems = R.pipe(
-        DOM.getElemsBySelector,
-        R.filter(visibleFilter),
-        changeHintablesToLargestChild,
-    )(selectors, [])
+    const elems = changeHintablesToLargestChild(
+        DOM.getElemsBySelector(selectors, []).filter(visibleFilter),
+    )
     const hintables: Hintables[] = [{ elements: elems }]
     if (withjs) {
         hintables.push({
-            elements: R.pipe(
-                Array.from,
-                // Ramda gives an error here without the "any"
-                // Problem for a rainy day :)
-                R.filter(visibleFilter) as any,
-                R.without(elems),
-                changeHintablesToLargestChild,
-            )(DOM.hintworthy_js_elems),
+            elements: changeHintablesToLargestChild(
+                Array.from(DOM.hintworthy_js_elems).filter(
+                    el => visibleFilter(el) && !elems.includes(el),
+                ),
+            ),
             hintclasses: ["TridactylJSHint"],
         })
     }


### PR DESCRIPTION
I got annoyed at hinting being slow on YouTube, so I decided to look into it and found that Ramda's functions significantly slowed down `hintables()`. Doing things "by hand" makes it run a lot faster on complex pages – [this profile comparison](https://share.firefox.dev/3v1G0jD) I made reports about a 25% performance improvement. It definitely also *feels* faster to me, though of course that might just be because I'm biased in favour of my own code ;-).