### PR TITLE
Add hint flag for specifying a selector that also keeps default hints

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5125,6 +5125,7 @@ const KILL_STACK: Element[] = []
         - -c [selector] hint links that match the css selector
           - `bind ;c hint -c [class*="expand"],[class*="togg"]` works particularly well on reddit and HN
           - this works with most other hint modes, with the caveat that if other hint mode takes arguments your selector must contain no spaces, i.e. `hint -c[yourOtherFlag] [selector] [your other flag's arguments, which may contain spaces]`
+        - -C [selector] like `-c [selector]` but also hints all elements that would normally be hinted given the other options selected
         - -x [selector] exclude the matched elements from hinting
         - -f [text] hint links and inputs that display the given text
           - `bind <c-e> hint -f Edit`


### PR DESCRIPTION
Fixes #4780.

@bovine3dom I am no good with names and chose `-C` for that new flag. Please fix :).

With this change, the Reddit comment collapser hints could be part of `f` (instead of having its own [custom shortcut](https://github.com/tridactyl/tridactyl/blob/850acdf2ca11018ed3c2fc7a8ae157d77f50bc17/src/excmds.ts#L5126)) like so:
```
bindurl www.reddit.com f hint -C .threadline
```
With that, when pressing `f` on Reddit you get both default hints and comment collapser hints.