### PR TITLE
Fixed the hint example for matching on the comment collapsers on Hacker News

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5123,7 +5123,7 @@ const KILL_STACK: Element[] = []
 
     Element selection flags:
         - -c [selector] hint links that match the css selector
-          - `bind ;c hint -c [class*="expand"],[class="togg"]` works particularly well on reddit and HN
+          - `bind ;c hint -c [class*="expand"],[class*="togg"]` works particularly well on reddit and HN
           - this works with most other hint modes, with the caveat that if other hint mode takes arguments your selector must contain no spaces, i.e. `hint -c[yourOtherFlag] [selector] [your other flag's arguments, which may contain spaces]`
         - -x [selector] exclude the matched elements from hinting
         - -f [text] hint links and inputs that display the given text


### PR DESCRIPTION
Hacker News added an additional class which prevents the example hint for matching on the Reddit/HN comment collapsers from matching correctly. By matching on any of the classes this seems to be fixed. I thought it might be nice to update the example in the documentation as well for anyone that stumbles upon it. 

I noticed that @bovine3dom made the same change in his example [.tridactylrc](https://github.com/tridactyl/tridactyl/blob/608744bc36fd0c8a3ad39ab94274952596f005eb/.tridactylrc#L44). 