### PR TITLE
Fix the `f` and `F` hints on DDG in the sample `.tridactylrc`

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -71,9 +71,8 @@
 " bindurl www.google.com F hint -Jbc #search div:not(.action-menu) > a
 " 
 " 
-" " DDG binds are broken as of May 2021
-" " bindurl ^https://duckduckgo.com f hint -Jc [class=result__a]
-" " bindurl ^https://duckduckgo.com F hint -Jbc [class=result__a]
+" bindurl ^https://duckduckgo.com f hint -Jc [class~=result__a]
+" bindurl ^https://duckduckgo.com F hint -Jbc [class~=result__a]
 " 
 " " Allow Ctrl-a to select all in the commandline
 " unbind --mode=ex <C-a>


### PR DESCRIPTION
The fix is to use the [`~=` attribute selector][selector] to match the
result class instead of `=`; it works on DuckDuckGo now.

[selector]: https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#syntax