### PR TITLE
Provide hook for basic CSS override for new Reader mode

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -6074,6 +6074,17 @@ export async function readerurl() {
  * Use `:reader --old` to use Firefox's built-in reader mode, which Tridactyl can't run on.
  *
  * __NB:__ the reader page is a privileged environment which has access to all Tridactyl functions, notably the native messenger if you have it installed. We are parsing untrusted web-content to run in this environment. Mozilla's readability library will strip out most of these, then we use a sanitation library, `js-xss`, to strip out any remaining unsafe tags, but if there was a serious bug in this library, and a targeted attack against Tridactyl, an attacker could get remote code execution. If you're worried about this, use `:reader --old` instead or only use `:reader` on pages you trust.
+ *
+ * You may use [userContent.css](http://kb.mozillazine.org/index.php?title=UserContent.css&printable=yes) to enhance or override default styling of the new reader view. The `body` of the page has id `tridactyl-reader` and the article content follows in a `main` tag. Therefore to alter default styling, you can do something like this in your `userContent.css`:
+ *
+ * ```css
+ * #tridactyl-reader > main {
+ *   width: 80vw !important;
+ *   text-align: left;
+ * }
+ * ```
+ *
+ * Follow [issue #4657](https://github.com/tridactyl/tridactyl/issues/4657) if you would like to find out when we have made a more user-friendly solution.
  */
 //#content
 export async function reader(...args: string[]) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1290,6 +1290,11 @@ export class default_config {
      * https://fusejs.io/api/options.html#threshold
      */
     completionfuzziness = 0.3
+
+    /**
+     * Whether to show article url in the document.title of Reader View.
+     */
+    readerurlintitle: "true" | "false" = "false"
 }
 
 const platform_defaults = {

--- a/src/static/css/reader.css
+++ b/src/static/css/reader.css
@@ -91,20 +91,14 @@ html {
     scroll-behavior: smooth;
 }
 
-/* Make the body a nice central block */
 body {
     color: var(--text);
     background-color: var(--bg);
     font-size: 1.15rem;
     line-height: 1.5;
-    display: grid;
-    grid-template-columns: 1fr min(45rem, 90%) 1fr;
     margin: 0;
     text-align: justify;
     hyphens: auto;
-}
-body > * {
-    grid-column: 2;
 }
 
 /* Make the header bg full width, but the content inline with body */
@@ -112,8 +106,7 @@ body > header {
     background-color: var(--accent-bg);
     border-bottom: 1px solid var(--border);
     text-align: center;
-    padding: 0 0.5rem 2rem 0.5rem;
-    grid-column: 1 / -1;
+    padding: 2rem 0.5rem 2rem 0.5rem;
 }
 
 body > header h1 {
@@ -126,9 +119,10 @@ body > header p {
     margin: 1rem auto;
 }
 
-/* Add a little padding to ensure spacing is correct between content and header > nav */
-main {
+body > main {
     padding-top: 1.5rem;
+    width: min(45rem, 90%);
+    margin: auto;
 }
 
 body > footer {

--- a/src/static/reader.html
+++ b/src/static/reader.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="css/hint.css">
         <link rel="stylesheet" href="css/viewsource.css">
     </head>
-    <body>
+    <body id="tridactyl-reader">
     </body>
     <script src="../content.js"></script>
     <script src="../reader.js"></script>


### PR DESCRIPTION
Top level body now has the fixed DOM id: `tridactyl-reader`. Article content is wrapped in a `main` tag.

This doesn't really solve #4657 with proper theming support, but does bare minimum to make it configurable at least. Now one can do something like this in their `userContent.css`:

```css
#tridactyl-reader > main {
  width: 80vw !important;
  text-align: left;
  font-family: Ubuntu;
}
```

Wrapped the article content in a `main` tag for determinism, I checked a few articles and none of them had that. Also got rid of `grid` for the body without messing up current layout, I think it's not intuitive to have to set width for the child content in the parent (body) unless you know grid is being used.

I admit to wanting to add article link to the title for purely personal reason. My [time tracking software](https://arbtt.nomeata.de/) relies on pattern matching on window name derived from title, the [firefox plugin](https://github.com/erichgoldman/add-url-to-window-title) that I use to add that automatically seems unable to do so for the new reader mode because of the url mangling that happens. Let me know if that's undesirable.