### PR TITLE
 Do not hide ex cmdline after fillcmdline_tmp if it is focus

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3843,7 +3843,7 @@ export async function fillcmdline_tmp(ms: number, ...strarr: string[]) {
     Messaging.messageOwnTab("commandline_frame", "fillcmdline", [strarr.join(" "), false, false])
     return new Promise<void>(resolve =>
         setTimeout(async () => {
-            if ((await Messaging.messageOwnTab("commandline_frame", "getContent", [])) === str) {
+            if (document.activeElement?.id !== "cmdline_iframe") {
                 CommandLineContent.hide_and_blur()
                 resolve(Messaging.messageOwnTab("commandline_frame", "clear", [true]))
             }


### PR DESCRIPTION
Sometimes the cmdline is closed before I start editing it.
Determine with focus state should be more appropriate than determine with the modification,
or are there any reason to do so?

I know check a hard-code id is a bad idea, but I can not figure out other ways to check
whether the cmdline is focused; please help.
Should I add a new exported function in `src/commandline_frame.ts` to check focus or blur?
Any better solutions?