### PR TITLE
Sort history completions by frecency

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -9,7 +9,7 @@ class BmarkCompletionOption
 
     constructor(
         public value: string,
-        bmark: browser.bookmarks.BookmarkTreeNode,
+        bmark: providers.HistoryItem,
     ) {
         super()
         if (!bmark.title) {

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -107,7 +107,10 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
             this.updateSectionHeader("Search " + match.title)
             // Actual query sent to browser needs to be space separated
             // list of tokens, otherwise partial matches won't be found
-            query = match.url.split("%s").join(" ") + " " + query
+            const urlParts = match.url
+                .split("%s")
+                .map(part => decodeURIComponent(part))
+            query = urlParts.join(" ") + " " + query
         } else {
             this.updateSectionHeader(
                 HistoryCompletionSource.DEFAULT_SECTION_HEADER,

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -13,18 +13,20 @@ class HistoryCompletionOption
             page.title = new URL(page.url).host
         }
 
-        this.value = page.search ? options + page.title : options + page.url
+        const search = page.type === providers.HistoryItemType.SearchUrl
+        const bmark = page.type === providers.HistoryItemType.Bmark
+        this.value = search ? options + page.title : options + page.url
 
-        let preplain = page.bmark ? "B" : ""
-        preplain += page.search ? "S" : ""
+        let preplain = bmark ? "B" : ""
+        preplain += search ? "S" : ""
         let pre = preplain
         if (config.get("completions", "Tab", "statusstylepretty") === "true") {
-            pre = page.bmark ? "\u2B50" : ""
-            pre += page.search ? "\u{1F50D}" : ""
+            pre = bmark ? "\u2B50" : ""
+            pre += search ? "\u{1F50D}" : ""
         }
 
         // Push properties we want to fuzmatch on
-        this.fuseKeys.push(preplain, page.title, page.url) // weight by page.visitCount
+        this.fuseKeys.push(preplain, page.title, page.url) // weight by page.score?
 
         // Create HTMLElement
         this.html = html`<tr class="HistoryCompletionOption option">
@@ -32,7 +34,7 @@ class HistoryCompletionOption
             <td class="prefixplain" hidden>${preplain}</td>
             <td class="title">${page.title}</td>
             <td class="content">
-                ${page.search ? "Search " : ""}
+                ${search ? "Search " : ""}
                 <a class="url" target="_blank" href=${page.url}>${page.url}</a>
             </td>
         </tr>`

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -99,18 +99,15 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
         query = query.substring(options.length)
 
         const tokens = query.split(" ")
-        const match = (await providers.getSearchUrls(tokens[0])).find(
-            su => su.title === tokens[0],
-        )
-        if ((tokens.length > 1 || query.endsWith(" ")) && match !== undefined) {
-            query = tokens.slice(1).join(" ")
-            this.updateSectionHeader("Search " + match.title)
-            // Actual query sent to browser needs to be space separated
-            // list of tokens, otherwise partial matches won't be found
-            const urlParts = match.url
-                .split("%s")
-                .map(part => decodeURIComponent(part))
-            query = urlParts.join(" ") + " " + query
+        const searchUrl = providers.searchUrlMap().get(tokens[0])
+        if (
+            (tokens.length > 1 || query.endsWith(" ")) &&
+            searchUrl !== undefined
+        ) {
+            this.updateSectionHeader("Search " + tokens[0])
+            const queryParts = tokens.slice(1)
+            queryParts.push(providers.searchUrlToQuery(searchUrl))
+            query = queryParts.join(" ")
         } else {
             this.updateSectionHeader(
                 HistoryCompletionSource.DEFAULT_SECTION_HEADER,

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -42,6 +42,7 @@ class HistoryCompletionOption
 export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
     static readonly DEFAULT_SECTION_HEADER = "History and bookmarks"
     public options: Completions.CompletionOptionFuse[]
+    headerPostfix: string[] = []
 
     constructor(private _parent) {
         super(
@@ -91,34 +92,30 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
             options = "-private"
             headerPostfix.push("private window")
         }
+        this.headerPostfix = headerPostfix
         options += options ? " " : ""
         query = query.substring(options.length)
 
-        this.updateSectionHeader(
-            HistoryCompletionSource.DEFAULT_SECTION_HEADER,
-            headerPostfix,
-        )
         const tokens = query.split(" ")
-        if (tokens.length > 1 || query.endsWith(" ")) {
-            const match = (await providers.getSearchUrls(tokens[0])).find(
-                su => su.title === tokens[0],
+        const match = (await providers.getSearchUrls(tokens[0])).find(
+            su => su.title === tokens[0],
+        )
+        if ((tokens.length > 1 || query.endsWith(" ")) && match !== undefined) {
+            query = tokens.slice(1).join(" ")
+            this.updateSectionHeader("Search " + match.title)
+            // Actual query sent to browser needs to be space separated
+            // list of tokens, otherwise partial matches won't be found
+            query = match.url.split("%s").join(" ") + " " + query
+        } else {
+            this.updateSectionHeader(
+                HistoryCompletionSource.DEFAULT_SECTION_HEADER,
             )
-            if (match !== undefined) {
-                query = tokens.slice(1).join(" ")
-                this.updateSectionHeader("Search " + match.title, headerPostfix)
-                // Actual query sent to browser needs to be space separated
-                // list of tokens, otherwise partial matches won't be found
-                query = match.url.split("%s").join(" ") + " " + query
-            }
         }
 
         // Options are pre-trimmed to the right length.
         // Typescript throws an error here - further investigation is probably warranted
         this.options = (
-            (await this.scoreOptions(
-                query,
-                config.get("historyresults"),
-            )) as any
+            await this.scoreOptions(query, config.get("historyresults"))
         ).map(page => new HistoryCompletionOption(page, options))
 
         // Deselect any selected, but remember what they were.
@@ -147,16 +144,22 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
     updateChain() {}
 
     private async scoreOptions(query: string, n: number) {
-        if (!query || config.get("historyresults") === 0) {
-            return (await providers.getTopSites()).slice(0, n)
+        let results
+        if (
+            (!query.trim() && config.get("usetopsites") === "true") ||
+            n === 0
+        ) {
+            this.updateSectionHeader("Top sites")
+            results = (await providers.getTopSites(5)).slice(0, n)
         } else {
-            return (await providers.getCombinedHistoryBmarks(query)).slice(0, n)
+            results = await providers.getCombinedHistoryBmarks(query, 5)
         }
+        return results.slice(0, n)
     }
 
-    private updateSectionHeader(newTitle: string, postfix: string[]) {
-        if (postfix.length > 0) {
-            newTitle += " (" + postfix.join(", ") + ")"
+    private updateSectionHeader(newTitle: string) {
+        if (this.headerPostfix.length > 0) {
+            newTitle += " (" + this.headerPostfix.join(", ") + ")"
         }
         const headerNode = this.node.firstElementChild
         const oldTitle = headerNode.innerHTML

--- a/src/completions/TabGroup.ts
+++ b/src/completions/TabGroup.ts
@@ -77,7 +77,11 @@ export class TabGroupCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        if (this.options) {
+            return this.updateChain()
+        } else {
+            return this.updateOptions(exstr)
+        }
     }
 
     private async updateOptions(exstr = "") {

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -66,24 +66,18 @@ export async function getSearchUrls(query: string): Promise<HistoryItem[]> {
             prop.startsWith(query)
         ) {
             const url = suconf[prop]
-            const url_parts = url.split("%s").join(" ")
-            const history = await browserBg.history.search({
-                text: url_parts,
-                startTime: 0,
-            })
             searchUrls.push(
                 new HistoryItem(
                     prop,
                     url,
                     HistoryItemType.SearchUrl,
-                    searchScore + history.length,
+                    searchScore,
                 ),
             )
         }
     }
     // Sort urls with equal score alphabetically
     searchUrls.sort((a, b) => (a.title > b.title ? 1 : -1))
-    searchUrls.sort((a, b) => b.score - a.score)
     return searchUrls
 }
 

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -118,11 +118,8 @@ export function searchUrlMap(query = ""): Map<string, string> {
     // Return searchUrls as a Map of name-URL pairs
     const suconf = config.get("searchurls")
     const searchUrls = new Map<string, string>()
-    for (const prop in suconf) {
-        if (
-            Object.prototype.hasOwnProperty.call(suconf, prop) &&
-            prop.startsWith(query)
-        ) {
+    for (const prop of Object.keys(suconf)) {
+        if (prop.startsWith(query)) {
             searchUrls.set(prop, suconf[prop])
         }
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1138,7 +1138,7 @@ export class default_config {
     usetopsites: "true" | "false" = "true"
 
     /**
-     * Half life in days of visits used for exponential decay in frecency calculation. Set to 0 to disable frecency and sort by visited count only.
+     * Half life in days of visits used for exponential decay in frecency calculation. Set to 0 to disable frecency and sort by visited count only. Smaller numbers mean that recency of visits matter more for ranking; bigger numbers mean that the absolute number of visits is more important.
      */
     frecencyhalflife = 30
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1143,6 +1143,11 @@ export class default_config {
     frecencyhalflife = 30
 
     /**
+     * Minimum interval between searchurl score updates, in seconds. (To improve performance, searchurl scores used to rank history completions are cached.)
+     */
+    searchurlscoreupdateinterval = 600
+
+    /**
      * When displaying bookmarks in history completions, how many page views to pretend they have.
      */
     bmarkweight = 100
@@ -1150,7 +1155,7 @@ export class default_config {
     /**
      * When displaying searchurls in history completions, how many page views to pretend they have.
      */
-    searchurlweight = 150
+    searchurlweight = 100
 
     /**
      * Default selector for :goto command.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1133,7 +1133,7 @@ export class default_config {
     historyresults = 50
 
     /**
-     * Half life in days of visits used for exponential decay in frecency calculation.
+     * Half life in days of visits used for exponential decay in frecency calculation. Set to 0 to disable frecency and sort by visited count only.
      */
     frecencyhalflife = 30
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1133,6 +1133,11 @@ export class default_config {
     historyresults = 50
 
     /**
+     * Whether to use the Firefox "top sites" API in history completions. This setting is ignored if [[historyresults]] is set to 0.
+     */
+    usetopsites: "true" | "false" = "true"
+
+    /**
      * Half life in days of visits used for exponential decay in frecency calculation. Set to 0 to disable frecency and sort by visited count only.
      */
     frecencyhalflife = 30

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1133,6 +1133,11 @@ export class default_config {
     historyresults = 50
 
     /**
+     * Half life in days of visits used for exponential decay in frecency calculation.
+     */
+    frecencyhalflife = 30
+
+    /**
      * When displaying bookmarks in history completions, how many page views to pretend they have.
      */
     bmarkweight = 100

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -317,7 +317,7 @@ export async function queryAndURLwrangler(
 
     // Maybe it's a domain without protocol
     try {
-        const url = new URL("http://" + address)
+        const url = new URL("https://" + address)
         // Ignore unlikely domains
         if (url.hostname.indexOf(".") > 0 || url.port || url.password) {
             return url.href

--- a/src/state.ts
+++ b/src/state.ts
@@ -53,10 +53,21 @@ class State {
         scrollY: number
         tabId: number
     } = undefined
+    searchUrlScores: {
+        scores: Map<string, number>
+        lastUpdated: number
+    } = {
+        scores: new Map(),
+        lastUpdated: -1,
+    }
 }
 
 // Store these keys in the local browser storage to persist between restarts
-const PERSISTENT_KEYS: Array<keyof State> = ["cmdHistory", "globalMarks"]
+const PERSISTENT_KEYS: Array<keyof State> = [
+    "cmdHistory",
+    "globalMarks",
+    "searchUrlScores",
+]
 
 // Don't change these from const or you risk breaking the Proxy below.
 const defaults = Object.freeze(new State())


### PR DESCRIPTION
- Add exponential decay frecency algorithm (https://wiki.mozilla.org/User:Jesse/NewFrecency). Each new visit gets a count of 2, and loses half that score every halflife (default is 30 days).
- Add `frecencyhalflife` option - setting to 0 sorts by visitCount (current behaviour)
- SearchURLs are scored by the number of matching visits in history + `searchurlweight`
- Add searchurls to top sites (fixes #4572)
- Add `usetopsites` option (default true for current behaviour) - if false, completions are taken from history results even fore empty string
- Add `providers.HistoryItem` class to store history/bookmark etc. information in a more TypeScript-friendly way. This also means we can calculate frecency scores once and then store them as a property of the entry - previously, scores were being recalculated multiple times for each entry while sorting.
- Change default protocol (e.g. for `open github.com`) from `http://` to `https://` (Firefox redirects to `https://` now anyway, so this was just cluttering up the history with duplicate entries)