### PR TITLE
Make ctrl-space insert a space in command line

### DIFF
--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -108,18 +108,18 @@ export function getCommandlineFns(cmdline_state: {
             if (command) {
                 cmdline_state.clInput.value = command + " "
             } else {
-                const selectionStart = cmdline_state.clInput.selectionStart
-                const selectionEnd = cmdline_state.clInput.selectionEnd
-                cmdline_state.clInput.value =
-                    cmdline_state.clInput.value.substring(0, selectionStart) +
-                    " " +
-                    cmdline_state.clInput.value.substring(selectionEnd)
-                cmdline_state.clInput.selectionStart =
-                    cmdline_state.clInput.selectionEnd = selectionStart + 1
+                space(cmdline_state)
             }
             return cmdline_state.refresh_completions(
                 cmdline_state.clInput.value,
             )
+        },
+
+        /**
+         * Insert a space
+         */
+        insert_space: () => {
+            space(cmdline_state)
         },
 
         /** Hide the command line and cmdline_state.clear its content without executing it. **/
@@ -232,4 +232,15 @@ function execute_ex_on_x(args_only: boolean, cmdline_state, excmd: string) {
     cmdline_state.fns.store_ex_string(cmdToExec)
 
     return messageOwnTab("controller_content", "acceptExCmd", [cmdToExec])
+}
+
+function space(cmdline_state) {
+    const selectionStart = cmdline_state.clInput.selectionStart
+    const selectionEnd = cmdline_state.clInput.selectionEnd
+    cmdline_state.clInput.value =
+        cmdline_state.clInput.value.substring(0, selectionStart) +
+        " " +
+        cmdline_state.clInput.value.substring(selectionEnd)
+    cmdline_state.clInput.selectionStart = cmdline_state.clInput.selectionEnd =
+        selectionStart + 1
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -143,7 +143,7 @@ export class default_config {
         "<Tab>": "ex.next_completion",
         "<S-Tab>": "ex.prev_completion",
         "<Space>": "ex.insert_space_or_completion",
-        "<S-Space>": "ex.insert_space",
+        "<C-Space>": "ex.insert_space",
 
         "<C-o>yy": "ex.execute_ex_on_completion_args clipboard yank",
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -143,6 +143,7 @@ export class default_config {
         "<Tab>": "ex.next_completion",
         "<S-Tab>": "ex.prev_completion",
         "<Space>": "ex.insert_space_or_completion",
+        "<S-Space>": "ex.insert_space",
 
         "<C-o>yy": "ex.execute_ex_on_completion_args clipboard yank",
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -100,13 +100,13 @@ export class default_config {
      * Changing this might do weird stuff.
      */
     modesubconfigs: { [key: string]: DeepPartial<default_config> } = {
-        "normal": {},
-        "insert": {},
-        "input": {},
-        "ignore": {},
-        "ex": {},
-        "hint": {},
-        "visual": {},
+        normal: {},
+        insert: {},
+        input: {},
+        ignore: {},
+        ex: {},
+        hint: {},
+        visual: {},
     }
 
     /**


### PR DESCRIPTION
Sometimes you don't want to insert an automatically selected bind when you press space, e.g. when you want to add arguments.

~~Blocked by #4175~~