### PR TITLE
Add custom eslint rule detecting uses of potentially unsupported APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         "sonarjs"
     ],
     "rules": {
+        "unsupported-apis": "warn",
         "sonarjs/cognitive-complexity": "off", //"error",
         "sonarjs/no-duplicate-string": "off",
         "sonarjs/no-unused-collection": "off", //"error", // There seems to be a bug with this rule - exported collections are assumed unused

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -6,4 +6,4 @@ else
 	echo "Warning: shellcheck is not installed, skipping shell scripts"
 fi
 yarn run lint
-"$(yarn bin)/eslint" --ext .ts .
+"$(yarn bin)/eslint" --rulesdir custom-eslint-rules --ext .ts .

--- a/custom-eslint-rules/unsupported-apis.js
+++ b/custom-eslint-rules/unsupported-apis.js
@@ -1,0 +1,42 @@
+const bcd = require('@mdn/browser-compat-data');
+const api = bcd.webextensions.api;
+const supported_browsers = ["firefox", "chrome"];
+
+function detectBrowserUsage(context, node) {
+    let localApi = api;
+    let fullName = [];
+    while (node.type == "MemberExpression" && node.property.name in localApi) {
+        const n = node;
+        node = node.parent;
+        fullName.push(n.property.name);
+        localApi = localApi[n.property.name];
+        if (!localApi.__compat) {
+            continue;
+        }
+        let support = localApi.__compat.support;
+        for (let browser of supported_browsers) {
+            if (support[browser].version_added === false) {
+                context.report({
+                    node: n,
+                    messageId: "unsupportedApis",
+                    data: {
+                        name: browser,
+                    }
+                });
+            }
+        }
+    }
+}
+
+module.exports = {
+    meta: {
+        messages: {
+            unsupportedApis: "Unsupported on '{{ name }}'"
+        }
+    },
+    create(context) {
+        return {
+            'MemberExpression[object.name="browser"]': (n) => detectBrowserUsage(context, n),
+        };
+    }
+};


### PR DESCRIPTION
This eslint rule enables detecting uses of webextension APIs that are not supported on Chrome (and vice versa).