### PR TITLE
Add illegal character sanitisation in filename

### DIFF
--- a/src/background/download_background.ts
+++ b/src/background/download_background.ts
@@ -101,7 +101,18 @@ export async function downloadUrlAs(
         urlToDownload = urlToSave.href
     }
 
-    const fileName = getDownloadFilenameForUrl(urlToSave)
+    let fileName = getDownloadFilenameForUrl(urlToSave)
+    const regex_matcher = new RegExp("[" + config.get("illegalfilenamechars") + "]", "g")
+    fileName = fileName.replace(regex_matcher, config.get("illegalfilenamereplacement"))
+
+    const os = (await browser.runtime.getPlatformInfo()).os
+    if (os === "win") {
+        config.get("illegalwindowsfilenames").split(",").forEach((item) => {
+            if (item.trim() === fileName) {
+                fileName = fileName + config.get("illegalfilenamereplacement")
+            }
+        })
+    }
 
     const downloadId = await browser.downloads.download({
         conflictAction: "uniquify",

--- a/src/background/download_background.ts
+++ b/src/background/download_background.ts
@@ -102,17 +102,14 @@ export async function downloadUrlAs(
     }
 
     let fileName = getDownloadFilenameForUrl(urlToSave)
-    const regex_matcher = new RegExp("[" + config.get("illegalfilenamechars") + "]", "g")
-    fileName = fileName.replace(regex_matcher, config.get("illegalfilenamereplacement"))
+    const regex_matcher = new RegExp("[" + config.get("downloadforbiddenchars") + "]", "g")
+    fileName = fileName.replace(regex_matcher, config.get("downloadforbiddenreplacement"))
 
-    const os = (await browser.runtime.getPlatformInfo()).os
-    if (os === "win") {
-        config.get("illegalwindowsfilenames").split(",").forEach((item) => {
-            if (item.trim() === fileName) {
-                fileName = fileName + config.get("illegalfilenamereplacement")
-            }
-        })
-    }
+    config.get("downloadforbiddennames").split(",").forEach((item) => {
+        if (item.trim() === fileName) {
+            fileName = fileName + config.get("downloadforbiddenreplacement")
+        }
+    })
 
     const downloadId = await browser.downloads.download({
         conflictAction: "uniquify",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -703,26 +703,6 @@ export class default_config {
     homepages: string[] = []
 
     /**
-     * Default set of characters that are to be considered illegal
-     * as download file-names.
-     */
-    illegalfilenamechars = "#%&{}\\<>*?/$!'\":@+`|="
-    /**
-     * Default value that will be used to replace the illegal
-     * character(s), if found, in the download file-name.
-     */
-    illegalfilenamereplacement = "_"
-
-    /**
-     * Comma-separated list of Windows file-names which, if matches
-     * with the download file-name, will be suffixed with the
-     * "illegalfilenamereplacement" value.
-     */
-    illegalwindowsfilenames = "CON, PRN, AUX, NUL, COM1, COM2,"
-        + "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1,"
-        + "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,"
-
-    /**
      * Characters to use in hint mode.
      *
      * They are used preferentially from left to right.
@@ -978,6 +958,23 @@ export class default_config {
     downloadsskiphistory: "true" | "false" = "false"
 
     /**
+     * Set of characters that are to be considered illegal as download filenames.
+     */
+    downloadforbiddenchars = "/\0"
+
+    /**
+     * Value that will be used to replace the illegal character(s), if found, in the download filename.
+     */
+    downloadforbiddenreplacement = "_"
+
+    /**
+     * Comma-separated list of whole filenames which, if match
+     * with the download filename, will be suffixed with the
+     * "downloadforbiddenreplacement" value.
+     */
+    downloadforbiddennames = ""
+
+    /**
      * Set this to something weird if you want to have fun every time Tridactyl tries to update its native messenger.
      *
      * %TAG will be replaced with your version of Tridactyl for stable builds, or "master" for beta builds
@@ -1211,6 +1208,10 @@ const platform_defaults = {
 (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/tridactyl/native_messenger/master/installers/windows.ps1', '%TEMP%/tridactyl_installnative.ps1');\
 & '%TEMP%/tridactyl_installnative.ps1' -Tag %TAG;\
 Remove-Item '%TEMP%/tridactyl_installnative.ps1'"`,
+        downloadforbiddenchars: "#%&{}\\<>*?/$!'\":@+`|=",
+        downloadforbiddennames: "CON, PRN, AUX, NUL, COM1, COM2,"
+            + "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1,"
+            + "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,",
     },
     linux: {
         nmaps: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -703,6 +703,26 @@ export class default_config {
     homepages: string[] = []
 
     /**
+     * Default set of characters that are to be considered illegal
+     * as download file-names.
+     */
+    illegalfilenamechars = "#%&{}\\<>*?/$!'\":@+`|="
+    /**
+     * Default value that will be used to replace the illegal
+     * character(s), if found, in the download file-name.
+     */
+    illegalfilenamereplacement = "_"
+
+    /**
+     * Comma-separated list of Windows file-names which, if matches
+     * with the download file-name, will be suffixed with the
+     * "illegalfilenamereplacement" value.
+     */
+    illegalwindowsfilenames = "CON, PRN, AUX, NUL, COM1, COM2,"
+        + "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1,"
+        + "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,"
+
+    /**
      * Characters to use in hint mode.
      *
      * They are used preferentially from left to right.


### PR DESCRIPTION
Firefox's download API [0] currently does not support invalid characters
in the "saveAs" value, and the following error is thrown if download
filename contains illegal character(s). The issue has been reported to
the Firefox team, and currently it is in "WONTFIX" status [1].

  "filename must not contain illegal characters"

The issue prevents Tridactyl from downloading files from URLs with
certain "illegal" characters, e.g. ":" (colon), that are valid for URLs,
but are rejected in the filenames by the underlying OS's file system.

The default behaviour for operating systems like Mac is to replace the
invalid character(s) with "space" when saving the file to the disk.

The patches here implement basic filename sanitisation support by
introducing the following three configuration parameters in config.ts:

  - illegalfilenamechars
  - illegalwindowsfilenames
  - illegalfilenamereplacement

Essentially, if the "illegalfilenamechars" are found in the downloaded
filename, these characters are replaced by the
"illegalfilenamereplacement" value. The same logic is applied to each of
the comma-separated "illegalwindowsfilenames" values; if any of these
names matches the "saveAs" file-name, the file-name is suffixed with the
"illegalfilenamereplacement" value.

[0] https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/download
[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1390473