### PR TITLE
e2e workflow: pin & update version of actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Setup cache
       uses: actions/cache@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
+      shell: bash
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Setup cache

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,6 +85,7 @@ jobs:
         max_attempts: 40
         timeout_minutes: 10
         retry_wait_seconds: 10
+        shell: bash
         command: |
           yarn run clean && yarn run build --old-native && yarn make-zip && yarn jest
     # - name: Test (Chrome, Linux)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v2
-      id: yarn-cache
+    - name: Setup cache
+      uses: actions/cache@v3
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -77,7 +77,7 @@ jobs:
       run: firefox --version
 
     - name: Build and test (Firefox)
-      uses: nick-invision/retry@v1
+      uses: nick-fields/retry@v2
       if: matrix.browser != 'chrome'
       env:
         HEADLESS: 1


### PR DESCRIPTION
It's a bit safer to pin actions to a major version, so the workflow won't be affected by breaking changes.

Also updating `cache` and `retry` action to get rid of the following warning:
<img width="992" alt="Screenshot 2023-01-15 at 19 32 45" src="https://user-images.githubusercontent.com/5363448/212560149-b738bac0-9264-4faa-99d7-fc2a9ed6a829.png">

I've made sure that there are no breaking changes in those releases. (`nick-invasion` has been transferred to `nick-fields`, but is still the same, see https://github.com/nick-fields/retry#ownership)