### PR TITLE
Fix #4256: add mode indicator to title

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -323,15 +323,23 @@ config.getAsync("modeindicator").then(mode => {
         window.addEventListener("mousemove", onMouseOut)
     })
 
+    async function setWindowModePrefix(mode) {
+        webext.browserBg.windows.update(await webext.activeWindowId(), {
+            titlePreface: "[ " + mode + " ] ",
+        })
+    }
+
     try {
         // On quick loading pages, the document is already loaded
         statusIndicator.textContent = contentState.mode || "normal"
+        setWindowModePrefix(contentState.mode || "normal")
         document.body.appendChild(statusIndicator)
         document.head.appendChild(style)
     } catch (e) {
         // But on slower pages we wait for the document to load
         window.addEventListener("DOMContentLoaded", () => {
             statusIndicator.textContent = contentState.mode || "normal"
+            setWindowModePrefix(contentState.mode || "normal")
             document.body.appendChild(statusIndicator)
             document.head.appendChild(style)
         })
@@ -349,6 +357,8 @@ config.getAsync("modeindicator").then(mode => {
                 mode = oldMode
             }
         }
+
+        setWindowModePrefix(mode)
 
         const privateMode = browser.extension.inIncognitoContext
             ? "TridactylPrivate"


### PR DESCRIPTION
Need to add a configuration option defaulting to off and document it with its uses.

Should look into the "mode indicator doesn't get updated on entering/exiting insert mode with the mouse" bug because this would presumably make it annoying.

Also wouldn't work if the mode indicator was turned off so the code should probably be separated from that before merging.