### PR TITLE
Add setting to force page autofocus settings in certain modes

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3796,6 +3796,8 @@ export function setmode(mode: string, key: string, ...values: string[]) {
     if (!mode || !key || !values.length) {
         throw new Error("seturl syntax: mode key value")
     }
+    if (key !== "allowautofocus")
+        throw new Error("Setting '" + key + "' not supported with setmode")
 
     return config.set("modesubconfigs", mode, ...validateSetArgs(key, values))
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3778,6 +3778,28 @@ export function seturl(pattern: string, key: string, ...values: string[]) {
     return config.setURL(pattern, ...validateSetArgs(key, values))
 }
 
+/**
+ * Usage: `setmode mode key values`
+ *
+ * @param mode The Mode the setting should be set for, e.g. `insert` or `ignore`.
+ * @param key The name of the setting you want to set, e.g. `allowautofocus`
+ * @param values The value you wish for, e.g. `true`
+ *
+ * Currently this command is only supported for the following settings:
+ * - [[allowautofocus]]
+ *
+ * Example:
+ * - `setmode ignore allowautofocus true`
+ */
+//#content
+export function setmode(mode: string, key: string, ...values: string[]) {
+    if (!mode || !key || !values.length) {
+        throw new Error("seturl syntax: mode key value")
+    }
+
+    return config.set("modesubconfigs", mode, ...validateSetArgs(key, values))
+}
+
 /** Set a key value pair in config.
 
     Use to set any values found [here](/static/docs/classes/_src_lib_config_.default_config.html).
@@ -4007,7 +4029,7 @@ export async function unbind(...args: string[]) {
  *
  * This unbinds `I` in ignore mode on every website the URL of which contains `jupyter`, while keeping the binding active everywhere else.
  *
- * Also see [[bind]], [[bindurl]], [[seturl]], [[unbind]], [[unseturl]]
+ * Also see [[bind]], [[bindurl]], [[seturl]], [[unbind]], [[unseturl]], [[setmode]], [[unsetmode]]
  */
 //#background
 export async function unbindurl(pattern: string, mode: string, keys: string) {
@@ -4043,6 +4065,8 @@ export async function reset(mode: string, key: string) {
  *  - [[unbindurl]]
  *  - [[seturl]]
  *  - [[unseturl]]
+ *  - [[setmode]]
+ *  - [[unsetmode]]
  */
 //#background
 export async function reseturl(pattern: string, mode: string, key: string) {
@@ -4261,6 +4285,23 @@ export function unseturl(pattern: string, key: string) {
         pattern = window.location.href
     }
     return config.unsetURL(pattern, key.split("."))
+}
+
+/**
+ * Reset a mode-specific setting.
+ *
+ * usage: `unsetmode mode key`
+ *
+ * @param mode The mode the setting should be unset on, e.g. `insert`.
+ * @param key The key that should be unset.
+ *
+ * Example: `unsetmode ignore allowautofocus`
+ *
+ * Note that this removes a setting from the mode-specific config, it doesn't "invert" it. This means that if you have a setting set to `false` in your global config and the same setting set to `false` in a mode-specific setting, using `unseturl` will result in the setting still being set to `false`.
+ */
+//#content
+export function unsetmode(mode: string, key: string) {
+    return config.unset("modesubconfigs", mode, ...key.split("."))
 }
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -95,6 +95,21 @@ export class default_config {
     }
 
     /**
+     * Internal field to handle mode-specific configs. Use :setmode/:unsetmode to change these values.
+     *
+     * Changing this might do weird stuff.
+     */
+    modesubconfigs: { [key: string]: DeepPartial<default_config> } = {
+        "normal": {},
+        "insert": {},
+        "input": {},
+        "ignore": {},
+        "ex": {},
+        "hint": {},
+        "visual": {},
+    }
+
+    /**
      * Internal field to handle site-specific config priorities. Use :seturl/:unseturl to change this value.
      */
     priority = 0
@@ -748,21 +763,6 @@ export class default_config {
      * Best used in conjunction with browser.autofocus in `about:config`
      */
     allowautofocus: "true" | "false" = "true"
-
-    /**
-     * Controls modes which the [[allowautofocus]] setting will affect.
-     *
-     * This lets you suppress the effects of [[allowautofocus]] to allow page behavior in certain modes - by default this setting always allows the setting to take effect.
-     */
-    preventautofocusmodes: { [key: string]: "true" | "false" } = {
-        normal: "true",
-        insert: "true",
-        input: "true",
-        ignore: "true",
-        ex: "true",
-        hint: "true",
-        visual: "true",
-    }
 
     /**
      * Uses a loop to prevent focus until you interact with a page. Only recommended for use via `seturl` for problematic sites as it can be a little heavy on CPU if running on all tabs. Should be used in conjuction with [[allowautofocus]]

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -750,6 +750,21 @@ export class default_config {
     allowautofocus: "true" | "false" = "true"
 
     /**
+     * Controls modes which the [[allowautofocus]] setting will affect.
+     *
+     * This lets you suppress the effects of [[allowautofocus]] to allow page behavior in certain modes - by default this setting always allows the setting to take effect.
+     */
+    preventautofocusmodes: { [key: string]: "true" | "false" } = {
+        normal: "true",
+        insert: "true",
+        input: "true",
+        ignore: "true",
+        ex: "true",
+        hint: "true",
+        visual: "true",
+    }
+
+    /**
      * Uses a loop to prevent focus until you interact with a page. Only recommended for use via `seturl` for problematic sites as it can be a little heavy on CPU if running on all tabs. Should be used in conjuction with [[allowautofocus]]
      */
     preventautofocusjackhammer: "true" | "false" = "false"

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -2,6 +2,7 @@ import * as config from "@src/lib/config"
 import state from "@src/state"
 import * as State from "@src/state"
 import * as Logging from "@src/lib/logging"
+import { contentState } from "@src/content/state_content"
 import {
     activeTabId,
     openInNewTab,
@@ -537,7 +538,8 @@ function onPageFocus(elem: HTMLElement): boolean {
     if (isTextEditable(elem)) {
         LAST_USED_INPUT = elem
     }
-    return config.get("allowautofocus") === "true"
+    const suppressSetting = config.get("preventautofocusmodes", contentState.mode) === "false"
+    return suppressSetting || config.get("allowautofocus") === "true"
 }
 
 async function setInput(el) {

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -538,8 +538,8 @@ function onPageFocus(elem: HTMLElement): boolean {
     if (isTextEditable(elem)) {
         LAST_USED_INPUT = elem
     }
-    const suppressSetting = config.get("preventautofocusmodes", contentState.mode) === "false"
-    return suppressSetting || config.get("allowautofocus") === "true"
+    const setting = config.get("modesubconfigs", contentState.mode, "allowautofocus") || config.get("allowautofocus")
+    return setting === "true"
 }
 
 async function setInput(el) {


### PR DESCRIPTION
This is a pretty simple change, just adding a setting so the behavior of "allowautofocus" can only be applied. This is point 3 in #2485 (if configured). By default, this setting preserves the current behavior.

Unfortunately the "prevent" vs "allow" wording is quite confusing - I tried to pick names the least confusing to me, but it's still pretty bad, let me know if you have better ideas :(. Maybe "preventallowautofocusmodes". I'm bad at names. I'm trying to avoid "allowautofocusmodes" as its unclear if a true value would enable the setting to change things on the page, or enable auto-focus  (which are opposite behaviors).