### PR TITLE
Include header in webRequest BeforeSendHeaders and HeaderReceived events

### DIFF
--- a/src/background/webrequests.ts
+++ b/src/background/webrequests.ts
@@ -26,7 +26,7 @@ export const registerWebRequestAutocmd = (
     return browser.webRequest["on" + requestEvent].addListener(
         listener,
         { urls: [pattern] },
-        ["blocking", "requestBody"],
+        ["blocking", "requestHeaders", "requestBody", "responseHeaders"],
     )
 }
 


### PR DESCRIPTION
Since we already have blocking and requestBody, adding requestHeaders and responseHeaders should be okay too.

I create this because some website does not like `Linux` in the user-agent header. With BeforeSendHeaders, I can change my user-agent for some websites.