### PR TITLE
Fix comment toggler for Hacker News

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -41,7 +41,7 @@
 " "
 " 
 " " Comment toggler for Reddit, Hacker News and Lobste.rs
-" bind ;c hint -Jc [class*="expand"],[class="togg"],[class="comment_folder"]
+" bind ;c hint -Jc [class*="expand"],[class*="togg"],[class="comment_folder"]
 " 
 " " GitHub pull request checkout command to clipboard (only works if you're a collaborator or above)
 " bind yp composite js document.getElementById("clone-help-step-1").textContent.replace("git checkout -b", "git checkout -B").replace("git pull ", "git fetch ") + "git reset --hard " + document.getElementById("clone-help-step-1").textContent.split(" ")[3].replace("-","/") | yank


### PR DESCRIPTION
Hacker News added a "clicky" class to the toggle buttons, so the
selector needs wildcard matching.