### PR TITLE
Add config change listener for mode indicator

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -408,6 +408,14 @@ config.getAsync("modeindicator").then(mode => {
             statusIndicator.classList.remove("TridactylInvisble")
         }
     })
+
+    config.addChangeListener("modeindicator", (_, newVal) => {
+        if (newVal !== "true") {
+            statusIndicator.classList.add("TridactylInvisible")
+        } else {
+            statusIndicator.classList.remove("TridactylInvisble")
+        }
+    })
 })
 
 function protectSlash(e) {


### PR DESCRIPTION
Would fix #4738

Currently has weird behaviour - mode indicator flashes on scrolling after changing setting. Steps to reproduce:

1. `:set modeindicator false`
2. `jjj`
3. observe mode indicator flash