### PR TITLE
Find from the viewport

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "stream": "stream-browserify"
   },
   "dependencies": {
+    "arg": "^5.0.2",
     "cleanslate": "^0.10.1",
     "csp-serdes": "github:cmcaine/csp-serdes",
     "css": "^3.0.0",
     "editor-adapter": "^0.0.3",
     "esbuild": "^0.14.47",
     "fuse.js": "^6.6.2",
-    "minimist": "^1.2.6",
     "nearley": "^2.20.1",
     "ramda": "^0.28.0",
     "semver-compare": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "editor-adapter": "^0.0.3",
     "esbuild": "^0.14.47",
     "fuse.js": "^6.6.2",
+    "minimist": "^1.2.6",
     "nearley": "^2.20.1",
     "ramda": "^0.28.0",
     "semver-compare": "^1.0.0",

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -176,7 +176,10 @@ export function removeHighlighting() {
     while (host.firstChild) host.removeChild(host.firstChild)
 }
 
-export async function jumpToNextMatch(n: number, searchFromView: boolean) {
+export async function jumpToNextMatch(
+    n: number,
+    searchFromView: boolean = false
+) {
     const lastSearchQuery = await State.getAsync("lastSearchQuery")
     if (!lastHighlights) {
         return lastSearchQuery ? jumpToMatch(lastSearchQuery, n < 0) : undefined

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -28,6 +28,13 @@ class FindHighlight extends HTMLSpanElement {
 
     constructor(private rects, public range: Range) {
         super()
+        {
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
+            const proto = FindHighlight.prototype
+            for (const key of Object.getOwnPropertyNames(proto)) {
+                this[key] = proto[key]
+            }
+        }
         this.style.position = "absolute"
         this.style.top = "0px"
         this.style.left = "0px"

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,36 +26,8 @@ function getFindHost() {
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
 
-    constructor(private rects, public range) {
+    constructor(private rects, public range: Range) {
         super()
-        ;(this as any).unfocus = () => {
-            for (const node of this.children) {
-                ;(
-                    node as HTMLElement
-                ).style.background = `rgba(127,255,255,0.5)`
-            }
-        }
-        ;(this as any).focus = () => {
-            if (!DOM.isVisible(this.children[0])) {
-                this.children[0].scrollIntoView({
-                    block: "center",
-                    inline: "center",
-                })
-            }
-            let parentNode = this.range.startContainer.parentNode
-            while (parentNode && !(parentNode instanceof HTMLAnchorElement)) {
-                parentNode = parentNode.parentNode
-            }
-            if (parentNode) {
-                parentNode.focus()
-            }
-            for (const node of this.children) {
-                ;(
-                    node as HTMLElement
-                ).style.background = `rgba(255,127,255,0.5)`
-            }
-        }
-
         this.style.position = "absolute"
         this.style.top = "0px"
         this.style.left = "0px"
@@ -77,7 +49,7 @@ class FindHighlight extends HTMLSpanElement {
         ;(this as any).unfocus()
     }
 
-    static fromFindApi(rectData, rangeData, allTextNode) {
+    static fromFindApi(rectData, rangeData, allTextNode: Text[]) {
         const range = document.createRange()
         range.setStart(
             allTextNode[rangeData.startTextNodePos],
@@ -91,6 +63,28 @@ class FindHighlight extends HTMLSpanElement {
             if (DOM.isVisible(child)) return true
         }
         return false
+    }
+
+    unfocus() {
+        for (const node of this.children) {
+            ;(node as HTMLElement).style.background = `rgba(127,255,255,0.5)`
+        }
+    }
+    focus() {
+        if (!this.isVisible()) {
+            this.children[0].scrollIntoView({
+                block: "center",
+                inline: "center",
+            })
+        }
+        let parentNode = this.range.startContainer.parentNode
+        while (parentNode && !(parentNode instanceof HTMLAnchorElement)) {
+            parentNode = parentNode.parentNode
+        }
+        if (parentNode) parentNode.focus()
+        for (const node of this.children) {
+            ;(node as HTMLElement).style.background = `rgba(255,127,255,0.5)`
+        }
     }
 }
 

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -74,11 +74,20 @@ class FindHighlight extends HTMLSpanElement {
                 inline: "center",
             })
         }
-        let parentNode = this.range.startContainer.parentNode
-        while (parentNode && !(parentNode instanceof HTMLAnchorElement)) {
-            parentNode = parentNode.parentNode
+
+        let parentElement = this.range.startContainer.parentElement
+        loop: while (parentElement) {
+            switch (parentElement.nodeName.toLowerCase()) {
+                case "a":
+                case "input":
+                case "button":
+                case "details":
+                    parentElement.focus()
+                    break loop
+            }
+            parentElement = parentElement.parentElement
         }
-        if (parentNode) parentNode.focus()
+
         for (const node of this.children) {
             ;(node as HTMLElement).style.background = `rgba(255,127,255,0.5)`
         }

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -140,7 +140,7 @@ export async function jumpToMatch(searchQuery, reverse) {
         )
         host.appendChild(high)
         lastHighlights.push(high)
-        if (!focused && DOM.isVisible(high)) {
+        if (!focused && Array.from(high.children).some(e => DOM.isVisible(e))) {
             focused = true
             ;(high as any).focus()
             selected = lastHighlights.length - 1

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -94,7 +94,7 @@ let selected = 0
 
 let HIGHLIGHT_TIMER
 
-export async function jumpToMatch(searchQuery, reverse) {
+export async function jumpToMatch(searchQuery, option) {
     const timeout = config.get("findhighlighttimeout")
     if (timeout > 0) {
         clearTimeout(HIGHLIGHT_TIMER)
@@ -151,15 +151,25 @@ export async function jumpToMatch(searchQuery, reverse) {
         throw new Error("Pattern not found: " + searchQuery)
     }
     lastHighlights.sort(
-        reverse ? (a, b) => b.top - a.top : (a, b) => a.top - b.top,
+        option.reverse ? (a, b) => b.top - a.top : (a, b) => a.top - b.top,
     )
+
+    if ("jumpTo" in option) {
+        selected = (option.jumpTo + lastHighlights.length) % lastHighlights.length
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        ;(lastHighlights[selected] as any).focus()
+        return
+    }
 
     // Just reuse the code to find the first match in the view
     selected = 0
     if (lastHighlights[selected].isVisible()) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         ;(lastHighlights[selected] as any).focus()
-    } else jumpToNextMatch(1, true)
+    } else {
+        const searchFromView = true
+        await jumpToNextMatch(1, searchFromView)
+    }
 }
 
 function drawHighlights(highlights) {

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -151,11 +151,12 @@ export async function jumpToMatch(searchQuery, option) {
         throw new Error("Pattern not found: " + searchQuery)
     }
     lastHighlights.sort(
-        option.reverse ? (a, b) => b.top - a.top : (a, b) => a.top - b.top,
+        option["reverse"] ? (a, b) => b.top - a.top : (a, b) => a.top - b.top,
     )
 
     if ("jumpTo" in option) {
-        selected = (option.jumpTo + lastHighlights.length) % lastHighlights.length
+        selected =
+            (option["jumpTo"] + lastHighlights.length) % lastHighlights.length
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         ;(lastHighlights[selected] as any).focus()
         return
@@ -183,9 +184,14 @@ export function removeHighlighting() {
 }
 
 export async function jumpToNextMatch(n: number, searchFromView = false) {
-    const lastSearchQuery = await State.getAsync("lastSearchQuery")
+    let lastSearchQuery
     if (!lastHighlights) {
-        return lastSearchQuery ? jumpToMatch(lastSearchQuery, n < 0) : undefined
+        lastSearchQuery = await State.getAsync("lastSearchQuery")
+        if (!lastSearchQuery) return
+        await jumpToMatch(lastSearchQuery, { reverse: n < 0 })
+        if (Math.abs(n) === 1) return
+        n = n - n / Math.abs(n)
+        searchFromView = false
     }
     if (!host.firstChild) {
         const timeout = config.get("findhighlighttimeout")

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -58,13 +58,10 @@ class FindHighlight extends HTMLSpanElement {
         range.setEnd(allTextNode[rangeData.endTextNodePos], rangeData.endOffset)
         return new this(rectData, range)
     }
-    isVisible(): boolean {
-        for (const child of this.children) {
-            if (DOM.isVisible(child)) return true
-        }
-        return false
-    }
 
+    isVisible(): boolean {
+        return DOM.isVisible(this.range)
+    }
     unfocus() {
         for (const node of this.children) {
             ;(node as HTMLElement).style.background = `rgba(127,255,255,0.5)`

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1462,12 +1462,12 @@ export function find(...args: string[]) {
 export function findnext(...args: string[]) {
     let n = 1
     const option = minimist(args, {
-        boolean: Array.from("fr"),
+        boolean: Array.from("f?"),
         alias: {
             f: ["search-from-view", "searchFromView"],
-            r: "reverse",
+            "?": "reverse",
         },
-        default: { f: false, r: false },
+        default: { f: false, "?": false },
     })
     if (option._.length > 0) n = Number(option._[0])
     if (option.reverse) n = -n

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1458,8 +1458,17 @@ export function find(...args: string[]) {
  *
  */
 //#content
-export function findnext(n = 1) {
-    return finding.jumpToNextMatch(n)
+export function findnext(...args: string[]) {
+    let n = 1
+    let searchFromView = false
+    if (args.length > 0) {
+        if (args[0] == '-f' || args[0] == '--search-from-view') {
+            searchFromView = true
+            args.shift()
+        }
+        if (args.length > 0) n = Number(args[0])
+    }
+    return finding.jumpToNextMatch(n, searchFromView)
 }
 
 //#content

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1496,6 +1496,17 @@ export function clearsearchhighlight() {
     return finding.removeHighlighting()
 }
 
+/**
+ * Highlight the current find-mode match result and enter the visual mode.
+ */
+//#content
+export function findselect() {
+    const range = finding.currentMatchRange()
+    const selection = document.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+}
+
 /** @hidden */
 //#content_helper
 function history(url_or_num: string, direction: number) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -96,7 +96,7 @@ import semverCompare from "semver-compare"
 import * as hint_util from "@src/lib/hint_util"
 import { OpenMode } from "@src/lib/hint_util"
 import * as Proxy from "@src/lib/proxy"
-import minimist from "minimist"
+import * as arg from "@src/lib/arg_util"
 
 /**
  * This is used to drive some excmd handling in `composite`.
@@ -1461,17 +1461,20 @@ export function find(...args: string[]) {
 //#content
 export function findnext(...args: string[]) {
     let n = 1
-    const option = minimist(args, {
-        boolean: Array.from("f?"),
-        alias: {
-            f: ["search-from-view", "searchFromView"],
-            "?": "reverse",
+    const option = arg.lib(
+        {
+            "--search-from-view": Boolean,
+            "--searchFromView": "--search-from-view",
+            "-f": "--search-from-view",
+
+            "--reverse": Boolean,
+            "-?": "--reverse",
         },
-        default: { f: false, "?": false },
-    })
+        { argv: args },
+    )
     if (option._.length > 0) n = Number(option._[0])
-    if (option.reverse) n = -n
-    return finding.jumpToNextMatch(n, option.searchFromView)
+    if (option["--reverse"]) n = -n
+    return finding.jumpToNextMatch(n, Boolean(option["--search-from-view"]))
 }
 
 //#content

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1431,8 +1431,8 @@ export function scrollpage(n = 1, count = 1) {
  *      bind ? fillcmdline find --reverse
  *      bind n findnext --search-from-view
  *      bind N findnext --search-from-view --reverse
- *      bind gn findnext
- *      bind gN findnext --reverse
+ *      bind gn findselect
+ *      bind gN composite findnext --search-from-view --reverse; findselect
  *      bind ,<Space> nohlsearch
  *
  *  Argument: A string you want to search for.

--- a/src/lib/arg_util.ts
+++ b/src/lib/arg_util.ts
@@ -1,16 +1,41 @@
 import arg from "arg"
 
+/**
+ * The arguments parsing library name
+ */
 export const name = "arg"
+
+/**
+ * The imported library itself
+ */
 export const lib = arg
-export function correctSingleHyphen(argv, ...singleNames) {
+
+/**
+ * Function to easily allow some single hyphen prefix option
+ * to be treated as long option too.
+ *
+ * E.g. correctSingleHyphen("-private https://some.url".split(" "), "-private")
+ * will retrun "--private http://some.url".split(" "), which can be parsed
+ * as a normal long option.
+ */
+export function correctSingleHyphen(
+    argv: string[],
+    ...singleNames: string[]
+): string[] {
     return argv.map(arg => {
-        const scan = arg.match(/^-[\w-]{2,}/)
+        const scan = /^-[\w-]{2,}/.exec(arg)
         if (!scan) return arg
         const index = singleNames.indexOf(scan[0])
         if (index === -1) return arg
         else return "-" + arg
     })
 }
-export function isLastDoubleHyphen(argv) {
-    return argv.at(-1) === "--"
+
+/**
+ * Small function to test if the double hyphen is the last option.
+ * If a command does not expect empty arguments, and user just pass "--"
+ * as a normal argument, this function cal tell it.
+ */
+export function isLastDoubleHyphen(argv: string[]): boolean {
+    return argv[argv.length - 1] === "--"
 }

--- a/src/lib/arg_util.ts
+++ b/src/lib/arg_util.ts
@@ -1,0 +1,16 @@
+import arg from "arg"
+
+export const name = "arg"
+export const lib = arg
+export function correctSingleHyphen(argv, ...singleNames) {
+    return argv.map(arg => {
+        const scan = arg.match(/^-[\w-]{2,}/)
+        if (!scan) return arg
+        const index = singleNames.indexOf(scan[0])
+        if (index === -1) return arg
+        else return "-" + arg
+    })
+}
+export function isLastDoubleHyphen(argv) {
+    return argv.at(-1) === "--"
+}

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -208,8 +208,8 @@ export function widthMatters(style: CSSStyleDeclaration) {
 
 export function isVisibleFilter(
     includeInvisible: boolean,
-): (_: Element) => boolean {
-    return (elem: Element) => includeInvisible || isVisible(elem)
+): (_: Element | Range) => boolean {
+    return (elem: Element | Range) => includeInvisible || isVisible(elem)
 }
 
 // Saka-key caches getComputedStyle. Maybe it's a good idea!
@@ -221,11 +221,11 @@ export function isVisibleFilter(
     Based on https://github.com/guyht/vimari/blob/master/vimari.safariextension/linkHints.js
 
  */
-export function isVisible(element: Element) {
-    while (!(element.getBoundingClientRect instanceof Function)) {
-        element = element.parentElement
+export function isVisible(thing: Element | Range) {
+    while (!(thing.getBoundingClientRect instanceof Function)) {
+        thing = thing.parentElement
     }
-    const clientRect = element.getBoundingClientRect()
+    const clientRect = thing.getBoundingClientRect()
     switch (true) {
         case !clientRect:
         case clientRect.bottom < 4:
@@ -235,6 +235,9 @@ export function isVisible(element: Element) {
             return false
     }
 
+    if (thing instanceof Range) return true
+
+    const element = thing
     // remove elements that are barely within the viewport, tiny, or invisible
     // Only call getComputedStyle when necessary
     const computedStyle = getComputedStyle(element)
@@ -289,9 +292,10 @@ export function isVisible(element: Element) {
  */
 export function getAllDocumentFrames(doc = document) {
     if (!(doc instanceof HTMLDocument)) return []
-    const frames = (Array.from(
-        doc.getElementsByTagName("iframe"),
-    ) as HTMLIFrameElement[] & HTMLFrameElement[])
+    const frames = (
+        Array.from(doc.getElementsByTagName("iframe")) as HTMLIFrameElement[] &
+            HTMLFrameElement[]
+    )
         .concat(Array.from(doc.getElementsByTagName("frame")))
         .filter(frame => !frame.src.startsWith("moz-extension://"))
     return frames.concat(
@@ -538,7 +542,9 @@ function onPageFocus(elem: HTMLElement): boolean {
     if (isTextEditable(elem)) {
         LAST_USED_INPUT = elem
     }
-    const setting = config.get("modesubconfigs", contentState.mode, "allowautofocus") || config.get("allowautofocus")
+    const setting =
+        config.get("modesubconfigs", contentState.mode, "allowautofocus") ||
+        config.get("allowautofocus")
     return setting === "true"
 }
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -222,8 +222,10 @@ export function isVisibleFilter(
 
  */
 export function isVisible(thing: Element | Range) {
-    while (!(thing.getBoundingClientRect instanceof Function)) {
-        thing = thing.parentElement
+    if (thing instanceof Element) {
+        while (typeof thing.getBoundingClientRect !== "function") {
+            thing = thing.parentElement
+        }
     }
     const clientRect = thing.getBoundingClientRect()
     switch (true) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,6 +1242,11 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+arg@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
+  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"


### PR DESCRIPTION
This PR make the `find` and `findnext` commands be able to search from the viewport instead of the previous match, if the `-f` or `--search-from-view` option exist. The only exception is that if the previous match is in the viewport, the findnext will always jump to the next match relative to the previous match.

The original implementation is buggy, the DOM.isVisible can not tell if the custom element Hithlight is visible, so I add a isVisible method to the element. The stradegy to find the next match in `find` does not work fine in reverse search; my implementation move most stradegy code to the jumpToNextMatch.

## Behavior
* `find` should always jump to the next match from the view. If `-?` or `--reverse` is specified, search upward, and the the *first in the viewport* is count from the bottom of the page.
* `findnext -?|--reverse $n` will reverse the sign of `$n`, so we can add number-prefix to the `bind N findnext -?`.
* `-f` and `--find-from-view` are only work for `findnext`, since the original `find` should find from the viewport if there are no bugs. I am just correcting it.

## New Library
The arguments parsing library I use is [arg](https://www.npmjs.com/package/arg), and I implement some useful parsing functions in `src/lib/args_util.ts`.

## Related issue
* #1612 : imporve find mode
* #4270 : support long option `--reverse` and import a arguments parsing library
* #4373 : maybe support it in this PR?

## Todo
* ~~Docs and types for `args_util.ts`~~ done
* ~~Add suggested binding `bind n findnext --search-from-view` and `bind gn findnext`.~~ done