### PR TITLE
Add (secret) sidebar toggle command for browser binds

### DIFF
--- a/src/background/commands.ts
+++ b/src/background/commands.ts
@@ -6,12 +6,14 @@ import * as controller from "@src/lib/controller"
 function makelistener(commands: Array<browser.commands.Command>) {
     return (command_name: string) => {
         const command = commands.filter(c => c.name == command_name)[0]
-        const exstring = config.get(
-            "browsermaps",
-            keyseq.mozMapToMinimalKey(command.shortcut).toMapstr(),
-        )
-        if (exstring in useractions) return useractions[exstring]()
-        return controller.acceptExCmd(exstring)
+        const [excmd, ...exargs] = config
+            .get(
+                "browsermaps",
+                keyseq.mozMapToMinimalKey(command.shortcut).toMapstr(),
+            )
+            .split(" ")
+        if (excmd in useractions) return useractions[excmd](...exargs)
+        return controller.acceptExCmd([excmd, ...exargs].join(" "))
     }
 }
 

--- a/src/background/user_actions.ts
+++ b/src/background/user_actions.ts
@@ -36,6 +36,14 @@ function escapehatch() {
     })()
 }
 
+/**
+ * Toggle the sidebar. Bind with e.g. `:bind --mode=browser <C-.> sidebartoggle`
+ */
+function sidebartoggle() {
+    return browser.sidebarAction.toggle()
+}
+
 export const useractions: Record<string, () => void> = {
     escapehatch,
+    sidebartoggle,
 }

--- a/src/background/user_actions.ts
+++ b/src/background/user_actions.ts
@@ -43,7 +43,12 @@ function sidebartoggle() {
     return browser.sidebarAction.toggle()
 }
 
-export const useractions: Record<string, () => void> = {
+function jsua(...args: string[]) {
+    return eval(args.join(" "))
+}
+
+export const useractions: Record<string, (...args: string[]) => void> = {
     escapehatch,
     sidebartoggle,
+    jsua,
 }


### PR DESCRIPTION
Ref #4640 

I don't want to advertise this because it is kind of janky; the sidebar page breaks totally if you try to open the Tridactyl command line on it.

Usage:

`:bind --mode=browser <C-.> sidebartoggle`

Then you can add a `sidebaropen` ex command with `command sidebaropen jsb -d¶ tri.webext.queryAndURLwrangler(JS_ARGS.slice(1)).then(url => browser.sidebarAction.setPanel({panel: url}))¶`