### PR TITLE
Fix #4516 unsupported extraSpecInfo passed to webRequest event

### DIFF
--- a/src/background/webrequests.ts
+++ b/src/background/webrequests.ts
@@ -1,14 +1,15 @@
-export const requestEvents = [
-    "AuthRequired",
-    "BeforeRedirect",
-    "BeforeRequest",
-    "BeforeSendHeaders",
-    "Completed",
-    "ErrorOccured",
-    "HeadersReceived",
-    "ResponseStarted",
-    "SendHeaders",
-]
+export const requestEventExpraInfoSpecMap = {
+    AuthRequired: ["blocking", "responseHeaders"],
+    BeforeRedirect: ["responseHeaders"],
+    BeforeRequest: ["blocking", "requestBody"],
+    BeforeSendHeaders: ["blocking", "requestHeaders"],
+    Completed: ["responseHeaders"],
+    ErrorOccured: [],
+    HeadersReceived: ["blocking", "responseHeaders"],
+    ResponseStarted: ["responseHeaders"],
+    SendHeaders: ["requestHeaders"],
+}
+export const requestEvents = Object.keys(requestEventExpraInfoSpecMap)
 
 // I'm being lazy - strictly the functions map strings to void | blocking responses
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -27,7 +28,7 @@ export const registerWebRequestAutocmd = (
     return browser.webRequest["on" + requestEvent].addListener(
         listener,
         { urls: [pattern] },
-        ["blocking", "requestHeaders", "requestBody", "responseHeaders"],
+        requestEventExpraInfoSpecMap[requestEvent],
     )
 }
 


### PR DESCRIPTION
`browser.webRequest.on*.addListener` will throw errors if unsupported extraSpecInfo passed.
We pass the extraSpecInfo for onBeforeRequest for all events, and add more info in previous release.
Then, some user reported onBeforeRequest event stop working.

We will pass all supported extraSpecInfo for different event in this commit.