### PR TITLE
Fix negative number not parsed in findnext command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "stream": "stream-browserify"
   },
   "dependencies": {
-    "arg": "^5.0.2",
     "cleanslate": "^0.10.1",
     "csp-serdes": "github:cmcaine/csp-serdes",
     "css": "^3.0.0",
@@ -23,6 +22,7 @@
     "ramda": "^0.28.0",
     "semver-compare": "^1.0.0",
     "stream-browserify": "^3.0.0",
+    "tridactyl-arg": "git+https://github.com/GHolk/arg.git#v5.1.0",
     "tsdef": "^0.0.14",
     "typedoc": "^0.19.2",
     "typedoc-default-themes": "^0.12.10"

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1460,7 +1460,11 @@ export function find(...args: string[]) {
             "--reverse": Boolean,
             "-?": "--reverse",
         },
-        { argv: args, permissive: true },
+        {
+            argv: args,
+            permissive: true,
+            splitUnknownArguments: false,
+        },
     )
     const option = {}
     option["reverse"] = Boolean(argOpt["--reverse"])
@@ -1489,7 +1493,10 @@ export function findnext(...args: string[]) {
             "--reverse": Boolean,
             "-?": "--reverse",
         },
-        { argv: args },
+        {
+            argv: args,
+            allowNegativePositional: true,
+        },
     )
     if (option._.length > 0) n = Number(option._[0])
     if (option["--reverse"]) n = -n

--- a/src/lib/arg_util.ts
+++ b/src/lib/arg_util.ts
@@ -1,35 +1,14 @@
-import arg from "arg"
+import arg from "tridactyl-arg"
 
 /**
  * The arguments parsing library name
  */
-export const name = "arg"
+export const name = "tridactyl-arg"
 
 /**
  * The imported library itself
  */
 export const lib = arg
-
-/**
- * Function to easily allow some single hyphen prefix option
- * to be treated as long option too.
- *
- * E.g. correctSingleHyphen("-private https://some.url".split(" "), "-private")
- * will retrun "--private http://some.url".split(" "), which can be parsed
- * as a normal long option.
- */
-export function correctSingleHyphen(
-    argv: string[],
-    ...singleNames: string[]
-): string[] {
-    return argv.map(arg => {
-        const scan = /^-[\w-]{2,}/.exec(arg)
-        if (!scan) return arg
-        const index = singleNames.indexOf(scan[0])
-        if (index === -1) return arg
-        else return "-" + arg
-    })
-}
 
 /**
  * Small function to test if the double hyphen is the last option.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,11 +1306,6 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-arg@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
-  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
-
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -7105,6 +7100,10 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+"tridactyl-arg@git+https://github.com/GHolk/arg.git#v5.1.0":
+  version "5.1.0"
+  resolved "git+https://github.com/GHolk/arg.git#28f3f1d9e2828b7c58d61ba5cce2ffa242374c63"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I fork the vercel/arg to support the edge cases in tridactyl, and fix #4482.
This fork contains more options to fulfill tridactyl's argument parsing requirement.
The fork package is installed from my github repository directly.