### PR TITLE
Revert "Appease esbuild warnings about direct eval() by using window.eval()"

### DIFF
--- a/src/background/webrequests.ts
+++ b/src/background/webrequests.ts
@@ -21,7 +21,7 @@ export const registerWebRequestAutocmd = (
 ) => {
     // I'm being lazy - strictly the functions map strings to void | blocking responses
     // eslint-disable-next-line @typescript-eslint/ban-types
-    const listener = window.eval(func) as Function
+    const listener = eval(func) as Function
     LISTENERS[requestEvent] = { [pattern]: listener }
     return browser.webRequest["on" + requestEvent].addListener(
         listener,

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2782,7 +2782,7 @@ export async function tabmove(index = "$") {
 //#background
 export async function tabsort(...callbackchunks: string[]) {
     const argument = callbackchunks.join(" ")
-    const comparator = argument == "--containers" ? (l, r) => l.cookieStoreId < r.cookieStoreId : argument == "--title" ? (l, r) => l.title < r.title : argument == "--url" || argument == "" ? (l, r) => l.url < r.url : window.eval(argument)
+    const comparator = argument == "--containers" ? (l, r) => l.cookieStoreId < r.cookieStoreId : argument == "--title" ? (l, r) => l.title < r.title : argument == "--url" || argument == "" ? (l, r) => l.url < r.url : eval(argument)
     const windowTabs = await browser.tabs.query({ currentWindow: true })
     windowTabs.sort(comparator)
     Object.entries(windowTabs).forEach(([index, tab]) => {
@@ -4417,7 +4417,7 @@ export async function hint(...args: string[]): Promise<any> {
         // If the user specified a callback, eval it, else use the default
         // action which performs the action matching the open mode
         const action = config.callback
-            ? window.eval(config.callback)
+            ? eval(config.callback)
             : (elem: any) => {
                   if (config.pipeAttribute !== null) {
                       // We have an attribute to pipe
@@ -4975,7 +4975,7 @@ async function js_helper(str: string[]) {
         jsContent = file.content
     }
 
-    return window.eval(jsContent)
+    return eval(jsContent)
 }
 
 /**


### PR DESCRIPTION
This reverts #3659.

Turns out what esbuild was warning about was behaviour we actually wanted, because now `:js` doesn't have access to `tri` any more. The reason I didn't catch this must be that I tested it only on Tridactyl's new tab page, where excmds apparently run in a slightly different context from non-Tridactyl pages, so it kept working there.