### PR TITLE
Broken: switch metadata from tsc to esbuild

### DIFF
--- a/compiler/gen_metadata.ts
+++ b/compiler/gen_metadata.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript"
 import * as fs from "fs"
-import * as commandLineArgs from "command-line-args"
+import commandLineArgs from "command-line-args"
 import * as AllTypes from "./types/AllTypes"
 import * as AllMetadata from "./metadata/AllMetadata"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,8 +59,8 @@ if [ "$QUICK_BUILD" != "1" ]; then
 
     # It's important to generate the metadata before the documentation because
     # missing imports might break documentation generation on clean builds
-    "$(yarn bin)/tsc" compiler/gen_metadata.ts -m commonjs --target es2017 \
-      && node compiler/gen_metadata.js \
+    "$(yarn bin)/esbuild" --target=node10 --platform=node --bundle compiler/gen_metadata.ts > compiler/gen_metadata.js \
+    && node compiler/gen_metadata.js \
               --out src/.metadata.generated.ts \
               --themeDir src/static/themes \
               src/excmds.ts src/lib/config.ts


### PR DESCRIPTION
This somehow breaks some binds (e.g. b) but not all (e.g. : works fine, as does typing out :tab manually).


Probably not really worth putting all that much time into - it takes builds down from 30s to 25s.