### PR TITLE
Add which-key like dynamic cheat sheet for keybinds

### DIFF
--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -1,11 +1,20 @@
-const esbuild = require('esbuild')
+const esbuild = require("esbuild")
 
-for (let f of ["content", "background", "help", "newtab", "commandline_frame"]) {
-        esbuild.build({
-        entryPoints: [`src/${f}.ts`],
-        bundle: true,
-        sourcemap: true,
-        target: "firefox68",
-        outfile: `buildtemp/${f}.js`,
-    }).catch(() => process.exit(1))
+for (let f of [
+    "content",
+    "background",
+    "help",
+    "newtab",
+    "commandline_frame",
+    "whichkey_frame",
+]) {
+    esbuild
+        .build({
+            entryPoints: [`src/${f}.ts`],
+            bundle: true,
+            sourcemap: true,
+            target: "firefox68",
+            outfile: `buildtemp/${f}.js`,
+        })
+        .catch(() => process.exit(1))
 }

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -4,7 +4,7 @@ import Logger from "@src/lib/logging"
 import * as controller from "@src/lib/controller"
 import { KeyEventLike, ParserResponse, PrintableKey } from "@src/lib/keyseq"
 import { deepestShadowRoot } from "@src/lib/dom"
-import { whichKey } from "@src/lib/which_key"
+import { whichKey, hideWhichKey } from "@src/lib/which_key"
 
 import * as hinting from "@src/content/hinting"
 import * as gobblemode from "@src/parsers/gobblemode"
@@ -177,6 +177,7 @@ function* ParserController() {
             }
             contentState.suffix = ""
             controller.acceptExCmd(exstr)
+            hideWhichKey()
         } catch (e) {
             // Rumsfeldian errors are caught here
             logger.error("An error occurred in the content controller: ", e)

--- a/src/content/whichkey_content.ts
+++ b/src/content/whichkey_content.ts
@@ -1,0 +1,84 @@
+/** Inject an input element into unsuspecting webpages and provide an API for interaction with tridactyl */
+
+import Logger from "@src/lib/logging"
+import * as config from "@src/lib/config"
+import { theme } from "@src/content/styling"
+const logger = new Logger("messaging")
+const whichkey_logger = new Logger("whichkey")
+
+const whichkey_iframe = window.document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    "iframe",
+) as HTMLIFrameElement
+whichkey_iframe.className = "cleanslate"
+whichkey_iframe.setAttribute(
+    "src",
+    browser.runtime.getURL("static/whichkey.html"),
+)
+whichkey_iframe.setAttribute("id", "whichkey_iframe")
+whichkey_iframe.setAttribute("loading", "lazy")
+
+let enabled = false
+
+/** Initialise the cmdline_iframe element unless the window location is included in a value of config/noiframe */
+async function init() {
+    const noiframe = await config.getAsync("noiframe")
+    const notridactyl = await config.getAsync("superignore")
+    if (noiframe === "false" && notridactyl !== "true" && !enabled) {
+        hide()
+        document.documentElement.appendChild(whichkey_iframe)
+        enabled = true
+        // first theming of page root
+        await theme(window.document.querySelector(":root"))
+    }
+}
+
+// Load the iframe immediately if we can (happens if tridactyl is reloaded or on ImageDocument)
+// Else load lazily to avoid upsetting page JS that hates foreign iframes.
+init().catch(() => {
+    // Surrender event loop with setTimeout() to page JS in case it's still doing stuff.
+    document.addEventListener("DOMContentLoaded", () =>
+        setTimeout(() => {
+            init().catch(e =>
+                logger.error("Couldn't initialise whichkey_iframe!", e),
+            )
+        }, 0),
+    )
+})
+
+export function show(hidehover = false) {
+    try {
+        /* Hide "hoverlink" pop-up which obscures command line
+         *
+         * Inspired by VVimpulation: https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5
+         */
+
+        if (hidehover) {
+            const a = window.document.createElement("A")
+            ;(a as any).href = ""
+            document.body.appendChild(a)
+            a.focus({ preventScroll: true })
+            document.body.removeChild(a)
+        }
+
+        whichkey_iframe.classList.remove("hidden")
+        const height =
+            whichkey_iframe.contentWindow.document.body.offsetHeight + "px"
+        whichkey_iframe.setAttribute("style", `height: ${height} !important;`)
+    } catch (e) {
+        whichkey_logger.error(e)
+    }
+}
+
+export function hide() {
+    try {
+        whichkey_iframe.classList.add("hidden")
+        whichkey_iframe.setAttribute("style", "height: 0px !important;")
+    } catch (e) {
+        whichkey_logger.error(e)
+    }
+}
+
+import * as Messaging from "@src/lib/messaging"
+import * as SELF from "@src/content/whichkey_content"
+Messaging.addListener("whichkey_content", Messaging.attributeCaller(SELF))

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -355,7 +355,7 @@ export class default_config {
         "<AC-Escape>": "mode ignore",
         "<AC-`>": "mode ignore",
         "<S-Escape>": "mode ignore",
-        "<Escape>": "composite mode normal ; hidecmdline",
+        "<Escape>": "composite mode normal ; hidecmdline ; hidewhichkey",
         "<C-[>": "composite mode normal ; hidecmdline",
         a: "current_url bmark",
         A: "bmark",
@@ -371,7 +371,7 @@ export class default_config {
         ".": "repeat",
         "<AS-ArrowUp><AS-ArrowUp><AS-ArrowDown><AS-ArrowDown><AS-ArrowLeft><AS-ArrowRight><AS-ArrowLeft><AS-ArrowRight>ba":
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
-        "m": "gobble 1 markadd",
+        m: "gobble 1 markadd",
         "`": "gobble 1 markjump",
     }
 
@@ -1259,9 +1259,10 @@ const platform_defaults = {
 & '%TEMP%/tridactyl_installnative.ps1' -Tag %TAG;\
 Remove-Item '%TEMP%/tridactyl_installnative.ps1'"`,
         downloadforbiddenchars: "#%&{}\\<>*?/$!'\":@+`|=",
-        downloadforbiddennames: "CON, PRN, AUX, NUL, COM1, COM2,"
-            + "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1,"
-            + "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,",
+        downloadforbiddennames:
+            "CON, PRN, AUX, NUL, COM1, COM2," +
+            "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1," +
+            "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,",
     },
     linux: {
         nmaps: {

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -107,7 +107,7 @@ export type KeyEventLike = MinimalKey | KeyboardEvent
 // {{{ parser and completions
 
 type MapTarget = string | ((...args: any[]) => any)
-type KeyMap = Map<MinimalKey[], MapTarget>
+export type KeyMap = Map<MinimalKey[], MapTarget>
 
 export interface ParserResponse {
     keys?: KeyEventLike[]
@@ -115,6 +115,7 @@ export interface ParserResponse {
     exstr?: string
     isMatch?: boolean
     numericPrefix?: number
+    possibleMappings?: KeyMap
 }
 
 function splitNumericPrefix(
@@ -194,7 +195,11 @@ export function parse(keyseq: KeyEventLike[], map: KeyMap): ParserResponse {
     // command, numericPrefix is a numeric prefix of that. We want to
     // preserve that whole thing, so concat them back together before
     // returning.
-    return { keys: numericPrefix.concat(keyseq), isMatch: keyseq.length > 0 }
+    return {
+        keys: numericPrefix.concat(keyseq),
+        isMatch: keyseq.length > 0,
+        possibleMappings,
+    }
 }
 
 /** True if seq1 is a prefix or equal to seq2 */
@@ -295,10 +300,8 @@ function expandAliases(key: string) {
 export function bracketexprToKey(inputStr) {
     if (inputStr.indexOf(">") > 0) {
         try {
-            const [
-                [modifiers, key],
-                remainder,
-            ] = bracketexpr_parser.feedUntilError(inputStr)
+            const [[modifiers, key], remainder] =
+                bracketexpr_parser.feedUntilError(inputStr)
             return [new MinimalKey(expandAliases(key), modifiers), remainder]
         } catch (e) {
             // No valid bracketExpr
@@ -506,6 +509,33 @@ export function translateKeysUsingKeyTranslateMap(
 }
 
 // }}}
+
+export function PrintableKey(k: KeyEventLike) {
+    let result = k.key
+    if (
+        result === "Control" ||
+        result === "Meta" ||
+        result === "Alt" ||
+        result === "Shift" ||
+        result === "OS"
+    ) {
+        return ""
+    }
+
+    if (k.altKey) {
+        result = "A-" + result
+    }
+    if (k.ctrlKey) {
+        result = "C-" + result
+    }
+    if (k.shiftKey) {
+        result = "S-" + result
+    }
+    if (result.length > 1) {
+        result = "<" + result + ">"
+    }
+    return result
+}
 
 browser.storage.onChanged.addListener(changes => {
     if ("userconfig" in changes) {

--- a/src/lib/which_key.ts
+++ b/src/lib/which_key.ts
@@ -4,22 +4,26 @@ import * as Messaging from "@src/lib/messaging"
 
 const logger = new Logger("whichkey")
 
+export type WhichKeyMap = Map<string, { target: string; isTerm: boolean }>
+
 /** Display possible suffixes with their respective targets */
 export function whichKey(prefix: string, possibleMappings?: KeyMap) {
     if (!possibleMappings || possibleMappings.size === 0) {
         return
     }
 
-    const maps: Map<string, string> = new Map()
+    const maps: WhichKeyMap = new Map()
     for (let [key, target] of possibleMappings) {
         const suffix = key.slice(prefix.length)
         // if suffix has multiple terminators, only show multiple suffixes
+        let isTerm = true
         if (suffix.length > 1) {
             // TODO: target should be setable by user
             target = "+prefix"
+            isTerm = false
         }
         const printableSuffix = suffix[0].toMapstr()
-        maps.set(printableSuffix, target as string)
+        maps.set(printableSuffix, { target: target as string, isTerm })
     }
     logger.debug(maps)
     Messaging.messageOwnTab("whichkey_content", "show")

--- a/src/lib/which_key.ts
+++ b/src/lib/which_key.ts
@@ -1,18 +1,27 @@
-import { KeyMap, PrintableKey } from "@src/lib/keyseq"
+import { KeyMap /* , PrintableKey*/ } from "@src/lib/keyseq"
 import Logger from "@src/lib/logging"
+import * as Messaging from "@src/lib/messaging"
 
 const logger = new Logger("whichkey")
 
-export function whichKey(keyseq: string, possibleMappings?: KeyMap) {
-    logger.debug(keyseq)
-    if (possibleMappings?.size === 0) {
-        return undefined
+/** Display possible suffixes with their respective targets */
+export function whichKey(prefix: string, possibleMappings?: KeyMap) {
+    if (!possibleMappings || possibleMappings.size === 0) {
+        return
     }
-    for (const [key, target] of possibleMappings) {
-        const suffix = key
-            .slice(keyseq.length)
-            .map(x => PrintableKey(x))
-            .join("")
-        logger.debug(suffix, target)
+
+    const maps: Map<string, string> = new Map()
+    for (let [key, target] of possibleMappings) {
+        const suffix = key.slice(prefix.length)
+        // if suffix has multiple terminators, only show multiple suffixes
+        if (suffix.length > 1) {
+            // TODO: target should be setable by user
+            target = "+prefix"
+        }
+        const printableSuffix = suffix[0].toMapstr()
+        maps.set(printableSuffix, target as string)
     }
+    logger.debug(maps)
+    Messaging.messageOwnTab("whichkey_content", "show")
+    Messaging.messageOwnTab("whichkey_frame", "showMappings", [prefix, maps])
 }

--- a/src/lib/which_key.ts
+++ b/src/lib/which_key.ts
@@ -1,0 +1,18 @@
+import { KeyMap, PrintableKey } from "@src/lib/keyseq"
+import Logger from "@src/lib/logging"
+
+const logger = new Logger("whichkey")
+
+export function whichKey(keyseq: string, possibleMappings?: KeyMap) {
+    logger.debug(keyseq)
+    if (possibleMappings?.size === 0) {
+        return undefined
+    }
+    for (const [key, target] of possibleMappings) {
+        const suffix = key
+            .slice(keyseq.length)
+            .map(x => PrintableKey(x))
+            .join("")
+        logger.debug(suffix, target)
+    }
+}

--- a/src/lib/which_key.ts
+++ b/src/lib/which_key.ts
@@ -25,3 +25,7 @@ export function whichKey(prefix: string, possibleMappings?: KeyMap) {
     Messaging.messageOwnTab("whichkey_content", "show")
     Messaging.messageOwnTab("whichkey_frame", "showMappings", [prefix, maps])
 }
+
+export function hideWhichKey() {
+    Messaging.messageOwnTab("whichkey_content", "hide")
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,9 +9,7 @@
         "150": "static/logo/Tridactyl_150px.png"
     },
     "background": {
-        "scripts": [
-            "background.js"
-        ]
+        "scripts": ["background.js"]
     },
     "chrome_url_overrides": {
         "newtab": "static/newtab.html"
@@ -90,12 +88,8 @@
     },
     "content_scripts": [
         {
-            "matches": [
-                "<all_urls>"
-            ],
-            "js": [
-                "content.js"
-            ],
+            "matches": ["<all_urls>"],
+            "js": ["content.js"],
             "css": [
                 "static/css/cleanslate.css",
                 "static/css/content.css",
@@ -109,6 +103,7 @@
     "content_security_policy": "script-src 'unsafe-eval' 'self'; object-src 'self'",
     "web_accessible_resources": [
         "static/commandline.html",
+        "static/whichkey.html",
         "static/defaultFavicon"
     ],
     "permissions": [

--- a/src/static/css/content.css
+++ b/src/static/css/content.css
@@ -61,3 +61,16 @@
     background-color: var(--tridactyl-search-highlight-color) !important;
     z-index: 2147483647 !important;
 }
+
+#whichkey_iframe {
+    position: fixed !important;
+    bottom: 0 !important;
+    z-index: 2047483641 !important;
+    width: 100% !important;
+    height: 0 !important;
+    border: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    min-height: 0 !important;
+    max-height: none !important;
+}

--- a/src/static/css/whichkey.css
+++ b/src/static/css/whichkey.css
@@ -1,0 +1,21 @@
+#whichkey-completions {
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    flex-flow: column wrap;
+    justify-content: flex-start;
+    height: 13rem;
+    padding: 2% 5%;
+}
+.BindingsCompletionOption {
+    width: 30%;
+    height: 1.4em;
+    font-family: sans-serif;
+}
+
+.arrow {
+    color: #76ff03;
+}
+
+.name {
+    color: #ff4081;
+}

--- a/src/static/css/whichkey.css
+++ b/src/static/css/whichkey.css
@@ -19,3 +19,12 @@
 .name {
     color: #ff4081;
 }
+
+.command {
+    color: #eee;
+}
+
+.more {
+    color: #0cf;
+    font-weight: bold;
+}

--- a/src/static/whichkey.html
+++ b/src/static/whichkey.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html class="TridactylOwnNamespace">
+    <head>
+        <meta charset="utf-8" />
+        <title>Tridactyl whichkey</title>
+        <link rel="stylesheet" href="css/cleanslate.css" />
+        <link rel="stylesheet" href="css/whichkey.css" />
+    </head>
+    <body>
+        <div id="whichkey-completions"></div>
+        <script src="../whichkey_frame.js"></script>
+    </body>
+</html>

--- a/src/whichkey_frame.ts
+++ b/src/whichkey_frame.ts
@@ -1,0 +1,22 @@
+import * as SELF from "@src/whichkey_frame"
+import * as Messaging from "@src/lib/messaging"
+import "@src/lib/html-tagged-template"
+
+export function showMappings(prefix: string, vals: Map<string, string>) {
+    const div = window.document.getElementById(
+        "whichkey-completions",
+    ) as HTMLDivElement
+    div.innerHTML = ""
+    const fragment = document.createDocumentFragment()
+    for (const [suffix, target] of vals) {
+        const a = html`<div class="BindingsCompletionOption option">
+            <span class="name">${suffix}</span>
+            <span class="arrow">&rarr;</span>
+            <span class="content">${target}</span>
+        </div>`
+        fragment.appendChild(a)
+    }
+    div.appendChild(fragment)
+}
+
+Messaging.addListener("whichkey_frame", Messaging.attributeCaller(SELF))

--- a/src/whichkey_frame.ts
+++ b/src/whichkey_frame.ts
@@ -2,17 +2,20 @@ import * as SELF from "@src/whichkey_frame"
 import * as Messaging from "@src/lib/messaging"
 import "@src/lib/html-tagged-template"
 
-export function showMappings(prefix: string, vals: Map<string, string>) {
+import type { WhichKeyMap } from "@src/lib/which_key"
+
+export function showMappings(prefix: string, vals: WhichKeyMap) {
     const div = window.document.getElementById(
         "whichkey-completions",
     ) as HTMLDivElement
     div.innerHTML = ""
     const fragment = document.createDocumentFragment()
-    for (const [suffix, target] of vals) {
+    for (const [suffix, { target, isTerm }] of vals) {
+        const targetClass = isTerm ? "command" : "more"
         const a = html`<div class="BindingsCompletionOption option">
             <span class="name">${suffix}</span>
             <span class="arrow">&rarr;</span>
-            <span class="content">${target}</span>
+            <span class=${targetClass}>${target}</span>
         </div>`
         fragment.appendChild(a)
     }

--- a/whichkey.css
+++ b/whichkey.css
@@ -1,0 +1,12 @@
+:root #whichkey_iframe {
+    position: fixed !important;
+    bottom: 0 !important;
+    z-index: 2047483641 !important;
+    width: 100% !important;
+    height: 0 !important;
+    border: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    min-height: 0 !important;
+    max-height: none !important;
+}


### PR DESCRIPTION
# Rough first draft

Currently, it shows a somewhat similar cheat sheet as [which-key.nvim](https://github.com/folke/which-key.nvim) for a non-terminator key is pressed. Cannot yet be disabled.

Quite possible broken in many places as I only tested the happy path in `yarn run run` for basic commands without doing much else yet. Existing tests pass.

## Concerns

Most of the code is copied from cmdline, so I'm unsure about the additional performance overhead created and what
potential security concerns might exist in the current implementation.

## To-dos

Some to-dos that I thought should still be done:

- [ ] Add toggle to enable/disable cheat sheet e.g. `:whichkey enable/disable`
- [ ] Test for bugs. 
- [ ] Add tests.
- [ ] Improve presentation code (most of the presentation code stolen from command line, including creating a new iframe).
- [ ] Add command for showing binds without needing to press a non-terminal bind, e.g. `:whichkey-show normal`.
- [ ] Change default style (current style is kinda opinionated and non-standard)
- [ ] Add user styling