### PR TITLE
WIP: initial experiment with per-mode settings

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -230,6 +230,7 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
     native,
     styling,
     contentLocation: window.location,
+    contentMode: contentState.mode,
     perf,
     R,
     updates,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1806,13 +1806,18 @@ export function get(target_typed?: keyof default_config, ...target: string[]) {
         target = [target_typed as string].concat(target)
     }
     // Window.tri might not be defined when called from the untrusted page context
-    let loc = window.location
-    if ((window as any).tri && (window as any).tri.contentLocation)
-        loc = (window as any).tri.contentLocation
+    // let loc = window.location
+    // if ((window as any).tri && (window as any).tri.contentLocation)
+    //     loc = (window as any).tri.contentLocation
+    let mode = undefined
+    if ((window as any).tri && (window as any).tri.contentMode)
+        mode = (window as any).tri.contentMode
     // If there's a site-specifing setting, it overrides global settings
-    const site = getURL(loc.href, target)
+    // const site = getURL(loc.href, target) ?? (mode ? getURL(mode, target) : undefined)
+    const site = (mode ? getURL(mode, target) : undefined)
     const user = getDeepProperty(USERCONFIG, target)
     const defult = getDeepProperty(DEFAULTS, target)
+    console.log(site)
 
     // Merge results if there's a default value and it's not an Array or primitive.
     if (typeof defult === "object") {


### PR DESCRIPTION
Currently totally replaces per-URL settings for ease of experimentation.

NB: mostly broken. Steps to reproduce:

1. `:seturl normal keyboardlayoutforce true`
2. change your layout somewhere, observe that keyboardlayoutforce works in normal mode as expected
3. select text to enter visual mode
4. note that keyboardlayoutforce true is still applied, which is unexpected


Once working and merged, closes #3635 