### PR TITLE
Allow mode change to restore mode indicator.

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -352,7 +352,9 @@ config.getAsync("modeindicator").then(mode => {
             config.get("modeindicator") !== "true" ||
             config.get("modeindicatormodes", mode) === "false"
         ) {
-            statusIndicator.remove()
+            statusIndicator.classList.add("TridactylInvisible")
+        } else {
+            statusIndicator.classList.remove("TridactylInvisble")
         }
     })
 })


### PR DESCRIPTION
Fixes issue #2690
Rather than delete the statusIndicator span, apply the TridactylInvisible class. This class includes pointer-events:none, which prevents conditional overlap with the statusIndicator EventListener "mouseenter".