### PR TITLE
Make E2E tests more helpful for PRs

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -1,11 +1,12 @@
-name: e2e
+name: e2e_pr
+
+# This is just a duplicate of e2e.yml with fewer tries & no fail-fast so people can get quicker + better feedback on PRs
+# I'm sure there's a neater way of doing it with ifs but this was quicker
 
 on:
-  push:
+  pull_request:
     branches:
-      - 'master'
-  schedule:
-    - cron: "45 7 * * *"
+      - '**'
 
 jobs:
   test:
@@ -79,11 +80,12 @@ jobs:
       env:
         HEADLESS: 1
       with: 
-        max_attempts: 40
+        max_attempts: 1
         timeout_minutes: 10
         retry_wait_seconds: 10
+        # clearing setupFilesAfterEnv removes the fail-fast script
         command: |
-          yarn run clean && yarn run build --old-native && yarn make-zip && yarn jest
+          yarn run clean && yarn run build --old-native && yarn make-zip && yarn jest --setupFilesAfterEnv=""
     # - name: Test (Chrome, Linux)
     #   if: matrix.browser == 'chrome' && matrix.os == 'ubuntu'
     #   run: xvfb-run --auto-servernum npm run jest -- ${{ matrix.browser }} || xvfb-run --auto-servernum npm run jest -- ${{ matrix.browser }}

--- a/e2e_tests/e2e.test.ts
+++ b/e2e_tests/e2e.test.ts
@@ -33,6 +33,7 @@ describe("webdriver", () => {
         const options = (new Options())
                 .setPreference("xpinstall.signatures.required", false)
                 .addExtensions(extensionPath)
+        // options.setBinary("/usr/bin/firefox-developer-edition") // set this if running locally :)
         if (env["HEADLESS"]) {
             options.headless();
         }


### PR DESCRIPTION
PRs are more likely to have genuine failures than commits to master, so retry them less often and try all the tests even if some fail