### PR TITLE
Docs: add notice about `shellescape` usage in `exclaim` help.

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -692,7 +692,7 @@ export async function nativeopen(...args: string[]) {
  *
  * Requires the native messenger, obviously.
  *
- * If you're using `exclaim` with arguments coming from a pipe, consider using `shellescape` to properly escape arguments and to prevent unsafe commands.
+ * If you're using `exclaim` with arguments coming from a pipe, consider using [[shellescape]] to properly escape arguments and to prevent unsafe commands.
  *
  * If you want to use a different shell, just prepend your command with whatever the invocation is and keep in mind that most shells require quotes around the command to be executed, e.g. `:exclaim xonsh -c "1+2"`.
  *

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -692,6 +692,8 @@ export async function nativeopen(...args: string[]) {
  *
  * Requires the native messenger, obviously.
  *
+ * If you're using `exclaim` with arguments coming from a pipe, consider using `shellescape` to properly escape arguments and to prevent unsafe commands.
+ *
  * If you want to use a different shell, just prepend your command with whatever the invocation is and keep in mind that most shells require quotes around the command to be executed, e.g. `:exclaim xonsh -c "1+2"`.
  *
  * Aliased to `!` but the exclamation mark **must be followed with a space**.


### PR DESCRIPTION
Found it out at #2944 while troubleshooting a similar problem.
I think it's worth it to add to docs, as it might help others avoid some trouble.