### PR TITLE
Appease esbuild warnings about direct eval() by using window.eval()

### DIFF
--- a/src/background/webrequests.ts
+++ b/src/background/webrequests.ts
@@ -21,7 +21,7 @@ export const registerWebRequestAutocmd = (
 ) => {
     // I'm being lazy - strictly the functions map strings to void | blocking responses
     // eslint-disable-next-line @typescript-eslint/ban-types
-    const listener = eval(func) as Function
+    const listener = window.eval(func) as Function
     LISTENERS[requestEvent] = { [pattern]: listener }
     return browser.webRequest["on" + requestEvent].addListener(
         listener,

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2775,7 +2775,7 @@ export async function tabmove(index = "$") {
 //#background
 export async function tabsort(...callbackchunks: string[]) {
     const argument = callbackchunks.join(" ")
-    const comparator = argument == "--containers" ? (l, r) => l.cookieStoreId < r.cookieStoreId : argument == "--title" ? (l, r) => l.title < r.title : argument == "--url" || argument == "" ? (l, r) => l.url < r.url : eval(argument)
+    const comparator = argument == "--containers" ? (l, r) => l.cookieStoreId < r.cookieStoreId : argument == "--title" ? (l, r) => l.title < r.title : argument == "--url" || argument == "" ? (l, r) => l.url < r.url : window.eval(argument)
     const windowTabs = await browser.tabs.query({ currentWindow: true })
     windowTabs.sort(comparator)
     Object.entries(windowTabs).forEach(([index, tab]) => {
@@ -4410,7 +4410,7 @@ export async function hint(...args: string[]): Promise<any> {
         // If the user specified a callback, eval it, else use the default
         // action which performs the action matching the open mode
         const action = config.callback
-            ? eval(config.callback)
+            ? window.eval(config.callback)
             : (elem: any) => {
                   if (config.pipeAttribute !== null) {
                       // We have an attribute to pipe
@@ -4968,7 +4968,7 @@ async function js_helper(str: string[]) {
         jsContent = file.content
     }
 
-    return eval(jsContent)
+    return window.eval(jsContent)
 }
 
 /**


### PR DESCRIPTION
See also https://esbuild.github.io/content-types/#direct-eval.
Bare ("direct") `eval()` evaluates in the local scope where it is called
instead of the global scope, which can cause problems (which is why
esbuild complains). Our uses of it don't need local scope, so we can
safely switch to `window.eval()`.