### PR TITLE
Fix #4285: mktridactyl output wrong seturl command

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1882,8 +1882,9 @@ const parseConfigHelper = (pconf, parseobj, prefix = []) => {
         if (typeof pconf[i] !== "object") {
             if (prefix[0] === "subconfigs") {
                 const pattern = prefix[1]
+                const subconf = [...prefix.slice(2), i].join(".")
                 parseobj.subconfigs.push(
-                    `seturl ${pattern} ${[...prefix, i].join(".")} ${pconf[i]}`,
+                    `seturl ${pattern} ${subconf} ${pconf[i]}`,
                 )
             } else {
                 parseobj.conf.push(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1881,8 +1881,7 @@ const parseConfigHelper = (pconf, parseobj, prefix = []) => {
     for (const i of Object.keys(pconf)) {
         if (typeof pconf[i] !== "object") {
             if (prefix[0] === "subconfigs") {
-                prefix.shift()
-                const pattern = prefix.shift()
+                const pattern = prefix[1]
                 parseobj.subconfigs.push(
                     `seturl ${pattern} ${[...prefix, i].join(".")} ${pconf[i]}`,
                 )


### PR DESCRIPTION
If there are more than one seturl/bindurl config
in one url, `mktridactylrc` will outputs wrong
seturl/bindurl commands, which become global settings.

Because `prefix.shift()` will mutate the array.
Then in the next iteration, the subconfig and url in prefix
will miss.