### PR TITLE
Expand env variables in tri.native.write

### DIFF
--- a/native/native_main.py
+++ b/native/native_main.py
@@ -468,7 +468,8 @@ def handleMessage(message):
                 reply["code"] = 2
 
     elif cmd == "write":
-        with open(message["file"], "w", encoding="utf-8") as file:
+        path = os.path.expandvars(os.path.expanduser(message["file"]))
+        with open(path, "w", encoding="utf-8") as file:
             file.write(message["content"])
 
     elif cmd == "writerc":


### PR DESCRIPTION
native_main.py: expand tilde and env variables
                                                                  
Part of https://github.com/tridactyl/tridactyl/issues/2134
Ideally also should be done in
https://github.com/tridactyl/native_messenger, but two minutes of
googling weren't enough to figure out how to do this.