### PR TITLE
Add completion options for all binds

### DIFF
--- a/src/completions/Apropos.ts
+++ b/src/completions/Apropos.ts
@@ -2,8 +2,10 @@ import * as Completions from "@src/completions"
 import * as Metadata from "@src/.metadata.generated"
 import * as aliases from "@src/lib/aliases"
 import * as config from "@src/lib/config"
+import { mode2maps } from "@src/lib/binding"
 
-class AproposCompletionOption extends Completions.CompletionOptionHTML
+class AproposCompletionOption
+    extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
     public fuseKeys = []
 
@@ -48,11 +50,44 @@ export class AproposCompletionSource extends Completions.CompletionSourceFuse {
         const fns = excmds.getFunctions()
         const settings = config.get()
         const exaliases = settings.exaliases
-        const bindings = settings.nmaps
+        const allbindings = {}
+
+        for (const [key, value] of mode2maps.entries()) {
+            allbindings[key] = settings[value]
+        }
+
+        function query2bindcompletions(options, query) {
+            const modenames = Object.keys(allbindings)
+            const completions = []
+            for (const modename of modenames) {
+                const binds = Object.keys(
+                    allbindings[modename],
+                ).filter(binding =>
+                    (binding + allbindings[modename][binding])
+                        .toLowerCase()
+                        .includes(query),
+                )
+                for (const binding of binds) {
+                    completions.push(
+                        new AproposCompletionOption(
+                            binding,
+                            `${
+                                modename[0].toUpperCase() + modename.slice(1)
+                            } mode binding for \`${
+                                allbindings[modename][binding]
+                            }\``,
+                            "-b",
+                        ),
+                    )
+                }
+            }
+            return completions
+        }
+
         if (
             fns === undefined ||
             exaliases === undefined ||
-            bindings === undefined
+            settings.nmaps === undefined
         ) {
             return
         }
@@ -83,22 +118,7 @@ export class AproposCompletionSource extends Completions.CompletionSourceFuse {
                         }),
                 ),
             "-b": (options, query) =>
-                options.concat(
-                    Object.keys(bindings)
-                        .filter(binding =>
-                            (binding + bindings[binding])
-                                .toLowerCase()
-                                .includes(query),
-                        )
-                        .map(
-                            binding =>
-                                new AproposCompletionOption(
-                                    binding,
-                                    `Normal mode binding for \`${bindings[binding]}\``,
-                                    "-b",
-                                ),
-                        ),
-                ),
+                options.concat(query2bindcompletions(options, query)),
             "-e": (options, query) =>
                 options.concat(
                     fns


### PR DESCRIPTION
Completions work great, but hitting `<Enter>` on them usually doesn't take you anywhere useful. We should probably throw an error or fix #2926 / work out why `:help text.` etc. doesn't work. I thought it used to...

Also the code duplication in our completions makes me sad.

In general I suspect that we should change the completions so that `:help [<Tab until you find the j bind>]` actually runs `:help [the thing that `j` is bound to]`.

I think to get this merged usefully though `:help` should throw an error if the thing isn't found.