### PR TITLE
Add fuse search in undo and fix undo session id is undefind

### DIFF
--- a/src/completions/Sessions.ts
+++ b/src/completions/Sessions.ts
@@ -52,7 +52,7 @@ class SessionCompletionOption
         this.value = (session.tab || session.window).sessionId
         const [howLong, qualifier] = computeDate(session)
         const [tab, extraInfo] = getTabInfo(session)
-        this.fuseKeys.push(tab.title)
+        this.fuseKeys.push(tab.title, tab.url)
         this.html = html`<tr class="SessionCompletionOption option">
             <td class="type">${session.tab ? "T" : "W"}</td>
             <td class="time">${howLong}${qualifier}</td>

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2997,8 +2997,8 @@ export async function undo(item = "recent"): Promise<number> {
     const session = sessions.find(predicate)
 
     if (session) {
-        browser.sessions.restore((session.tab || session.window).sessionId)
-        return (session.tab || session.window).id
+        const restore = await browser.sessions.restore((session.tab || session.window).sessionId)
+        return (restore.tab || restore.window).id
     }
     return -1
 }


### PR DESCRIPTION
Allow fuse search with url in undo completion, #3777 .
I did not read the fuse search code; I just mimic how other completions do.

Fix undo access undefined value in session,
though I don't see that any code makes use of the return value of undo.