### PR TITLE
[Tutor] Fix keybinding on hint mode

### DIFF
--- a/src/static/clippy/1-tutor.md
+++ b/src/static/clippy/1-tutor.md
@@ -18,7 +18,7 @@ The idea behind Tridactyl is to allow you to navigate the web more efficiently w
 -   Hint mode
     -   This mode highlights elements on the web page and performs actions on those elements.
     -   This is most often used for following links, but it has many other submodes.
-    -   You can enter this mode with `f` and exit it with `Escape` or `Enter`.
+    -   You can enter this mode with `f` and exit it with `Escape` or `Ctrl-[`.
     -   Hint characters are displayed as uppercase letters, but you should type the lowercase letter.
 -   Visual mode (experimental)
     -   This mode allows you to select text on the web page and copy it to the clipboard or search for it using `s` and `S`.


### PR DESCRIPTION
`<Enter>` key is not mapped to exit hint mode, at least not anymore. It's now mapped to `hint.selectFocusedHint`.
https://github.com/tridactyl/tridactyl/blob/44efcf38af9290a6bc8061c59119b0ce24b52756/src/lib/config.ts#L411