### PR TITLE
Add more detailed docs on containerized firefox install support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,14 +61,18 @@ If you want to use advanced features such as edit-in-Vim, you'll also need to in
 
 * Upgrading to a beta version of Firefox (`>= 106.0b6`)
 * Enabling webextension permisisons: `flatpack permission-set webextensions tridactyl snap.firefox yes`
-* Rebooting your system (and likely nothing short of it).
+* Rebooting your system (and likely nothing short of it)
 
-See https://github.com/tridactyl/tridactyl/issues/2406 and this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) for more details.
+See this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) for more details.
 
 **Firejail** will require explicit path whitelisting, but should be feasible based on https://github.com/netblue30/firejail/issues/2109.
 
 For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above.
-With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
+With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file].
+
+**Troubleshooting:** If your extension is still not working, the [manifest json file] may be in the wrong place. To rule this out, copy or link it to both the Global and User manifest locations, closing all firefox processes, and restarting firefox (i.e. `ln -s /usr/lib/mozilla/native-messaging-hosts/ ~/.mozilla/native-messaging-hosts` on linux).
+
+[manifest json file]: https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests
 
 ### Migrating between beta and stable builds
 

--- a/readme.md
+++ b/readme.md
@@ -51,11 +51,25 @@ Tridactyl stable can be installed from the [Mozilla add-ons website (the AMO)][a
 
 [Click this in Firefox to install our "beta" builds][riskyclick]. These [betas][betas] are updated with each commit to master on this repo. Your browser will automatically update from there once a day. If you want more frequent updates, you can change `extensions.update.interval` in `about:config` to whatever time you want, say, 15 minutes (900 seconds). There is also another beta build that comes without a new tab page. You can get it from [here][nonewtablink].
 
-### Extra features
+### Extra features through [Native Messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging)
 
 If you want to use advanced features such as edit-in-Vim, you'll also need to install the native messenger or executable, instructions for which can be found by typing `:installnative` and hitting enter once you are in Tridactyl. Arch users can install the [AUR package](https://aur.archlinux.org/packages/firefox-tridactyl-native/) `firefox-tridactyl-native` instead.
 
-> **Notice**: `native` seems that does not work on Firefox instances installed with Snap (and probably other sandboxing/containerised package managers). See https://github.com/tridactyl/tridactyl/issues/2406
+#### Containerized/sandboxed Firefox Installations
+
+**Snap and Flatpak:** Native Messaging support here is fairly recent and may require:
+
+* Upgrading to a beta version of Firefox (`>= 106.0b6`)
+* Enabling webextension permisisons: `flatpack permission-set webextensions tridactyl snap.firefox yes`
+* Rebooting your system (and likely nothing short of it).
+
+See this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759)
+for more details. See https://github.com/tridactyl/tridactyl/issues/2406
+
+**Firejail** will require explicit path whitelisting, but should be feasible based on https://github.com/netblue30/firejail/issues/2109.
+
+For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above.
+With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file]([https://wiki.mozilla.org/WebExtensions/Native_Messaging](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
 
 ### Migrating between beta and stable builds
 

--- a/readme.md
+++ b/readme.md
@@ -63,13 +63,12 @@ If you want to use advanced features such as edit-in-Vim, you'll also need to in
 * Enabling webextension permisisons: `flatpack permission-set webextensions tridactyl snap.firefox yes`
 * Rebooting your system (and likely nothing short of it).
 
-See this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759)
-for more details. See https://github.com/tridactyl/tridactyl/issues/2406
+See https://github.com/tridactyl/tridactyl/issues/2406 and this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) for more details.
 
 **Firejail** will require explicit path whitelisting, but should be feasible based on https://github.com/netblue30/firejail/issues/2109.
 
 For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above.
-With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file]([https://wiki.mozilla.org/WebExtensions/Native_Messaging](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
+With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
 
 ### Migrating between beta and stable builds
 

--- a/readme.md
+++ b/readme.md
@@ -63,16 +63,12 @@ If you want to use advanced features such as edit-in-Vim, you'll also need to in
 * Enabling webextension permisisons: `flatpack permission-set webextensions tridactyl snap.firefox yes`
 * Rebooting your system (and likely nothing short of it)
 
-See this [call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) for more details.
+See [this call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) and [this PR](https://github.com/tridactyl/tridactyl/pull/4406) for more details and troubleshooting tips.
 
 **Firejail** will require explicit path whitelisting, but should be feasible based on https://github.com/netblue30/firejail/issues/2109.
 
 For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above.
-With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file].
-
-**Troubleshooting:** If your extension is still not working, the [manifest json file] may be in the wrong place. To rule this out, copy or link it to both the Global and User manifest locations, closing all firefox processes, and restarting firefox (i.e. `ln -s /usr/lib/mozilla/native-messaging-hosts/ ~/.mozilla/native-messaging-hosts` on linux).
-
-[manifest json file]: https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests
+With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
 
 ### Migrating between beta and stable builds
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -719,6 +719,7 @@ export async function exclaim_quiet(...str: string[]) {
 /**
  * Tells you if the native messenger is installed and its version.
  *
+ * For snap, flatpak, and other sandboxed installations, additional setup is required – see https://github.com/tridactyl#extra-features-through-native-messaging.
  */
 //#background
 export async function native() {
@@ -738,6 +739,8 @@ export async function native() {
  * The native messenger's source code may be found here: https://github.com/tridactyl/native_messenger/blob/master/src/native_main.nim
  *
  * If your corporate IT policy disallows execution of binaries which have not been whitelisted but allows Python scripts, you may instead use the old native messenger by running `install.sh` or `win_install.ps1` from https://github.com/tridactyl/tridactyl/tree/master/native - the main downside is that it is significantly slower.
+ * 
+ * For snap, flatpak, and other sandboxed installations, additional setup is required – see https://github.com/tridactyl#extra-features-through-native-messaging.
  */
 //#background
 export async function nativeinstall() {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -739,7 +739,7 @@ export async function native() {
  * The native messenger's source code may be found here: https://github.com/tridactyl/native_messenger/blob/master/src/native_main.nim
  *
  * If your corporate IT policy disallows execution of binaries which have not been whitelisted but allows Python scripts, you may instead use the old native messenger by running `install.sh` or `win_install.ps1` from https://github.com/tridactyl/tridactyl/tree/master/native - the main downside is that it is significantly slower.
- * 
+ *
  * For snap, flatpak, and other sandboxed installations, additional setup is required – see https://github.com/tridactyl#extra-features-through-native-messaging.
  */
 //#background


### PR DESCRIPTION
Snap & Flatpak now have support for native messaging so I wrote some docs to try and help resolve https://github.com/tridactyl/tridactyl/issues/2406.

This maybe belongs in a Wiki page instead of the main readme – lmk and I'll move it (or someone else can, w/e).

**NOTE for KDE users:** [Running firefox from krunner doesn't work](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759/102?u=micimize), you have to test from command line, or run with `sh -c 'firefox'`. Not sure why