### PR TITLE
Option to exclude selectors from hint result

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -432,8 +432,7 @@ export function hintElements(elements: Element[], option = {}) {
                 const first = await Promise.race([onSelect.promise, endPromise])
                 if (first && typeof first === "object" && key in first) {
                     yield first[key]
-                }
-                else return await endPromise
+                } else return await endPromise
             }
         }
         const result = wrap()

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -396,12 +396,19 @@ interface Hintables {
     hintclasses?: string[]
 }
 
-/** A convient javascript interface to hint on specified html elements.
-  The return value is a promise resolve to the selected element,
-  or a AsyncIterator resolve to the selected elements in rapid mode.
+/**
+  A convenient javascript interface to hint on specified html elements.
+  The return value is a promise resolving to the selected element,
+  or an AsyncIterator resolving to the selected elements in rapid mode.
+
+  Example usage:
+
+  `tri.hinting_content.hintElements(...).then(element => {tri.dom.simulateClick(element))`
+
+  `for (await e of tri.hinting_content.hintElements(..., {rapid: true}){tri.dom.simulateClick(e)})`
 
   @param elements a iterator yield html elements
-  @param option a option object. The `option.rapid` specify whether hint in rapid mode. Default value is false. The `option.callback` is execute when a hint is selected if specified.
+  @param option a option object. The `option.rapid` specify whether hint in rapid mode. Default value is false. The `option.callback` is executed when a hint is selected if specified. The default callback is a no-op.
 
   @returns promise resolve to the selected element, or a async iterator in rapid mode.
  */

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -396,6 +396,13 @@ interface Hintables {
     hintclasses?: string[]
 }
 
+export function hintElements(elements: Elements[], rapid = false) {
+    const hintable = toHintablesArray(elements)
+    return new Promise((resolve, reject) => {
+        hintPage(hintable, x => x, resolve, reject, rapid)
+    })
+}
+
 /** For each hintable element, add a hint
  * @hidden
  * */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5019,6 +5019,7 @@ const KILL_STACK: Element[] = []
         - -c [selector] hint links that match the css selector
           - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
           - this works with most other hint modes, with the caveat that if other hint mode takes arguments your selector must contain no spaces, i.e. `hint -c[yourOtherFlag] [selector] [your other flag's arguments, which may contain spaces]`
+        - -x [selector] exclude the matched elements from hinting
         - -f [text] hint links and inputs that display the given text
           - `bind <c-e> hint -f Edit`
           - Backslashes can escape spaces: `bind <c-s> hint -f Save\ as`


### PR DESCRIPTION
Sometimes, a real exclude operation after `-c` selector is really useful. It is labour to construct a selector to match anything you want to click except some element.

Another thing I am interested in is to add a convient interface in hint mode for javascript to filter elements.