### PR TITLE
Fix timestamp in completion of back command for shydactyl

### DIFF
--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -84,6 +84,14 @@ input:focus {
     width: 50%;
 }
 
+/* Accroding to src/completions/TabHistory.ts formatTimeSpan,
+ * max-width should be 14 characters (14ex), 20ex for more tolorance. */
+#completions table tr td.time {
+    width: 20ex;
+    text-align: right;
+    padding-right: 2ex;
+}
+
 #completions table tr {
     white-space: nowrap;
     overflow: hidden;

--- a/src/static/themes/shydactyl/shydactyl.css
+++ b/src/static/themes/shydactyl/shydactyl.css
@@ -84,10 +84,6 @@
     table-layout: unset;
 }
 
-:root #completions table tr .title {
-    width: 50%;
-}
-
 :root #completions table tr {
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
The completion for back/forward can show the history list.
The item contain title, url and timestamp,
but timestamp does not show up in shydactyl theme,
because the `.url` and `.title` both takes `width: 50%;`,
so no space is left for the timestamp.

This commit remove the `.title`'s width contrain,
so the title will adjust its width automatically.
Also style `.time` to appropriate width and align right.