### PR TITLE
Kill some copypated code in completions

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -143,7 +143,9 @@ export function enableCompletions() {
             .map(constructorr => {
                 try {
                     return new constructorr(commandline_state.completionsDiv)
-                } catch (e) {}
+                } catch (e) {
+                    console.error(e)
+                }
             })
             .filter(c => c)
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -93,7 +93,6 @@ export abstract class CompletionSource {
 
     /** Update [[node]] to display completions relevant to exstr */
     public abstract filter(exstr: string): Promise<void>
-
     abstract next(inc?: number): Promise<boolean>
 }
 
@@ -334,6 +333,32 @@ export abstract class CompletionSourceFuse extends CompletionSource {
     // Lots of methods don't need this but some do
     // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars-experimental
     async onInput(exstr: string) {}
+    // some children don't need to implement it so we provide a stub
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental, @typescript-eslint/require-await
+    protected async updateOptions(command, rest) {
+        throw new Error(
+            "updateOptions not implemented for CompletionSourceFuse!",
+        )
+    }
+    protected async handleCommand(exstr: string) {
+        this.lastExstr = exstr
+        const [cmd, args] = this.splitOnPrefix(exstr)
+
+        // Hide self and stop if prefixes don't match
+        if (cmd) {
+            // Show self if prefix and currently hidden
+            if (this.state === "hidden") {
+                this.state = "normal"
+            }
+        } else {
+            this.state = "hidden"
+            return
+        }
+
+        // the return keyword is super important here,
+        // without it a lot of weird stuff happens. Damn async!
+        return this.updateOptions(cmd, args)
+    }
 }
 
 // }}}

--- a/src/completions/Autocmd.ts
+++ b/src/completions/Autocmd.ts
@@ -30,7 +30,6 @@ export class AutocmdCompletionSource extends Completions.CompletionSourceFuse {
             "Autocommands",
         )
 
-        this.updateOptions()
         this.shouldSetStateFromScore =
             config.get("completions", "Autocmd", "autoselect") === "true"
         this._parent.appendChild(this.node)
