### PR TITLE
Use tab title if bookmarking current page

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5554,7 +5554,7 @@ export async function perfhistogram(...filters: string[]) {
  */
 //#background
 export async function bmark(url?: string, ...titlearr: string[]) {
-    const auto_url = url == undefined
+    const auto_url = url == undefined || url == (await activeTab()).url
     url =
         url === undefined
             ? (await activeTab()).url


### PR DESCRIPTION
There's currently no way to add a bookmark to a folder AND keep the title.

Most of the feature was implemented via PR https://github.com/tridactyl/tridactyl/pull/862/

Should fix issue https://github.com/tridactyl/tridactyl/issues/1856