### PR TITLE
Fix header line-height on new tab page

### DIFF
--- a/src/static/css/newtab.css
+++ b/src/static/css/newtab.css
@@ -6,7 +6,6 @@ body {
     color: var(--tridactyl-fg);
     background: var(--tridactyl-bg);
     max-width: 40em;
-    line-height: 140%;
     margin: auto;
 }
 
@@ -78,6 +77,7 @@ p,
 li {
     hyphens: auto;
     text-align: justify;
+    line-height: 140%;
 }
 
 div.align-left * {


### PR DESCRIPTION
The header lines smoosh into each other otherwise