### PR TITLE
Use MinimalKey internally, add terminator key to gobble mode

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -52,7 +52,7 @@ import * as genericParser from "@src/parsers/genericmode"
 import * as perf from "@src/perf"
 import state, * as State from "@src/state"
 import * as R from "ramda"
-import { MinimalKey, minimalKeyFromKeyboardEventLike } from "@src/lib/keyseq"
+import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
 
 /** @hidden **/
@@ -186,9 +186,7 @@ commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        commandline_state.keyEvents.push(
-            minimalKeyFromKeyboardEventLike(keyevent),
-        )
+        commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {
             keyevent.preventDefault()

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -52,7 +52,7 @@ import * as genericParser from "@src/parsers/genericmode"
 import * as perf from "@src/perf"
 import state, * as State from "@src/state"
 import * as R from "ramda"
-import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
+import { MinimalKey, minimalKeyFromKeyboardEventLike } from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
 
 /** @hidden **/
@@ -186,7 +186,9 @@ commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
+        commandline_state.keyEvents.push(
+            minimalKeyFromKeyboardEventLike(keyevent),
+        )
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {
             keyevent.preventDefault()

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -52,7 +52,7 @@ import * as genericParser from "@src/parsers/genericmode"
 import * as perf from "@src/perf"
 import state, * as State from "@src/state"
 import * as R from "ramda"
-import { KeyEventLike } from "@src/lib/keyseq"
+import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
 
 /** @hidden **/
@@ -78,7 +78,7 @@ const commandline_state = {
      * tl;dr TODO: delete this and better resolve race condition
      */
     isVisible: false,
-    keyEvents: new Array<KeyEventLike>(),
+    keyEvents: new Array<MinimalKey>(),
     refresh_completions,
     state,
 }
@@ -186,7 +186,7 @@ commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        commandline_state.keyEvents.push(keyevent)
+        commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {
             keyevent.preventDefault()

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -5,7 +5,7 @@ import * as controller from "@src/lib/controller"
 import {
     KeyEventLike,
     ParserResponse,
-    minimalKeyFromKeyboardEventLike,
+    minimalKeyFromKeyboardEvent,
     MinimalKey,
 } from "@src/lib/keyseq"
 import { deepestShadowRoot } from "@src/lib/dom"
@@ -138,7 +138,7 @@ function* ParserController() {
                     // binding, so it can't grow indefinitely unless you
                     // have a combination of maps that permits bindings of
                     // unbounded length.
-                    keyEvents.push(minimalKeyFromKeyboardEventLike(keyevent))
+                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
                 } else {
                     keyEvents.push(keyevent)
                 }

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -5,7 +5,7 @@ import * as controller from "@src/lib/controller"
 import {
     KeyEventLike,
     ParserResponse,
-    minimalKeyFromKeyboardEvent,
+    minimalKeyFromKeyboardEventLike,
     MinimalKey,
 } from "@src/lib/keyseq"
 import { deepestShadowRoot } from "@src/lib/dom"
@@ -138,7 +138,7 @@ function* ParserController() {
                     // binding, so it can't grow indefinitely unless you
                     // have a combination of maps that permits bindings of
                     // unbounded length.
-                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
+                    keyEvents.push(minimalKeyFromKeyboardEventLike(keyevent))
                 } else {
                     keyEvents.push(keyevent)
                 }

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1192,7 +1192,7 @@ function focusRightHint() {
 }
 
 /** @hidden */
-export function parser(keys: keyseq.KeyEventLike[]) {
+export function parser(keys: keyseq.MinimalKey[]) {
     const parsed = keyseq.parse(
         keys,
         keyseq.mapstrMapToKeyMap(

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5334,13 +5334,14 @@ export function run_exstr(...commands: string[]) {
 
 /** Initialize gobble mode.
 
-    It will read `nChars` input keys, append them to `endCmd` and execute that
-    string.
-
+    If numKeysOrTerminator is a number, it will read the provided amount of keys,
+    append them to `endCmd` and execute that string.
+    If numKeysOrTerminator is a key like 'k' or 'Enter', it will read keys until
+    the provided key is pressed, append them to `endCmd` and execute that string.
 */
 //#content
-export async function gobble(nChars: number, endCmd: string) {
-    return gobbleMode.init(nChars, endCmd)
+export async function gobble(numKeysOrTerminator: string, endCmd: string) {
+    return gobbleMode.init(numKeysOrTerminator, endCmd)
 }
 
 // }}}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5336,8 +5336,9 @@ export function run_exstr(...commands: string[]) {
 
     If numKeysOrTerminator is a number, it will read the provided amount of keys,
     append them to `endCmd` and execute that string.
-    If numKeysOrTerminator is a key like 'k' or 'Enter', it will read keys until
-    the provided key is pressed, append them to `endCmd` and execute that string.
+    If numKeysOrTerminator is a key or key combination like 'k', '<CR>' or '<C-j>',
+    it will read keys until the provided key is pressed, append them to `endCmd` and
+    execute that string.
 */
 //#content
 export async function gobble(numKeysOrTerminator: string, endCmd: string) {

--- a/src/lib/binding.ts
+++ b/src/lib/binding.ts
@@ -2,7 +2,7 @@
  *
  */
 
-import { mapstrToKeyseq } from "@src/lib/keyseq"
+import { canonicaliseMapstr } from "@src/lib/keyseq"
 
 export const mode2maps = new Map([
     ["normal", "nmaps"],
@@ -46,8 +46,7 @@ export function parse_bind_args(...args: string[]): bind_args {
 
     const key = args.shift()
     // Convert key to internal representation
-    const keyseq = mapstrToKeyseq(key)
-    result.key = keyseq.map(k => k.toMapstr()).join("")
+    result.key = canonicaliseMapstr(key)
 
     result.excmd = args.join(" ")
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -371,7 +371,7 @@ export class default_config {
         ".": "repeat",
         "<AS-ArrowUp><AS-ArrowUp><AS-ArrowDown><AS-ArrowDown><AS-ArrowLeft><AS-ArrowRight><AS-ArrowLeft><AS-ArrowRight>ba":
             "open https://www.youtube.com/watch?v=M3iOROuTuMA",
-        "m": "gobble 1 markadd",
+        m: "gobble 1 markadd",
         "`": "gobble 1 markjump",
     }
 
@@ -1265,9 +1265,10 @@ const platform_defaults = {
 & '%TEMP%/tridactyl_installnative.ps1' -Tag %TAG;\
 Remove-Item '%TEMP%/tridactyl_installnative.ps1'"`,
         downloadforbiddenchars: "#%&{}\\<>*?/$!'\":@+`|=",
-        downloadforbiddennames: "CON, PRN, AUX, NUL, COM1, COM2,"
-            + "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1,"
-            + "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,",
+        downloadforbiddennames:
+            "CON, PRN, AUX, NUL, COM1, COM2," +
+            "COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1," +
+            "LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9,",
     },
     linux: {
         nmaps: {

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -65,9 +65,8 @@ export class MinimalKey {
         }
     }
 
-    /** Does this key match a given MinimalKey extending object? */
+    /** Does this key match another MinimalKey */
     public match(keyevent: MinimalKey) {
-        // 'in' doesn't include prototypes, so it's safe for this object.
         if (this.key !== keyevent.key) return false
         for (const [_, attr] of modifiers.entries()) {
             if (this[attr] !== keyevent[attr]) return false

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -486,9 +486,11 @@ export function translateKeysUsingKeyTranslateMap(
         // almost certainly mean oscillations and other super-weird
         // breakage.
         if (!keyEvent.translated && newkey !== undefined) {
-            keyEvents[index] = minimalKeyFromKeyboardEventLike({
-                ...keyEvent,
-                key: newkey,
+            keyEvents[index] = new MinimalKey(newkey, {
+                altKey: keyEvent.altKey,
+                ctrlKey: keyEvent.ctrlKey,
+                metaKey: keyEvent.metaKey,
+                shiftKey: keyEvent.shiftKey,
             })
             keyEvents[index].translated = true
         }
@@ -499,13 +501,9 @@ export function translateKeysUsingKeyTranslateMap(
  * for further use. Key is obtained through layout-independent
  * code if config says so.
  */
-export function minimalKeyFromKeyboardEventLike(keyEvent: {
-    key: string
-    altKey: boolean
-    ctrlKey: boolean
-    metaKey: boolean
-    shiftKey: boolean
-}): MinimalKey {
+export function minimalKeyFromKeyboardEvent(
+    keyEvent: KeyboardEvent,
+): MinimalKey {
     return new MinimalKey(keyEvent.key, {
         altKey: keyEvent.altKey,
         ctrlKey: keyEvent.ctrlKey,

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -351,6 +351,12 @@ export function mapstrToKeyseq(mapstr: string): MinimalKey[] {
     return keyseq
 }
 
+export function canonicaliseMapstr(mapstr: string): string {
+    return mapstrToKeyseq(mapstr)
+        .map(k => k.toMapstr())
+        .join("")
+}
+
 export const commandKey2jsKey = {
     Comma: ",",
     Period: ".",

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -38,6 +38,13 @@ export interface KeyModifiers {
     shiftKey?: boolean
 }
 
+// Format modifiers
+const modifiers = new Map([
+    ["A", "altKey"],
+    ["C", "ctrlKey"],
+    ["M", "metaKey"],
+    ["S", "shiftKey"],
+])
 export class MinimalKey {
     readonly altKey = false
     readonly ctrlKey = false
@@ -47,17 +54,22 @@ export class MinimalKey {
     constructor(readonly key: string, modifiers?: KeyModifiers) {
         if (modifiers !== undefined) {
             for (const mod of Object.keys(modifiers)) {
+                if (
+                    this.key.length === 1 &&
+                    this.key !== " " &&
+                    mod === "shiftKey"
+                )
+                    continue
                 this[mod] = modifiers[mod]
             }
         }
     }
 
     /** Does this key match a given MinimalKey extending object? */
-    public match(keyevent) {
+    public match(keyevent: MinimalKey) {
         // 'in' doesn't include prototypes, so it's safe for this object.
-        for (const attr in this) {
-            // Don't check shiftKey for normal keys.
-            if (attr === "shiftKey" && this.key.length === 1) continue
+        if (this.key !== keyevent.key) return false
+        for (const [_, attr] of modifiers.entries()) {
             if (this[attr] !== keyevent[attr]) return false
         }
         return true
@@ -78,13 +90,6 @@ export class MinimalKey {
         let str = ""
         let needsBrackets = this.key.length > 1
 
-        // Format modifiers
-        const modifiers = new Map([
-            ["A", "altKey"],
-            ["C", "ctrlKey"],
-            ["M", "metaKey"],
-            ["S", "shiftKey"],
-        ])
         for (const [letter, attr] of modifiers.entries()) {
             if (this[attr]) {
                 str += letter

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -63,6 +63,17 @@ export class MinimalKey {
         return true
     }
 
+    public translate(keytranslatemap: { [inkey: string]: string }): MinimalKey {
+        let newkey = keytranslatemap[this.key]
+        if (newkey === undefined) newkey = this.key
+        return new MinimalKey(newkey, {
+            altKey: this.altKey,
+            ctrlKey: this.ctrlKey,
+            metaKey: this.metaKey,
+            shiftKey: this.shiftKey,
+        })
+    }
+
     public toMapstr() {
         let str = ""
         let needsBrackets = this.key.length > 1
@@ -479,19 +490,11 @@ export function translateKeysUsingKeyTranslateMap(
     keytranslatemap: { [inkey: string]: string },
 ) {
     for (let index = 0; index < keyEvents.length; index++) {
-        const keyEvent = keyEvents[index]
-        const newkey = keytranslatemap[keyEvent.key]
-
         // Translating anything more than once would
         // almost certainly mean oscillations and other super-weird
         // breakage.
-        if (!keyEvent.translated && newkey !== undefined) {
-            keyEvents[index] = new MinimalKey(newkey, {
-                altKey: keyEvent.altKey,
-                ctrlKey: keyEvent.ctrlKey,
-                metaKey: keyEvent.metaKey,
-                shiftKey: keyEvent.shiftKey,
-            })
+        if (!keyEvents[index].translated) {
+            keyEvents[index] = keyEvents[index].translate(keytranslatemap)
             keyEvents[index].translated = true
         }
     }

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -480,11 +480,9 @@ export function translateKeysUsingKeyTranslateMap(
         // almost certainly mean oscillations and other super-weird
         // breakage.
         if (!keyEvent.translated && newkey !== undefined) {
-            keyEvents[index] = new MinimalKey(newkey, {
-                altKey: keyEvent.altKey,
-                ctrlKey: keyEvent.ctrlKey,
-                metaKey: keyEvent.metaKey,
-                shiftKey: keyEvent.shiftKey,
+            keyEvents[index] = minimalKeyFromKeyboardEventLike({
+                ...keyEvent,
+                key: newkey,
             })
             keyEvents[index].translated = true
         }
@@ -495,9 +493,13 @@ export function translateKeysUsingKeyTranslateMap(
  * for further use. Key is obtained through layout-independent
  * code if config says so.
  */
-export function minimalKeyFromKeyboardEvent(
-    keyEvent: KeyboardEvent,
-): MinimalKey {
+export function minimalKeyFromKeyboardEventLike(keyEvent: {
+    key: string
+    altKey: boolean
+    ctrlKey: boolean
+    metaKey: boolean
+    shiftKey: boolean
+}): MinimalKey {
     return new MinimalKey(keyEvent.key, {
         altKey: keyEvent.altKey,
         ctrlKey: keyEvent.ctrlKey,

--- a/src/parsers/gobblemode.ts
+++ b/src/parsers/gobblemode.ts
@@ -1,22 +1,25 @@
 import { contentState } from "@src/content/state_content"
-import { isSimpleKey, KeyEventLike } from "@src/lib/keyseq"
+import { MinimalKey } from "@src/lib/keyseq"
 
 /** Simple container for the gobble state. */
 class GobbleState {
-    public numChars = 0
-    public chars = ""
+    public numKeysOrTerminator: number | string = 0
+    public keyCombination = ""
     public endCommand = ""
 }
 
 let modeState: GobbleState
 
-/** Init gobble mode. After parsing the defined number of input keys, execute
-`endCmd` with attached parsed input. `Escape` cancels the mode and returns to
-normal mode. */
-export function init(numChars: number, endCommand: string) {
+/** Init gobble mode. After parsing the defined number of input keys,
+ * or until provided terminator key, execute `endCmd` with attached parsed input.
+ * `Escape` cancels the mode and returns to normal mode. */
+export function init(numKeysOrTerminator: string, endCommand: string) {
     contentState.mode = "gobble"
     modeState = new GobbleState()
-    modeState.numChars = numChars
+    const number = Number(numKeysOrTerminator)
+    if (!isNaN(number)) {
+        modeState.numKeysOrTerminator = number
+    } else modeState.numKeysOrTerminator = numKeysOrTerminator
     modeState.endCommand = endCommand
 }
 
@@ -27,18 +30,29 @@ function reset() {
 }
 
 /** Receive keypress. If applicable, execute a command. */
-export function parser(keys: KeyEventLike[]) {
+export function parser(keys: MinimalKey[]) {
+    function exec() {
+        const exstr = modeState.endCommand + " " + modeState.keyCombination
+        reset()
+        return { keys: [], exstr }
+    }
+
     const key = keys[0].key
 
     if (key === "Escape") {
         reset()
-    } else if (isSimpleKey(keys[0])) {
-        modeState.chars += key
-        if (modeState.chars.length >= modeState.numChars) {
-            const exstr = modeState.endCommand + " " + modeState.chars
-            reset()
-            return { keys: [], exstr }
-        }
+    } else if (
+        typeof modeState.numKeysOrTerminator === "string" &&
+        modeState.numKeysOrTerminator === key
+    ) {
+        return exec()
+    } else if (keys[0].isPrintable()) {
+        modeState.keyCombination += keys[0].toMapstr()
+        if (
+            typeof modeState.numKeysOrTerminator === "number" &&
+            --modeState.numKeysOrTerminator <= 0
+        )
+            return exec()
     }
     return { keys: [], exstr: "", isMatch: true }
 }

--- a/src/parsers/gobblemode.ts
+++ b/src/parsers/gobblemode.ts
@@ -1,5 +1,5 @@
 import { contentState } from "@src/content/state_content"
-import { MinimalKey } from "@src/lib/keyseq"
+import { MinimalKey, canonicaliseMapstr } from "@src/lib/keyseq"
 
 /** Simple container for the gobble state. */
 class GobbleState {
@@ -19,7 +19,8 @@ export function init(numKeysOrTerminator: string, endCommand: string) {
     const number = Number(numKeysOrTerminator)
     if (!isNaN(number)) {
         modeState.numKeysOrTerminator = number
-    } else modeState.numKeysOrTerminator = numKeysOrTerminator
+    } else
+        modeState.numKeysOrTerminator = canonicaliseMapstr(numKeysOrTerminator)
     modeState.endCommand = endCommand
 }
 
@@ -43,7 +44,7 @@ export function parser(keys: MinimalKey[]) {
         reset()
     } else if (
         typeof modeState.numKeysOrTerminator === "string" &&
-        modeState.numKeysOrTerminator === key
+        modeState.numKeysOrTerminator === keys[0].toMapstr()
     ) {
         return exec()
     } else if (keys[0].isPrintable()) {

--- a/src/parsers/nmode.ts
+++ b/src/parsers/nmode.ts
@@ -25,7 +25,7 @@ export function init(endCommand: string, mode = "normal", numCommands = 1) {
 }
 
 /** Receive keypress. If applicable, execute a command. */
-export function parser(keys: keyseq.KeyEventLike[]) {
+export function parser(keys: keyseq.MinimalKey[]) {
     keys = keyseq.stripOnlyModifiers(keys)
     if (keys.length === 0) return { keys: [], isMatch: false }
     const conf = mode2maps.get(modeState.mode) || modeState.mode + "maps"


### PR DESCRIPTION
A patch which grew out of [this](https://github.com/tridactyl/tridactyl/pull/4439) PR. The main goal is to allow gobbling with terminator and also register things like `<C-x>` in gobble mode. It's easier to implement on concrete type than on KeyEventLike, so i changed types to MinimalKey. Because of that tests will likely fail, so i expect to spend some time fixing before it's really mergeble. But it'll simplify merging of original PR.