### PR TITLE
fix #4005 newtab changelog background color tweak

### DIFF
--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -101,7 +101,7 @@
     --tridactyl-of-bg: #ffec8b;
 
     /*new tab spoiler box*/
-    --tridactyl-highlight-box-bg: #eee;
+    --tridactyl-highlight-box-bg: rgba(0, 0, 0, 0.07);
     --tridactyl-highlight-box-fg: var(--tridactyl-fg);
 
     --tridactyl-private-window-icon-url: url("chrome://browser/skin/privatebrowsing/private-browsing.svg");


### PR DESCRIPTION
Uses a transparent black that looks like #eee on white backgrounds, but works on dark backgrounds as well.

Some themes already override this, but this helps for the midnight and quake themes which don't, and lets new themes work by default, while still allowing them to override if they want to.