### PR TITLE
Fix tridactyl#2510 use auto instead of default.css for content pages

### DIFF
--- a/src/static/css/authors.css
+++ b/src/static/css/authors.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 /* Adapted from https://css-tricks.com/snippets/css/star-wars-crawl-text/ */
 body {

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 body {
     overflow: hidden;

--- a/src/static/css/content.css
+++ b/src/static/css/content.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 #cmdline_iframe {
     position: fixed !important;

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 span.TridactylHint {
     position: absolute !important;

--- a/src/static/css/newtab.css
+++ b/src/static/css/newtab.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 body {
     font-family: var(--tridactyl-font-family-sans);

--- a/src/static/css/viewsource.css
+++ b/src/static/css/viewsource.css
@@ -1,4 +1,4 @@
-@import url("../themes/default/default.css");
+@import url("../themes/auto/auto.css");
 
 #TridactylViewsourceElement {
     position: absolute !important;

--- a/src/static/themes/auto/auto.css
+++ b/src/static/themes/auto/auto.css
@@ -1,2 +1,2 @@
+@import '../default/default.css';
 @import '../dark/dark.css' (prefers-color-scheme: dark);
-@import '../default/default.css' (prefers-color-scheme: light);


### PR DESCRIPTION
Just started looking at the code to generate my own theme, but this seems like a small improvement that might be welcome more generally.

Basically, the pages that previously loaded default.css, then had a short delay while the user's tridactyl theme kicked in, will now load auto.css, getting the default or dark theme depending on Firefox level user preference for the short time before their theme choice takes over, reducing or eliminating the brief flash for people using dark themes for both Firefox and Tridactyl.

I needed to change auto.css to always load default, then optionally load dark as it seems like dark on it's own is missing some styles (e.g. the commandline has no background set). That's probably more of a change than I'd want to make, and maybe there's a better way to do that. I'm possibly looking at making all the themes be auto switchable (web extensions seem the perfect excuse to use the latest CSS features) so happy to revisit that if it has negative impacts.

Only tested on Mac, but seems to work with the built in dark and light theme and the one that switches based on the mac system preference.

I'm possibly looking at making all the themes be auto switchable and loading them directly, so even the minor changes from e.g. dark to midnight shouldn't happen, but that's a bigger change.