### PR TITLE
Fix the hints on DuckDuckGo in the sample `.tridactylrc`

### DIFF
--- a/.tridactylrc
+++ b/.tridactylrc
@@ -71,8 +71,8 @@
 " bindurl www.google.com F hint -Jbc #search div:not(.action-menu) > a
 " 
 " 
-" bindurl ^https://duckduckgo.com f hint -Jc [class~=result__a]
-" bindurl ^https://duckduckgo.com F hint -Jbc [class~=result__a]
+" bindurl ^https://duckduckgo.com f hint -Jc [data-testid="result-title-a"]
+" bindurl ^https://duckduckgo.com F hint -Jbc [data-testid="result-title-a"]
 " 
 " " Allow Ctrl-a to select all in the commandline
 " unbind --mode=ex <C-a>


### PR DESCRIPTION
The webpage was updated and that broke the `f` and `F` hints in the
sample rc file (since commit 3bf7e4ab). This change updates the hints so
that they match the search result links again.