### PR TITLE
Fix wrong behavior of :tabopen with containers

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2806,16 +2806,9 @@ export async function tabopen_helper({ addressarr = [], waitForDom = false }): P
     }
 
     if (typeof maybeURL === "object") {
-        if (await firefoxVersionAtLeast(80)) {
-            // work around #2695 until we can work out what is going on
-            if (args.active === false || args.cookieStoreId !== undefined || waitForDom === true) {
-                throw new Error("Firefox search engines do not support containers or background tabs in FF >80. `:set searchengine google` or see issue https://github.com/tridactyl/tridactyl/issues/2695")
-            }
-
-            // This ignores :set tabopenpos / issue #342. TODO: fix that somehow.
-            return browser.search.search(maybeURL)
-        }
-        return openInNewTab(null, args, waitForDom).then(tab => browser.search.search({ tabId: tab.id, ...maybeURL }))
+        return openInNewTab(null, args, waitForDom)
+                   .then(tab => browser.tabs.get(tab.id))
+                   .then(tab => browser.search.search({tabId: tab.id, ...maybeURL}))
     }
 
     // Fall back to about:newtab

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2806,6 +2806,10 @@ export async function tabopen_helper({ addressarr = [], waitForDom = false }): P
     }
 
     if (typeof maybeURL === "object") {
+        // browser.search.search(tabId, ...) sometimes does not work when it is executed
+        // right after openInNewTab(). Calling browser.tabs.get() between openInNewTab()
+        // and browser.search.search() seems to fix that problem.
+        // See https://github.com/tridactyl/tridactyl/pull/4791.
         return openInNewTab(null, args, waitForDom)
                    .then(tab => browser.tabs.get(tab.id))
                    .then(tab => browser.search.search({tabId: tab.id, ...maybeURL}))


### PR DESCRIPTION
Related to issue https://github.com/tridactyl/tridactyl/issues/2695 and pull request https://github.com/tridactyl/tridactyl/pull/2698 from August 2020.

Assuming `autocontain` is empty (default value), `tabopencontaineraware` is false (default value), and current tab is in container `C`:
1. `:tabopen` opens a new tab in no container. Good.
2. `:tabopen -c C` opens a new tab container `C`. Good.
3. `:tabopen test`. Bad: opens a new tab in container `C`.
4. `:tabopen -c none test`. Bad: opens a new tab in container `C`. 
5. `:tabopen -c C test`. Bad: triggers a [Tridactyl exception](https://github.com/tridactyl/tridactyl/blob/4796b7d4d04d1e33b55425eaf1f286a36ceea589/src/excmds.ts#L2812C43-L2812C43)

Removing the entire if statement (`if (await firefoxVersionAtLeast(80))`) fixes 3., 4., and 5.
https://github.com/tridactyl/tridactyl/blob/4796b7d4d04d1e33b55425eaf1f286a36ceea589/src/excmds.ts#L2808-L2820

But now, `:tabopen test` behaves strangely. Sometimes (about 15% of the time in my tests), it will open a new tab in no container (that's good), but it will not trigger the search for "test".
I narrowed down the problem to `browser.search.search()`. My tests led me to believe that `browser.search.search()` called with no tabId works every time:
```js
browser.search.search(maybeURL)
```
but `search()` called with a tabId sometimes fails (15% of the time):
```js
browser.search.search({tabId: tab.id, ...maybeURL})
```
@bovine3dom, I think you experienced that bug back then in 2020, you were aware of the problem with `browser.search.search()` and that's the reason why you essentially removed the broken `browser.search.search()` call.

It's as if sometimes the newly created tab is not quite ready by the time we call `browser.search.search({tabId: tab.id, ...maybeURL})`, and that call therefore fails (silently).
Knowing that, I thought that "giving it some time" could help. I've tried inserting a 2 seconds sleep right before the `search()` call. That did not help, the bug still happened: the tab would be opened but 15% of the time, the search for "test" would not be triggered.
Instead of sleeping, I've also looked for other methods I could call on the newly created tab. And so I added the following just before the `search()` call:
```js
browser.tabs.get(tab.id)
```
For some reason, calling `browser.tabs.get()` just before `browser.search.search()` seems to have fixed the problem for me. I've ran the test (`:tabopen test`) at least a hundred times and it worked fine, whereas before, the bug would always occur within the first 8 tests.

It boils down to replacing line 2818:
https://github.com/tridactyl/tridactyl/blob/4796b7d4d04d1e33b55425eaf1f286a36ceea589/src/excmds.ts#L2818-L2818
with
```js
return openInNewTab(null, args, waitForDom)
           .then(tab => browser.tabs.get(tab.id))
           .then(tab => browser.search.search({tabId: tab.id, ...maybeURL}))
```
Here, if I remove the first `then()`, then `:tabopen test` will not trigger the search for "test" about 15% of the time. If I leave that line, then the search for "test" is always triggered, as expected.

My configuration:
Firefox 118.0.2
Windows 10
I've run all these tests with `yarn run run`.

TL;DR:
- Removing the if statement `if (await firefoxVersionAtLeast(80))` fixes several bugs regarding the wrong behavior of `:tabopen` with containers (bugs 3., 4., and 5. mentioned above).
- But removing that if statement introduces a bug with `:tabopen`. `:tabopen test` opens a new tab but sometimes does not trigger the search for "test".
- I could fix that by adding a call to `browser.tabs.get(tabId)` just before `browser.search.search(tabId, ...)`.