### PR TITLE
WIP: add setting to switch elements manually

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -186,6 +186,15 @@ export async function recursiveScroll(
         const sameSignX = xDistance < 0 === lastX < 0
         const sameSignY = yDistance < 0 === lastY < 0
         const sameElement = lastFocused == currentFocused
+        if (
+            lastRecursiveScrolled &&
+            config.get("scrollswitch") === "manual" &&
+            ((currentFocused && currentFocused == lastRecursiveScrolled) ||
+                !currentFocused)
+        ) {
+            scroll(xDistance, yDistance, lastRecursiveScrolled)
+            return true
+        }
         if (lastRecursiveScrolled && sameSignX && sameSignY && sameElement) {
             // We're scrolling in the same direction as the previous time so
             // let's try to pick up from where we left

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -764,6 +764,11 @@ export class default_config {
     scrollduration = 100
 
     /**
+     * Whether scrolling should change elements automatically once the bottom is reached
+     */
+    scrollswitch: "manual" | "auto" = "auto"
+
+    /**
      * Where to open tabs opened with `tabopen` - to the right of the current tab, or at the end of the tabs.
      */
     tabopenpos: "next" | "last" | "related" = "next"


### PR DESCRIPTION
Related: #3066

My goal with this PR is to add a setting that automatically picks the best element to scroll when scrolling is first performed on a page, as we do currently, but then does not change that element unless the focused element is changed.

It does not work - the element still changes - but it seems to have accidentally ameliorated #3587 as now scrolling up/down scrolls the same element. :shrug: 