### PR TITLE
Rewrite TabHistory with webNavigation API

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -119,6 +119,9 @@ browser.webNavigation.onDOMContentLoaded.addListener(() => {
     })
 })
 
+import { registTabHistory } from "@src/background/tab_history"
+registTabHistory()
+
 // Prevent Tridactyl from being updated while it is running in the hope of fixing #290
 browser.runtime.onUpdateAvailable.addListener(_ => undefined)
 

--- a/src/background/tab_history.ts
+++ b/src/background/tab_history.ts
@@ -25,7 +25,7 @@ export async function addTabHistory(nav) {
     if (isHistoryNavigation(nav)) {
         let itemId = pages.list.length - 1
         while (true) {
-            const item = pages[itemId]
+            const item = pages["list"][itemId]
             if (nav.url == item.href) {
                 pages.current = itemId
                 item.time = nav.timeStamp

--- a/src/background/tab_history.ts
+++ b/src/background/tab_history.ts
@@ -1,0 +1,67 @@
+export async function saveTabHistory(tabid, history) {
+    await browser.sessions.setTabValue(tabid, "history", history)
+}
+
+/** Returns a promise for an object with history list, index of a current, previous and next pages */
+export async function curTabHistory(tabid) {
+    return await browser.sessions.getTabValue(tabid, "history")
+}
+
+function isHistoryNavigation(nav) {
+    return nav.transitionQualifiers.includes("forward_back")
+}
+
+// Adds a new entry to history tree or updates it if already visited
+export async function addTabHistory(nav) {
+    const frameTop = 0
+    if (nav.frameId != frameTop) return
+    const tabid = nav.tabId
+    let pages = await curTabHistory(tabid)
+    if (!pages)
+        pages = {
+            current: null,
+            list: [],
+        }
+    if (isHistoryNavigation(nav)) {
+        let itemId = pages.list.length - 1
+        while (true) {
+            const item = pages[itemId]
+            if (nav.url == item.href) {
+                pages.current = itemId
+                item.time = nav.timeStamp
+                return await saveTabHistory(tabid, pages)
+            }
+            itemId = item.parent
+            if (itemId == null) break
+        }
+    }
+    const tab = await browser.tabs.get(tabid)
+    pages["list"].push({
+        parent: pages["current"],
+        href: nav.url,
+        title: tab.title,
+        id: pages["list"].length,
+        time: nav.timeStamp,
+    })
+    pages["current"] = pages["list"].length - 1
+    return await saveTabHistory(tabid, pages)
+}
+
+export const tabLock = new Map()
+export function registTabHistory() {
+    const tabHistoryHandler = async nav => {
+        const tab = nav.tabId
+        while (tabLock.has(tab)) {
+            const lock = tabLock.get(tab)
+            await lock
+        }
+        const lock = addTabHistory(nav)
+        tabLock.set(tab, lock)
+        await lock
+        if (tabLock.get(tab) == lock) tabLock.delete(tab)
+    }
+    const navigation = browser.webNavigation
+    navigation.onCommitted.addListener(tabHistoryHandler)
+    navigation.onHistoryStateUpdated.addListener(tabHistoryHandler)
+    navigation.onReferenceFragmentUpdated.addListener(tabHistoryHandler)
+}


### PR DESCRIPTION
Current TabHistory features do not work in some website (#4329), and overwrite native history api will cause some problems.
This PR is to rewrite it with WebExtension's webNavigation API.

Except webNavigation api, there are some other changes:

## History tree
The webNavigation api can tell if a location change is cause by backward/forward, so visit a url which is already in history without forward/backward will add a new record instead of set `current` to the old record index.
We will set the `current` only if user uses the forward/backward or a new record is added into the history.
The history records which are reachable with forward/backward, are also reachable from the last history record and the record its `parent` property pointing to, and so on; one of them must be the current record.

However, we can not tell how many steps does user move in history, so we will just pick the last record with same url as the current url.

## Back and forward
Second update should be a better completion for `back` and `forward` command.
I want these comands use `history.go()` instead of visiting the url.

Currently, autocompletion will complete to `back http://some.url` instead of `back 1`
if we select an url from autocompletion.

## Draft state
There are some bugs, and some edge cases are not tuned well.
Anyone who wants to work on this is wellcome.
I will not work on this very often because I am a little burn out.
