### PR TITLE
Use CustomEvent instead of Event

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -51,8 +51,8 @@ const realwindow = (window as any).wrappedJSObject ?? window // wrappedJSObject 
 const triPushState = (hist => (
     (...args) => {
         const ret = hist(...args)
-        realwindow.dispatchEvent(new Event("HistoryPushState"))
-        realwindow.dispatchEvent(new Event("HistoryState"))
+        realwindow.dispatchEvent(new CustomEvent("HistoryPushState"))
+        realwindow.dispatchEvent(new CustomEvent("HistoryState"))
         return ret
     })
 )(realwindow.history.pushState.bind(realwindow.history))
@@ -60,14 +60,14 @@ const triPushState = (hist => (
 const triReplaceState = (hist => (
     (...args) => {
         const ret = hist(...args)
-        realwindow.dispatchEvent(new Event("HistoryReplaceState"))
-        realwindow.dispatchEvent(new Event("HistoryState"))
+        realwindow.dispatchEvent(new CustomEvent("HistoryReplaceState"))
+        realwindow.dispatchEvent(new CustomEvent("HistoryState"))
         return ret
     })
 )(realwindow.history.replaceState.bind(realwindow.history))
 
 realwindow.addEventListener("popstate", () => {
-    realwindow.dispatchEvent(new Event("HistoryState"))
+    realwindow.dispatchEvent(new CustomEvent("HistoryState"))
 })
 
 history.replaceState = triReplaceState


### PR DESCRIPTION
Since they are custom events, we should use CustomEvent,
although I did not see any difference.
Fix #4358.