### PR TITLE
Search completions

### DIFF
--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -13,7 +13,7 @@ class HistoryCompletionOption
             page.title = new URL(page.url).host
         }
 
-        this.value = page.search ? page.title : options + page.url
+        this.value = page.search ? options + page.title : options + page.url
 
         let preplain = page.bmark ? "B" : ""
         preplain += page.search ? "S" : ""
@@ -75,18 +75,16 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
             if (query.startsWith("-c")) {
                 const args = query.split(" ")
                 options = args.slice(0, 2).join(" ")
-                query = args.slice(2).join(" ")
             }
             if (query.startsWith("-b")) {
                 const args = query.split(" ")
                 options = args.slice(0, 1).join(" ")
-                query = args.slice(1).join(" ")
             }
-        } else if (prefix === "winopen " && query.startsWith("-private")) {
+        } else if (prefix === "winopen " && query.startsWith("-private ")) {
             options = "-private"
-            query = query.substring(options.length)
         }
         options += options ? " " : ""
+        query = query.substring(options.length)
 
         this.updateSectionHeader("History and bookmarks")
         const tokens = query.split(" ")

--- a/src/completions/TabGroup.ts
+++ b/src/completions/TabGroup.ts
@@ -58,7 +58,7 @@ class TabGroupCompletionOption
         const urlMarkup = urls.map(
             u => `<a class="url" target="_blank" href="${u}">${u}</a>`,
         )
-        this.html.lastElementChild.innerHTML = urlMarkup.join(",")
+        this.html.lastElementChild.innerHTML = urlMarkup.join(", ")
     }
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1138,6 +1138,11 @@ export class default_config {
     bmarkweight = 100
 
     /**
+     * When displaying searchurls in history completions, how many page views to pretend they have.
+     */
+    searchurlweight = 150
+
+    /**
      * Default selector for :goto command.
      */
     gotoselector = "h1, h2, h3, h4, h5, h6"

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -139,7 +139,6 @@ input:focus {
 
 .url {
     text-decoration: var(--tridactyl-url-text-decoration);
-    padding-left: 7px;
 }
 
 .option:not(.focused) .url {


### PR DESCRIPTION
Fix #1010 - this solution is a bit hacky, but maybe it will do for now until completions/command line parsing are overhauled?

In history completion, while typing first word, matching `searchurl` entries are shown (there's no clever matching or sorting at the moment - it's just the first (up to) 5 matching entries in no particular order):
![image](https://user-images.githubusercontent.com/10012625/214000049-3ec18e67-4148-402c-8638-9026e344532a.png)

If the first word matches a `searchurl`, the completion title is updated to reflect this, and the query is updated to show search results from history matching that URL:
![image](https://user-images.githubusercontent.com/10012625/214000730-fb2d643b-d2aa-4f90-a946-72a584235542.png)
