### PR TITLE
Updated WindowCompletionOption in commandline.css stylesheet

### DIFF
--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -293,7 +293,7 @@ a.url:hover {
 }
 
 #completions .WindowCompletionOption td.id {
-    width: 4ch !important;
+    width: 6ch !important;
     text-align: right;
-    padding: 0px 3pt;
+    padding: 0px 8pt;
 }


### PR DESCRIPTION
Resolves #4613

The Window Id column in the completion list for commands such as 'winmerge' and 'tabpush' has a maximum width of 4 characters, which is not wide enough (5-digit id's are often encountered).

Made the following updates:

1. Increased the 'id'  column from 4ch to 6ch
2. Increased the left-right padding to increase spacing between the Window Id and the Window Title columns for improved readability

On branch fix-window_completion_option-in-commandline_css Changes to be committed:
    modified:   src/static/css/commandline.css