### PR TITLE
Fix completions for tabmove (#4602)

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -227,7 +227,7 @@ export abstract class CompletionSourceFuse extends CompletionSource {
     select(option: CompletionOption) {
         if (this.lastExstr !== undefined && option !== undefined) {
             const [prefix] = this.splitOnPrefix(this.lastExstr)
-            this.completion = prefix + option.value
+            this.completion = [prefix, option.value].join(" ")
             this.args = option.value
             option.state = "focused"
             this.lastFocused = option
@@ -240,7 +240,7 @@ export abstract class CompletionSourceFuse extends CompletionSource {
         for (const prefix of this.prefixes) {
             if (exstr.startsWith(prefix)) {
                 const query = exstr.replace(prefix, "")
-                return [prefix, query]
+                return [prefix.trim(), query]
             }
         }
         return [undefined, undefined]
@@ -297,7 +297,9 @@ export abstract class CompletionSourceFuse extends CompletionSource {
 
     /** Call to replace the current display */
     updateDisplay() {
-        const newContainer = this.optionContainer.cloneNode(false) as HTMLElement
+        const newContainer = this.optionContainer.cloneNode(
+            false,
+        ) as HTMLElement
 
         for (const option of this.options) {
             if (option.state !== "hidden")

--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -76,7 +76,7 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
             .slice(0, 10)
             .map(page => new BmarkCompletionOption(option + page.url, page))
 
-        this.lastExstr = prefix + query
+        this.lastExstr = [prefix, query].join(" ")
         return this.updateChain()
     }
 

--- a/src/completions/FileSystem.ts
+++ b/src/completions/FileSystem.ts
@@ -1,7 +1,8 @@
 import * as Completions from "@src/completions"
 import * as Native from "@src/lib/native"
 
-class FileSystemCompletionOption extends Completions.CompletionOptionHTML
+class FileSystemCompletionOption
+    extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
     public fuseKeys = []
 
@@ -52,7 +53,7 @@ export class FileSystemCompletionSource extends Completions.CompletionSourceFuse
         }
 
         // Update lastExstr because we modified the path and scoreOptions uses that in order to assign scores
-        this.lastExstr = cmd + path
+        this.lastExstr = [cmd, path].join(" ")
 
         let req
         try {

--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -74,7 +74,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
 
         // Ignoring command-specific arguments
         // It's terrible but it's ok because it's just a stopgap until an actual commandline-parsing API is implemented
-        if (prefix === "tabopen ") {
+        if (prefix === "tabopen") {
             if (query.startsWith("-c ")) {
                 const args = query.split(" ")
                 if (args.length > 2) {
@@ -87,7 +87,7 @@ export class HistoryCompletionSource extends Completions.CompletionSourceFuse {
                 options = args.slice(0, 1).join(" ")
                 headerPostfix.push("background tab")
             }
-        } else if (prefix === "winopen " && query.startsWith("-private ")) {
+        } else if (prefix === "winopen" && query.startsWith("-private ")) {
             options = "-private"
             headerPostfix.push("private window")
         }

--- a/src/completions/Settings.ts
+++ b/src/completions/Settings.ts
@@ -53,10 +53,12 @@ export class SettingsCompletionSource extends Completions.CompletionSourceFuse {
         // Ignoring command-specific arguments
         // It's terrible but it's ok because it's just a stopgap until an actual commandline-parsing API is implemented
         // copy pasting code is fun and good
-        if ((prefix === "seturl " || prefix === "unseturl ") || (
-            prefix === "viewconfig " &&
-            (query.startsWith("--user") || query.startsWith("--default"))
-        )) {
+        if (
+            prefix === "seturl" ||
+            prefix === "unseturl" ||
+            (prefix === "viewconfig" &&
+                (query.startsWith("--user") || query.startsWith("--default")))
+        ) {
             const args = query.split(" ")
             options = args.slice(0, 1).join(" ")
             query = args.slice(1).join(" ")

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -116,7 +116,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
     async filter(exstr) {
         this.lastExstr = exstr
         const prefix = this.splitOnPrefix(exstr).shift()
-        if (prefix === "tabrename ") this.shouldSetStateFromScore = false
+        if (prefix === "tabrename") this.shouldSetStateFromScore = false
         return this.onInput(exstr)
     }
 
@@ -180,13 +180,15 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         return res
     }
 
-    private async fillOptions() {
+    private async fillOptions(prefix: string) {
         // Get alternative tab, defined as last accessed tab in any group in
         // this window.
 
         const altTab = await prevActiveTab()
-
-        const tabs = await getSortedTabs()
+        // Since tabmove always uses absolute tab indices, we need
+        // to override possible MRU setting to match tabmove behavior
+        const forceSort = prefix === "tabmove" ? "default" : undefined
+        const tabs = await getSortedTabs(forceSort)
         const options = []
 
         const container_all = await browserBg.contextualIdentities.query({})
@@ -237,7 +239,7 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
         if (prefix === "tabmove")
             this.shouldSetStateFromScore = !/^[+-][0-9]+$/.exec(query)
 
-        await this.fillOptions()
+        await this.fillOptions(prefix)
         this.completion = undefined
 
         /* console.log('updateOptions', this.optionContainer) */

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -5,10 +5,14 @@ import * as UrlUtil from "@src/lib/url_util"
 import { sleep } from "@src/lib/patience"
 import * as R from "ramda"
 
-export async function getSortedTabs(): Promise<browser.tabs.Tab[]> {
+export async function getSortedTabs(
+    forceSort?: "mru" | "default",
+): Promise<browser.tabs.Tab[]> {
+    const sortAlg = forceSort ?? config.get("tabsort")
     const comp =
-        config.get("tabsort") === "mru"
-            ? (a, b) => +a.active || -b.active || b.lastAccessed - a.lastAccessed
+        sortAlg === "mru"
+            ? (a, b) =>
+                  +a.active || -b.active || b.lastAccessed - a.lastAccessed
             : (a, b) => a.index - b.index
     const hiddenVal = config.get("tabshowhidden") === "true" ? undefined : false
     return browserBg.tabs


### PR DESCRIPTION
Force default tabsort for tabmove.
Return trimmed prefix from splitOnPrefix for consistency.

I'm not sure how how safe is trimming splitOnPrefix::query so i didn't do it.

I was also astonished by updateOptions() and filter() having the same copypasted preamble in a ton of places. I'll try to clean it up this or next week, for now i just fixed what i broke, or at least i hope so:)
