### PR TITLE
WIP: add a compat wrapper for browser

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -97,6 +97,7 @@ const itertools = await import("@src/lib/itertools")
 const messaging = await import("@src/lib/messaging")
 const State = await import("@src/state")
 const webext = await import("@src/lib/webext")
+const {default: compatProxy} = await import("@src/lib/compat_proxy")
 const perf = await import("@src/perf")
 const keyseq = await import("@src/lib/keyseq")
 const native = await import("@src/lib/native")
@@ -206,6 +207,7 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
 })
 ;(window as any).tri = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
+    compatProxy,
     commandline_content,
     convert,
     config,

--- a/src/lib/compat_proxy.ts
+++ b/src/lib/compat_proxy.ts
@@ -1,0 +1,28 @@
+import { message } from "@src/lib/messaging"
+
+const compatProxy = new Proxy(Object.create(null), {
+    get(target, api) {
+        return new Proxy(
+            {},
+            {
+                get(_, func) {
+                    return (...args) => {
+                        if (typeof browser[api][func] === 'function') {
+                            return browser[api][func](...args)
+                        }
+                        // return Promise.reject(new Error(`browser.${String(api)}.${String(func)} isn't a function`))
+                        // ideally what we want is to use TypeScript's knowledge of browser to create an "empty"
+                        // return value of the same type as the function we're trying to call, but I don't know how to do that
+                        // if function missing, return an empty object of the same type using TypeScript
+
+                        // return ReturnType<typeof browser[api][func]> // can't use api because it's _any_, let's fix one thing at a time
+
+                        // return new ReturnType<typeof browser.runtime.getURL>() // Error: ReturnType refers to a type
+                    }
+                },
+            },
+        )
+    },
+}) as typeof browser
+
+export default compatProxy


### PR DESCRIPTION
Related: #3479

I was thinking, rather than trying to make sure we are gating every API that has patchy coverage between Chrome and Firefox, why not just gate every single API?


Since TypeScript knows what `typeof browser` is, it must be possible to create an "empty" version of each return value, but I can't work out how.

So

```js
let api = "runtime"
let func = "getURL"

if notFunction(browser[api][func)) {
  return new ReturnType<browser[api][func]>() // which in this case would be ""; for browser.tabs.query it would be []
}
```


If we could do this, we shouldn't need a compat layer, but we should be prepared for every API to return whatever their equivalent of no data would be.

Should also let us run Tridactyl on web pages e.g. in #4732 easily, although we would have to deal with weird stuff that we would never get in an extension context like "there are no tabs"