### PR TITLE
Fixing hard coded modeindicator border style

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -301,7 +301,7 @@ config.getAsync("modeindicator").then(mode => {
                     "style",
                     `border: ${
                         (container as any).colorCode
-                    } solid 1.5px !important`,
+                    } var(--tridactyl-indicator-border-style, solid) var(--tridactyl-indicator-border-width, 1.5px) !important`,
                 )
             })
             .catch(error => {


### PR DESCRIPTION
While I was playing with themes, I noticed there was a permanent style to modeindicator:
`border: #37adff solid 1.5px !important`

No matter what I specified, it was still overwritten.

I found out it was hard coded in `src/contents.ts` so I provided this as a temporary solution:

The user can specify `--tridactyl-indicator-border-style` and `--tridactyl-indicator-border-width` within their theme's css file, otherwise it will fallback to original values `solid` and `1.5px`