### PR TITLE
eslint(unsupported-apis): improve checking as outlined in #4792

### DIFF
--- a/custom-eslint-rules/unsupported-apis.js
+++ b/custom-eslint-rules/unsupported-apis.js
@@ -1,15 +1,21 @@
 const bcd = require('@mdn/browser-compat-data');
 const api = bcd.webextensions.api;
 const supported_browsers = ["firefox", "chrome"];
+const minimalSupportedFirefoxVersion = 114;
+
+function propertyNameOrValue(n) {
+    return (n.property.type == "Literal" ? n.property.value : n.property.name)
+}
 
 function detectBrowserUsage(context, node) {
     let localApi = api;
     let fullName = [];
-    while (node.type == "MemberExpression" && node.property.name in localApi) {
+    while (node.type == "MemberExpression" && propertyNameOrValue(node) in localApi) {
         const n = node;
         node = node.parent;
-        fullName.push(n.property.name);
-        localApi = localApi[n.property.name];
+        let name = propertyNameOrValue(n);
+        fullName.push(name);
+        localApi = localApi[name];
         if (!localApi.__compat) {
             continue;
         }
@@ -21,8 +27,21 @@ function detectBrowserUsage(context, node) {
                     messageId: "unsupportedApis",
                     data: {
                         name: browser,
+                        api: fullName.join("."),
                     }
                 });
+            } else {
+                const version = Number(support[browser].version_added);
+                if (!isNaN(version) && version > minimalSupportedFirefoxVersion) {
+                    context.report({
+                        node: n,
+                        messageId: "apiTooRecent",
+                        data: {
+                            api: fullName.join("."),
+                            version: minimalSupportedFirefoxVersion
+                        }
+                    });
+                }
             }
         }
     }
@@ -31,12 +50,14 @@ function detectBrowserUsage(context, node) {
 module.exports = {
     meta: {
         messages: {
-            unsupportedApis: "Unsupported on '{{ name }}'"
+            unsupportedApis: "{{ api }} unsupported on '{{ name }}'",
+            apiTooRecent: "{{ api }} is not supported on firefox {{ version }}",
         }
     },
     create(context) {
         return {
             'MemberExpression[object.name="browser"]': (n) => detectBrowserUsage(context, n),
+            'MemberExpression[object.name="browserBg"]': (n) => detectBrowserUsage(context, n),
         };
     }
 };


### PR DESCRIPTION
This takes care of all points outlined in #4792, although in a quick and dirty manner for the version checking :)