### PR TITLE
Comments: Change broken "findnext -1" to "findnext 1 -?" in config

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -293,7 +293,7 @@ export class default_config {
         // "/": "fillcmdline find",
         // "?": "fillcmdline find -?",
         // n: "findnext 1",
-        // N: "findnext -1",
+        // N: "findnext 1 -?",
         // ",<Space>": "nohlsearch",
         M: "gobble 1 quickmark",
         B: "fillcmdline taball",


### PR DESCRIPTION
"findnext -1" doesn't seem to work anymore. Although commented out, the binding should reflect the working "findnext 1 -?" for possible future use and for people looking to use it in their rc.