### PR TITLE
Fix #4158: bookmarklet execution bug

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1326,7 +1326,7 @@ export async function open(...urlarr: string[]) {
         // Open URLs that firefox won't let us by running `firefox <URL>` on the command line
         return nativeopen(url)
     } else if (/^javascript:/.exec(url)) {
-        const escapeUrl = url.replace(/"/g, "\\\"")
+        const escapeUrl = url.replace(/[\\"]/g, "\\$&")
         window.eval(`window.location.href = "${escapeUrl}"`)
     } else {
         const tab = await ownTab()

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1326,14 +1326,8 @@ export async function open(...urlarr: string[]) {
         // Open URLs that firefox won't let us by running `firefox <URL>` on the command line
         return nativeopen(url)
     } else if (/^javascript:/.exec(url)) {
-        const bookmarklet = url.replace(/^javascript:/, "")
-        document.body.append(
-            html`
-                <script>
-                    ${bookmarklet}
-                </script>
-            `,
-        )
+        const escapeUrl = url.replace(/"/g, "\\\"")
+        window.eval(`window.location.href = "${escapeUrl}"`)
     } else {
         const tab = await ownTab()
         return openInTab(tab, {}, urlarr)


### PR DESCRIPTION
In original implementation, a script tag will leave in html,
and the bookmarklet in URL Encoding will not work.
Moreover, if bookmarklet return a string after evaluation,
the string should replace current page's html content.

One can execute bookmarklet by assign it to `window.location.href`,
but it does not work in add-on's context,
so I assign it with `window.eval()`.