### PR TITLE
Reduce flickering when opening new about:blank tab

### DIFF
--- a/src/static/themes/dark/dark.css
+++ b/src/static/themes/dark/dark.css
@@ -229,8 +229,12 @@
 
     /* }}} */
 
+    /* 2021 firefox redesign changed the background color of a new tab.
+       this is a quick fix to remove flicker when opening a new about:blank tab with tridactyl installed.
+    */
+    --tridactyl-firefox-2021-redesign-background: #2b2a33;
     --tridactyl-fg: var(--tridactyl-photon-colours-in-content-page-color);
-    --tridactyl-bg: var(--tridactyl-photon-colours-in-content-page-background);
+    --tridactyl-bg: var(--tridactyl-firefox-2021-redesign-background);
 
     --tridactyl-scrollbar-color: var(--tridactyl-photon-colours-tone-8)
         var(--tridactyl-fg);


### PR DESCRIPTION
This patch updates the dark theme background color to reduce flickering when opening a new about:blank tab. 

The videos below show the state before and after applying the patch. 

Before:
https://user-images.githubusercontent.com/68248740/194871356-0a2d53ab-9a30-4efb-852d-acb2c9182bb2.mp4

Notice how the background of the new about:blank tab is flickering.

After:
https://user-images.githubusercontent.com/68248740/194871154-056ba34a-73c0-43be-bf89-fa89c98d9a8d.mp4

Now the background color doesn't change when the extension has finished loading.