### PR TITLE
Correct highlight position while scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "arg": "^5.0.2",
     "cleanslate": "^0.10.1",
+    "compute-scroll-into-view": "^1.0.17",
     "csp-serdes": "github:cmcaine/csp-serdes",
     "css": "^3.0.0",
     "editor-adapter": "^0.0.3",

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -66,8 +66,11 @@ class FindHighlight extends HTMLSpanElement {
         return new this(rectData, range)
     }
 
-    isVisible(): boolean {
-        return DOM.isVisible(this.range)
+    getBoundingClientRect() {
+        return this.range.getBoundingClientRect()
+    }
+    getClientRects() {
+        return this.range.getClientRects()
     }
     unfocus() {
         for (const node of this.children) {
@@ -75,7 +78,7 @@ class FindHighlight extends HTMLSpanElement {
         }
     }
     focus() {
-        if (!this.isVisible()) {
+        if (!DOM.isVisible(this)) {
             this.children[0].scrollIntoView({
                 block: "center",
                 inline: "center",
@@ -181,7 +184,7 @@ export async function jumpToMatch(searchQuery, option) {
 
     // Just reuse the code to find the first match in the view
     selected = 0
-    if (lastHighlights[selected].isVisible()) {
+    if (DOM.isVisible(lastHighlights[selected])) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         ;(lastHighlights[selected] as any).focus()
     } else {
@@ -225,7 +228,7 @@ export async function jumpToNextMatch(n: number, searchFromView = false) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     ;(lastHighlights[selected] as any).unfocus()
 
-    if (!searchFromView || lastHighlights[selected].isVisible()) {
+    if (!searchFromView || DOM.isVisible(lastHighlights[selected])) {
         // if the last selected is inside the view,
         // count nth match from the last selected.
         selected =

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -233,6 +233,10 @@ export function removeHighlighting() {
 
 export function focusHighlight(index) {
     lastHighlights[index].focus()
+    repositionHighlight()
+}
+
+export function repositionHighlight() {
     for (const node of lastHighlights) {
         node.updateRectsPosition()
     }
@@ -268,6 +272,7 @@ export async function jumpToNextMatch(n: number, searchFromView = false) {
         selected =
             (selected + n + lastHighlights.length) % lastHighlights.length
     } else {
+        repositionHighlight()
         const length = lastHighlights.length
         const reverse = lastHighlights[length - 1].top < lastHighlights[0].top
         const negative = n < 0

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,7 +26,7 @@ function getFindHost() {
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
 
-    constructor(private rects, public range: Range) {
+    constructor(public range: Range) {
         super()
         {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
@@ -38,32 +38,45 @@ class FindHighlight extends HTMLSpanElement {
         this.style.position = "absolute"
         this.style.top = "0px"
         this.style.left = "0px"
-        for (const rect of rects) {
-            if (rect.top < this.top) {
-                this.top = rect.top
+        this.updateRectsPosition()
+        ;(this as any).unfocus()
+    }
+
+    updateRectsPosition() {
+        const rects = this.getClientRects()
+        this.top = Infinity
+        const windowTop = window.pageYOffset
+        const windowLeft = window.pageXOffset
+        for (let i=0; i<rects.length; i++) {
+            const rect = rects[i]
+            if ((rect.top + windowTop) < this.top) {
+                this.top = rect.top + windowTop
             }
-            const highlight = document.createElement("span")
+            let highlight
+            if (i in this.children) highlight = this.children[i]
+            else {
+                highlight = document.createElement("span")
+                this.appendChild(highlight)
+            }
             highlight.className = "TridactylFindHighlight"
             highlight.style.position = "absolute"
-            highlight.style.top = `${rect.top}px`
-            highlight.style.left = `${rect.left}px`
+            highlight.style.top = `${rect.top + windowTop}px`
+            highlight.style.left = `${rect.left + windowLeft}px`
             highlight.style.width = `${rect.right - rect.left}px`
             highlight.style.height = `${rect.bottom - rect.top}px`
             highlight.style.zIndex = "2147483645"
             highlight.style.pointerEvents = "none"
-            this.appendChild(highlight)
         }
-        ;(this as any).unfocus()
     }
 
-    static fromFindApi(rectData, rangeData, allTextNode: Text[]) {
+    static fromFindApi(found, allTextNode: Text[]) {
         const range = document.createRange()
         range.setStart(
-            allTextNode[rangeData.startTextNodePos],
-            rangeData.startOffset,
+            allTextNode[found.startTextNodePos],
+            found.startOffset,
         )
-        range.setEnd(allTextNode[rangeData.endTextNodePos], rangeData.endOffset)
-        return new this(rectData, range)
+        range.setEnd(allTextNode[found.endTextNodePos], found.endOffset)
+        return new this(range)
     }
 
     getBoundingClientRect() {
@@ -79,7 +92,9 @@ class FindHighlight extends HTMLSpanElement {
     }
     focus() {
         if (!DOM.isVisible(this)) {
-            this.children[0].scrollIntoView({
+            // this may not always work, eg if the parent contains a lot of
+            // child element and text node.
+            this.range.startContainer.parentElement.scrollIntoView({
                 block: "center",
                 inline: "center",
             })
@@ -99,7 +114,7 @@ class FindHighlight extends HTMLSpanElement {
         }
 
         for (const node of this.children) {
-            ;(node as HTMLElement).style.background = `rgba(255,127,255,0.5)`
+            node.style.background = `rgba(255,127,255,0.5)`
         }
     }
 }
@@ -159,11 +174,7 @@ export async function jumpToMatch(searchQuery, option) {
             continue
         }
         const range = results.rangeData[i]
-        const high = FindHighlight.fromFindApi(
-            data.rectsAndTexts.rectList,
-            range,
-            nodes,
-        )
+        const high = FindHighlight.fromFindApi(range, nodes)
         host.appendChild(high)
         lastHighlights.push(high)
     }
@@ -177,16 +188,14 @@ export async function jumpToMatch(searchQuery, option) {
     if ("jumpTo" in option) {
         selected =
             (option["jumpTo"] + lastHighlights.length) % lastHighlights.length
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        ;(lastHighlights[selected] as any).focus()
+        focusHighlight(selected)
         return
     }
 
     // Just reuse the code to find the first match in the view
     selected = 0
     if (DOM.isVisible(lastHighlights[selected])) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        ;(lastHighlights[selected] as any).focus()
+        focusHighlight(selected)
     } else {
         const searchFromView = true
         await jumpToNextMatch(1, searchFromView)
@@ -201,6 +210,13 @@ function drawHighlights(highlights) {
 export function removeHighlighting() {
     const host = getFindHost()
     while (host.firstChild) host.removeChild(host.firstChild)
+}
+
+export function focusHighlight(index) {
+    lastHighlights[index].focus()
+    for (const node of lastHighlights) {
+        node.updateRectsPosition()
+    }
 }
 
 export async function jumpToNextMatch(n: number, searchFromView = false) {
@@ -250,8 +266,7 @@ export async function jumpToNextMatch(n: number, searchFromView = false) {
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    ;(lastHighlights[selected] as any).focus()
+    focusHighlight(selected)
 }
 
 export function currentMatchRange(): Range {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,6 +1906,11 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
+compute-scroll-into-view@^1.0.17:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
+  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
I introduce `compute-scroll-into-view` package to scroll a selection range into view.
The highlight's position is relative to the whole document (`position: absolute`),
so it would not match if the hightlight text inside a scrollable area,
or the matched text change its position relative to the absolute position.

I overwrite the `getBoundingClientRect` and `getClientRects` so the `DOM.isVisible` will work on it.
For `compute-scroll-into-view`, I create a fake node with same position
so it can compute the right scroll method.

A new method `queryInRange` is used to find the focusable element containing the matched text.
It will find all parent nodes of the node which is the beginning of the selection;
Then all the following nodes in *document order* until reach the node which is the end of the selection.