@@ -40,26 +39,14 @@ export class AutocmdCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
-    onInput(...whatever) {
-        return this.updateOptions(...whatever)
+    onInput(input: string) {
+        return this.handleCommand(input)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix, rest] = this.splitOnPrefix(exstr)
+    /* override*/ async updateOptions(command, rest) {
         const args = rest ? rest.split(/\s+/) : []
 
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-        const is_autocmddelete = /del/.test(prefix)
+        const is_autocmddelete = /del/.test(command)
         const filter_defined_autocmds = is_autocmddelete
         const defined_autocmds = config.get("autocmds")
         // Config may contain empty dictionnaries if user deleted all patterns

--- a/src/completions/Composite.ts
+++ b/src/completions/Composite.ts
@@ -13,8 +13,6 @@ export class CompositeCompletionSource extends Completions.CompletionSourceFuse 
 
     constructor(private _parent) {
         super([PREFIX], "CompositeCompletionSource", "ex commands")
-
-        this.updateOptions()
         this._parent.appendChild(this.node)
     }
 
@@ -24,7 +22,7 @@ export class CompositeCompletionSource extends Completions.CompletionSourceFuse 
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
@@ -49,22 +47,9 @@ export class CompositeCompletionSource extends Completions.CompletionSourceFuse 
         super.setStateFromScore(scoredOpts, false)
     }
 
-    private async updateOptions(exstr = "") {
-        const end_exstr = this.getendexstr(exstr)
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
+        const end_exstr = this.getendexstr(rest)
         const excmds = Metadata.everything.getFile("src/excmds.ts")
         if (!excmds) return
         const fns = excmds.getFunctions()

--- a/src/completions/Excmd.ts
+++ b/src/completions/Excmd.ts
@@ -3,7 +3,8 @@ import * as Metadata from "@src/.metadata.generated"
 import * as config from "@src/lib/config"
 import * as aliases from "@src/lib/aliases"
 
-export class ExcmdCompletionOption extends Completions.CompletionOptionHTML
+export class ExcmdCompletionOption
+    extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
     public fuseKeys = []
     constructor(public value: string, public documentation: string = "") {
@@ -24,7 +25,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
     constructor(private _parent) {
         super([], "ExcmdCompletionSource", "ex commands")
 
-        this.updateOptions()
+        this.handleCommand()
         this._parent.appendChild(this.node)
     }
 
@@ -34,7 +35,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
@@ -55,7 +56,7 @@ export class ExcmdCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, false)
     }
 
-    private async updateOptions(exstr = "") {
+    /* override*/ async handleCommand(exstr = "") {
         this.lastExstr = exstr
 
         const excmds = Metadata.everything.getFile("src/excmds.ts")

--- a/src/completions/FileSystem.ts
+++ b/src/completions/FileSystem.ts
@@ -29,21 +29,10 @@ export class FileSystemCompletionSource extends Completions.CompletionSourceFuse
     }
 
     public async onInput(exstr) {
-        return this.filter(exstr)
+        return this.handleCommand(exstr)
     }
 
-    public async filter(exstr: string) {
-        if (!exstr || exstr.indexOf(" ") === -1) {
-            this.state = "hidden"
-            return
-        }
-
-        let [cmd, path] = this.splitOnPrefix(exstr)
-        if (cmd === undefined) {
-            this.state = "hidden"
-            return
-        }
-
+    /* override*/ async updateOptions(cmd, path) {
         if (!path) path = "."
 
         if (!["/", "$", "~", "."].find(s => path.startsWith(s))) {

--- a/src/completions/Find.ts
+++ b/src/completions/Find.ts
@@ -41,7 +41,7 @@ export class FindCompletionSource extends Completions.CompletionSourceFuse {
         // Since we might have awaited for this.prevCompletion, we don't have a guarantee we're the last completion the user asked for anymore
         if (id === this.completionCount - 1) {
             // If we are the last completion
-            this.prevCompletion = this.updateOptions(exstr)
+            this.prevCompletion = this.handleCommand(exstr)
             await this.prevCompletion
         }
     }
@@ -51,7 +51,7 @@ export class FindCompletionSource extends Completions.CompletionSourceFuse {
         this.options.forEach(o => (o.state = "normal"))
     }
 
-    private async updateOptions(exstr?: string) {
+    /* override*/ async handleCommand(exstr?: string) {
         if (!exstr) return
 
         // Flag parsing because -? should reverse completions

--- a/src/completions/Goto.ts
+++ b/src/completions/Goto.ts
@@ -24,7 +24,6 @@ export class GotoCompletionSource extends Completions.CompletionSourceFuse {
     constructor(private _parent) {
         super(["goto"], "GotoCompletionSource", "Headings")
 
-        this.updateOptions()
         this.shouldSetStateFromScore =
             config.get("completions", "Goto", "autoselect") === "true"
         this._parent.appendChild(this.node)
@@ -34,25 +33,12 @@ export class GotoCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
-    onInput(...whatever) {
-        return this.updateOptions(...whatever)
+    onInput(input: string) {
+        return this.handleCommand(input)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
         if (this.options.length < 1) {
             this.options = (
                 await Messaging.messageOwnTab(

--- a/src/completions/Rss.ts
+++ b/src/completions/Rss.ts
@@ -30,7 +30,6 @@ export class RssCompletionSource extends Completions.CompletionSourceFuse {
     constructor(private _parent) {
         super(["rssexec"], "RssCompletionSource", "Feeds")
 
-        this.updateOptions()
         this.shouldSetStateFromScore =
             config.get("completions", "Rss", "autoselect") === "true"
         this._parent.appendChild(this.node)
@@ -40,25 +39,12 @@ export class RssCompletionSource extends Completions.CompletionSourceFuse {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
-    onInput(...whatever) {
-        return this.updateOptions(...whatever)
+    onInput(whatever: string) {
+        return this.handleCommand(whatever)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
         if (this.options.length < 1) {
             this.options = (
                 await Messaging.messageOwnTab(

--- a/src/completions/Sessions.ts
+++ b/src/completions/Sessions.ts
@@ -72,35 +72,21 @@ export class SessionsCompletionSource extends Completions.CompletionSourceFuse {
     constructor(private _parent) {
         super(["undo"], "SessionCompletionSource", "sessions")
 
-        this.updateOptions()
         this.shouldSetStateFromScore =
             config.get("completions", "Sessions", "autoselect") === "true"
         this._parent.appendChild(this.node)
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
     setStateFromScore(scoredOpts: Completions.ScoredOption[]) {
         super.setStateFromScore(scoredOpts, this.shouldSetStateFromScore)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
         const sessions = await browserBg.sessions.getRecentlyClosed()
         this.options = sessions.map(s => new SessionCompletionOption(s))
     }

--- a/src/completions/TabGroup.ts
+++ b/src/completions/TabGroup.ts
@@ -72,29 +72,15 @@ export class TabGroupCompletionSource extends Completions.CompletionSourceFuse {
             "Tab Groups",
         )
 
-        this.updateOptions()
         this._parent.appendChild(this.node)
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
         const currentGroup = await windowTgroup()
         const alternateGroup = await windowLastTgroup()
         const groups = [...(await tgroups())]

--- a/src/completions/Theme.ts
+++ b/src/completions/Theme.ts
@@ -22,8 +22,6 @@ export class ThemeCompletionSource extends Completions.CompletionSourceFuse {
 
     constructor(private _parent) {
         super(["set theme", "colourscheme"], "ThemeCompletionSource", "Themes")
-
-        this.updateOptions()
         this._parent.appendChild(this.node)
     }
 
@@ -33,36 +31,23 @@ export class ThemeCompletionSource extends Completions.CompletionSourceFuse {
     }
 
     async onInput(exstr) {
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
     setStateFromScore(scoredOpts: Completions.ScoredOption[]) {
         super.setStateFromScore(scoredOpts, false)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
         const themes = staticThemes.concat(
             Object.keys(await config.get("customthemes")),
         )
-        const [prefix, query] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
 
         // Add all excmds that start with exstr and that tridactyl has metadata about to completions
         this.options = this.scoreOptions(
             themes
-                .filter(name => name.startsWith(query))
+                .filter(name => name.startsWith(rest))
                 .map(name => new ThemeCompletionOption(name)),
         )
 

--- a/src/completions/Window.ts
+++ b/src/completions/Window.ts
@@ -38,15 +38,13 @@ export class WindowCompletionSource extends Completions.CompletionSourceFuse {
             "WindowCompletionSource",
             "Windows",
         )
-
-        this.updateOptions()
         this._parent.appendChild(this.node)
     }
 
     async onInput(exstr) {
         // Schedule an update, if you like. Not very useful for windows, but
         // will be for other things.
-        return this.updateOptions(exstr)
+        return this.handleCommand(exstr)
     }
 
     async filter(exstr) {
@@ -54,31 +52,16 @@ export class WindowCompletionSource extends Completions.CompletionSourceFuse {
         return this.onInput(exstr)
     }
 
-    private async updateOptions(exstr = "") {
-        this.lastExstr = exstr
-        const [prefix] = this.splitOnPrefix(exstr)
-
-        // Hide self and stop if prefixes don't match
-        if (prefix) {
-            // Show self if prefix and currently hidden
-            if (this.state === "hidden") {
-                this.state = "normal"
-            }
-        } else {
-            this.state = "hidden"
-            return
-        }
-
-        const excludeCurrentWindow = ["tabpush"].includes(prefix.trim())
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
+    /* override*/ async updateOptions(command, rest) {
+        const excludeCurrentWindow = ["tabpush"].includes(command.trim())
         this.options = (await browserBg.windows.getAll({ populate: true }))
-        .filter( win => !(excludeCurrentWindow && win.focused))
-        .map(
-            win => {
+            .filter(win => !(excludeCurrentWindow && win.focused))
+            .map(win => {
                 const o = new WindowCompletionOption(win)
                 o.state = "normal"
                 return o
-            },
-        )
+            })
         return this.updateDisplay()
     }
 }

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -6,9 +6,8 @@ import { sleep } from "@src/lib/patience"
 import * as R from "ramda"
 
 export async function getSortedTabs(
-    forceSort?: "mru" | "default",
+    sortAlg: "mru" | "default" = config.get("tabsort"),
 ): Promise<browser.tabs.Tab[]> {
-    const sortAlg = forceSort ?? config.get("tabsort")
     const comp =
         sortAlg === "mru"
             ? (a, b) =>


### PR DESCRIPTION
Aside from moving copypasted code to the base class, i also had to move updateOptions in TabHistory to please eslint, as well as suppress unused var warnings for overrides. Also, i discovered that our typescript is rather old(3.9.10 while the latest is 4.9.5) and doesn't know the override keyword. What stops us from bumping it to 4-something? It may also help with the case we bumped into [here](https://github.com/tridactyl/tridactyl/pull/4532#issuecomment-1399129366) and probably some other things. 

As for the patch itself, it's probably not the best solution but it removes some 100+ lines of repetition so i hope we can call it improvement, even though it's still OOP which i heard is not very liked here:)