### PR TITLE
Add --url option to define command in certain url and fix a recursion detection bug

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1925,7 +1925,12 @@ const parseConfigHelper = (pconf, parseobj, prefix = []) => {
                     parseobj.nulls.push(`setnull ${i}.${e}`)
                 } else if (i === "exaliases") {
                     // Only really useful if mapping the entire config and not just pconf.
-                    if (e === "alias") {
+                    if (prefix[0] === "subconfigs") {
+                        const url = prefix[1]
+                        const command = `alias --url ${url} ${e} ${pconf[i][e]}`
+                        parseobj.aliases.push(command)
+                    }
+                    else if (e === "alias") {
                         parseobj.aliases.push(`command ${e} ${pconf[i][e]}`)
                     } else {
                         parseobj.aliases.push(`alias ${e} ${pconf[i][e]}`)


### PR DESCRIPTION
Accept url option in command and output them in mktridactylrc with --url option. The original code can not output alias in subconfigs correctly (if they does exist). The doc about it and a example is added too.

The original code does not detect the recursive alias correctly. Thought it does detect, it detect before it define the alias; it should detect it after defining.