### PR TITLE
Fix the new webRequest autocmd overwriting the old one

### DIFF
--- a/src/background/webrequests.ts
+++ b/src/background/webrequests.ts
@@ -22,7 +22,8 @@ export const registerWebRequestAutocmd = (
     // I'm being lazy - strictly the functions map strings to void | blocking responses
     // eslint-disable-next-line @typescript-eslint/ban-types
     const listener = eval(func) as Function
-    LISTENERS[requestEvent] = { [pattern]: listener }
+    if (!LISTENERS[requestEvent]) LISTENERS[requestEvent] = {}
+    LISTENERS[requestEvent][pattern] = listener
     return browser.webRequest["on" + requestEvent].addListener(
         listener,
         { urls: [pattern] },

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4471,10 +4471,8 @@ export function autocmd(event: string, url: string, ...excmd: string[]) {
     // rudimentary run time type checking
     // TODO: Decide on autocmd event names
     if (!AUCMDS.includes(event)) throw new Error(event + " is not a supported event.")
-    if (webrequests.requestEvents.includes(event)) {
-        if (config.get("autocmds", event, url)) {
-            throw new Error(`Autocmd ${event} for ${url} already exist`)
-        }
+    if (webrequests.requestEvents.includes(event) && config.get("autocmds", event, url)) {
+        throw new Error(`Autocmd ${event} for ${url} already exist`)
     }
     return config.set("autocmds", event, url, excmd.join(" "))
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4471,6 +4471,11 @@ export function autocmd(event: string, url: string, ...excmd: string[]) {
     // rudimentary run time type checking
     // TODO: Decide on autocmd event names
     if (!AUCMDS.includes(event)) throw new Error(event + " is not a supported event.")
+    if (webrequests.requestEvents.includes(event)) {
+        if (config.get("autocmds", event, url)) {
+            throw new Error(`Autocmd ${event} for ${url} already exist`)
+        }
+    }
     return config.set("autocmds", event, url, excmd.join(" "))
 }
 


### PR DESCRIPTION
There are two commits:

 1. Fix the bug that the new web request autocmd overwrites the web request autocmd in the other url patterns.
 2. Throw an error when adding a new web request autocmd will overwrite the old one in config, which will cause problems.

Feel free to skip the second commit if you do not like it.