### PR TITLE
Make blacklistadd command add TabEnter

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4058,7 +4058,7 @@ export function autocmddelete(event: string, url: string) {
  */
 //#background
 export function blacklistadd(url: string) {
-    return autocmd("DocStart", url, "mode ignore")
+    return autocmd("DocStart", url, "mode ignore") && autocmd("TabEnter", url, "mode ignore")
 }
 
 /** Unbind a sequence of keys so that they do nothing at all.


### PR DESCRIPTION
## Pitch
`blacklistadd` command is good for some websites using keyboard shortcuts like gmail.
But it is get back to `normal` mode when switched tab.
Let `blacklistadd` command also adding `autocmd <url> TabEnter mode ignore`