### PR TITLE
Fix #4193: add jsurls

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -686,6 +686,13 @@ export class default_config {
     }
 
     /**
+     * Like [[searchurls]] but must be a Javascript function that takes one argument (a single string with the remainder of the command line including spaces) and maps it to a valid href that will be followed, e.g. `set jsurls.googleloud query => "https://google.com/search?q=" + query.toUpperCase()`
+     *
+     * NB: the href must be valid, i.e. it must include the protocol (e.g. "http://") and not just be e.g. "www.".
+     */
+    jsurls = {}
+
+    /**
      * URL the newtab will redirect to.
      *
      * All usual rules about things you can open with `open` apply, with the caveat that you'll get interesting results if you try to use something that needs `nativeopen`: so don't try `about:newtab` or a `file:///` URI. You should instead use a data URI - https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs - or host a local webserver (e.g. Caddy).

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -263,6 +263,11 @@ export async function queryAndURLwrangler(
         return url.href
     }
 
+    const jsurls = config.get("jsurls")
+    if (jsurls[firstWord]) {
+        return eval(jsurls[firstWord])(rest)
+    }
+
     const searchEngines = await browserBg.search.get()
     let engine = searchEngines.find(engine => engine.alias === firstWord)
     // Maybe firstWord is the name of a firefox search engine?


### PR DESCRIPTION
More powerful alternative to `searchurls` - run arbitrary JS to transform your query into a valid URL