### PR TITLE
Fix typo's in readme.md [Hacktoberfest]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ If you want to use advanced features such as edit-in-Vim, you'll also need to in
 **Snap and Flatpak:** Native Messaging support here is fairly recent and may require:
 
 * Upgrading to a beta version of Firefox (`>= 106.0b6`)
-* Enabling webextension permisisons: `flatpak permission-set webextensions tridactyl snap.firefox yes`
+* Enabling webextension permissions: `flatpak permission-set webextensions tridactyl snap.firefox yes`
 * Rebooting your system (and likely nothing short of it)
 
 See [this call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) and [this PR](https://github.com/tridactyl/tridactyl/pull/4406) for more details and troubleshooting tips.
@@ -80,7 +80,7 @@ The changelog for the stable versions can be found [here](https://github.com/tri
 
 ## First look
 
-Type `:help` or press `<F1>` for online help once you're in, or `:tutor` for a friendly introduction. You might also find the [unofficial Tridactyl Memrise course](https://app.memrise.com/course/5995499/tridactyls-main-shortcuts/) useful for memorising keybinds.
+Type `:help` or press `<F1>` for online help once you're in, or `:tutor` for a friendly introduction. You might also find the [unofficial Tridactyl Memrise course](https://app.memrise.com/course/5995499/tridactyls-main-shortcuts/) useful for memorizing keybinds.
 
 Remember that Tridactyl cannot run on any page on about:\*, data:\*, view-source:\* and file:\*. We're sorry about that and we're working with Firefox to improve this situation by removing restrictions on existing APIs and developing a new API.
 

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ The changelog for the stable versions can be found [here](https://github.com/tri
 
 ## First look
 
-Type `:help` or press `<F1>` for online help once you're in, or `:tutor` for a friendly introduction. You might also find the [unofficial Tridactyl Memrise course](https://app.memrise.com/course/5995499/tridactyls-main-shortcuts/) useful for memorizing keybinds.
+Type `:help` or press `<F1>` for online help once you're in, or `:tutor` for a friendly introduction. You might also find the [unofficial Tridactyl Memrise course](https://app.memrise.com/course/5995499/tridactyls-main-shortcuts/) useful for memorising keybinds.
 
 Remember that Tridactyl cannot run on any page on about:\*, data:\*, view-source:\* and file:\*. We're sorry about that and we're working with Firefox to improve this situation by removing restrictions on existing APIs and developing a new API.
 


### PR DESCRIPTION
1 - "permisisons" should be "permissions."
2 - "memorising" should be "memorizing."