### PR TITLE
Reduce likelihood of losing characters while command line is opening

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -172,7 +172,7 @@ export function focus() {
             logger.debug("Consuming buffered page keys", bufferedPageKeys,
                 "initialClInputValue = " + initialClInputValue,
                 "currentClInputValue = " + currentClInputValue);
-            // Native events are assumed to be character keydowns events,
+            // Native events are assumed to be character keydown events,
             // i.e. characters appended at the end of clInput.
             commandline_state.clInput.value =
                 initialClInputValue

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -213,7 +213,7 @@ commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        logger.info("Called keydown event listener")
+        logger.debug("Called clInput keydown event listener", keyevent)
         commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {
@@ -312,7 +312,7 @@ function clInputValueChanged() {
 
 /** @hidden **/
 commandline_state.clInput.addEventListener("input", () => {
-    logger.info("Called input event listener")
+    logger.debug("Called clInput input event listener")
     clInputValueChanged();
 })
 

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -175,22 +175,17 @@ export function focus() {
             return
         if (bufferedPageKeys.length !== 0) {
             const currentClInputValue = commandline_state.clInput.value;
-            // Native events are assumed to be characters added at the end of clInput.
-            const clInputNativeEventKeysReceived = commandline_state.initialClInputValue.length > currentClInputValue.length
+            let initialClInputValue = commandline_state.initialClInputValue;
             logger.debug("Consuming buffered page keys", bufferedPageKeys,
-                "initialClInputValue = " + commandline_state.initialClInputValue,
+                "initialClInputValue = " + initialClInputValue,
                 "currentClInputValue = " + currentClInputValue);
-            if (clInputNativeEventKeysReceived) {
-                // Insert page keys at the end.
-                commandline_state.clInput.value += bufferedPageKeys.join("")
-            } else {
-                let initialClInputValueLength = commandline_state.initialClInputValue.length;
-                // Insert page keys just after the command.
-                commandline_state.clInput.value =
-                    currentClInputValue.substring(0, initialClInputValueLength)
-                    + bufferedPageKeys.join("")
-                    + currentClInputValue.substring(initialClInputValueLength)
-            }
+            // Native events are assumed to be characters added at the end of clInput.
+            // If the user edits the command (initial clInput value) before the buffered page keys are received, we are out of luck.
+            // Insert page keys just after the command.
+            commandline_state.clInput.value =
+                initialClInputValue
+                + bufferedPageKeys.join("")
+                + currentClInputValue.substring(initialClInputValue.length)
             // Update completion.
             clInputValueChanged()
         }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -185,10 +185,10 @@ export function focus() {
             clInputValueChanged()
         }
     }
-    logger.debug("commandline_frame clInput focus()")
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
+    logger.debug("commandline_frame clInput focus(), activeElement is clInput: " + (window.document.activeElement === commandline_state.clInput))
     Messaging.messageOwnTab("buffered_page_keys").then(consumeBufferedPageKeys)
 }
 

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -405,6 +405,7 @@ export function editor_function(fn_name: keyof typeof tri_editor, ...args) {
 }
 
 Messaging.addListener("commandline_frame", Messaging.attributeCaller(SELF))
+logger.debug("Added commandline_frame message listener")
 
 commandline_state.fns = getCommandlineFns(commandline_state)
 Messaging.addListener(
@@ -420,3 +421,5 @@ Messaging.addListener(
 ;(window as any).tri = Object.assign(window.tri || {}, {
     perfObserver: perf.listenForCounters(),
 })
+
+Messaging.messageOwnTab("commandline_frame_ready_to_receive_messages")

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -167,8 +167,6 @@ export function focus() {
         const clInputStillFocused = window.document.activeElement === commandline_state.clInput;
         logger.debug("buffered_page_keys response received", bufferedPageKeys,
             "clInputStillFocused = " + clInputStillFocused)
-        if (!clInputStillFocused)
-            return
         if (bufferedPageKeys.length !== 0) {
             const currentClInputValue = commandline_state.clInput.value;
             const initialClInputValue = commandline_state.initialClInputValue;

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -162,18 +162,16 @@ const noblur = () => setTimeout(() => commandline_state.clInput.focus(), 0)
 
 /** @hidden **/
 export function focus() {
-    setTimeout(() => {
-        logger.info("Called focus() after 2000ms")
-        Messaging.messageOwnTab("clInputFocused", "unused")
-        commandline_state.clInput.focus()
-        commandline_state.clInput.removeEventListener("blur", noblur)
-        commandline_state.clInput.addEventListener("blur", noblur)
-        if (keysFromContentProcess.length !== 0) {
-            logger.info("Dispatching " + JSON.stringify(keysFromContentProcess));
-            keysFromContentProcess.forEach(key => commandline_state.clInput.value += key)
-            keysFromContentProcess = []
-        }
-    }, 2000)
+    logger.info("Called focus() after 2000ms")
+    Messaging.messageOwnTab("clInputFocused", "unused")
+    commandline_state.clInput.focus()
+    commandline_state.clInput.removeEventListener("blur", noblur)
+    commandline_state.clInput.addEventListener("blur", noblur)
+    if (keysFromContentProcess.length !== 0) {
+        logger.info("Dispatching " + JSON.stringify(keysFromContentProcess));
+        keysFromContentProcess.forEach(key => commandline_state.clInput.value += key)
+        keysFromContentProcess = []
+    }
 }
 
 let keysFromContentProcess: string[] = []

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -373,10 +373,7 @@ export function fillcmdline(
     trailspace = true,
     ffocus = true,
 ) {
-    logger.debug("Called commandline_frame fillcmdline")
-    // 1. Initialize clInput value.
-    // 2. Focus it.
-    // 3. Stop forwarding key events from content process to command line process.
+    logger.debug("Called commandline_frame fillcmdline, trailspace = " + trailspace + " ffocus = " + ffocus)
     if (trailspace) commandline_state.clInput.value = newcommand + " "
     else commandline_state.clInput.value = newcommand
     commandline_state.initialClInputValue = commandline_state.clInput.value

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -55,7 +55,6 @@ import state, * as State from "@src/state"
 import * as R from "ramda"
 import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
-import {ownTabId} from "@src/lib/webext";
 
 /** @hidden **/
 const logger = new Logger("cmdline")
@@ -190,7 +189,7 @@ export function focus() {
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
-    Messaging.messageTab(ownTabId(), "buffered_page_keys").then(consumeBufferedPageKeys)
+    Messaging.messageOwnTab("buffered_page_keys").then(consumeBufferedPageKeys)
 }
 
 /** @hidden **/

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -92,7 +92,6 @@ theme(document.querySelector(":root"))
 function resizeArea() {
     if (commandline_state.isVisible) {
         Messaging.messageOwnTab("commandline_content", "show")
-        Messaging.messageOwnTab("commandline_content", "focus")
         focus()
     }
 }

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -166,7 +166,7 @@ export function focus() {
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
-    logger.debug("Called focus()")
+    logger.debug("commandline_frame focus()")
     Messaging.messageOwnTab("buffered_page_keys", "").then((bufferedPageKeys : string[]) => {
         let clInputStillFocused = window.document.activeElement === commandline_state.clInput;
         logger.debug("buffered_page_keys response received", bufferedPageKeys,
@@ -213,7 +213,7 @@ commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        logger.debug("Called clInput keydown event listener", keyevent)
+        logger.debug("commandline_frame clInput keydown event listener", keyevent)
         commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {
@@ -288,6 +288,11 @@ export function refresh_completions(exstr) {
 
 /** @hidden **/
 let onInputPromise: Promise<any> = Promise.resolve()
+/** @hidden **/
+commandline_state.clInput.addEventListener("input", () => {
+    logger.debug("commandline_frame clInput input event listener")
+    clInputValueChanged();
+})
 
 function clInputValueChanged() {
     const exstr = commandline_state.clInput.value
@@ -309,12 +314,6 @@ function clInputValueChanged() {
         })
     }, 100)
 }
-
-/** @hidden **/
-commandline_state.clInput.addEventListener("input", () => {
-    logger.debug("Called clInput input event listener")
-    clInputValueChanged();
-})
 
 /** @hidden **/
 let cmdline_history_current = ""
@@ -373,7 +372,7 @@ export function fillcmdline(
     trailspace = true,
     ffocus = true,
 ) {
-    logger.debug("Called commandline_frame fillcmdline, trailspace = " + trailspace + " ffocus = " + ffocus)
+    logger.debug("commandline_frame fillcmdline(newcommand = " + newcommand + " trailspace = " + trailspace + " ffocus = " + ffocus + ")")
     if (trailspace) commandline_state.clInput.value = newcommand + " "
     else commandline_state.clInput.value = newcommand
     commandline_state.initialClInputValue = commandline_state.clInput.value

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -165,7 +165,7 @@ const noblur = () => setTimeout(() => commandline_state.clInput.focus(), 0)
 export function focus() {
     function consumeBufferedPageKeys(bufferedPageKeys: string[]) {
         const clInputStillFocused = window.document.activeElement === commandline_state.clInput;
-        logger.debug("buffered_page_keys response received", bufferedPageKeys,
+        logger.debug("stop_buffering_page_keys response received, bufferedPageKeys = ", bufferedPageKeys,
             "clInputStillFocused = " + clInputStillFocused)
         if (bufferedPageKeys.length !== 0) {
             const currentClInputValue = commandline_state.clInput.value;
@@ -187,7 +187,7 @@ export function focus() {
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
     logger.debug("commandline_frame clInput focus(), activeElement is clInput: " + (window.document.activeElement === commandline_state.clInput))
-    Messaging.messageOwnTab("buffered_page_keys").then(consumeBufferedPageKeys)
+    Messaging.messageOwnTab("stop_buffering_page_keys").then(consumeBufferedPageKeys)
 }
 
 /** @hidden **/

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -170,33 +170,20 @@ export function focus() {
         commandline_state.clInput.addEventListener("blur", noblur)
         if (buffer.length !== 0) {
             logger.info("Dispatching " + JSON.stringify(buffer));
-            buffer.forEach(e => processKeyboardEvent(e))
-            buffer.splice(-1)
+            buffer.forEach(key => commandline_state.clInput.value += key)
+            buffer = []
         }
     }, 2000)
 }
 
-let buffer: KeyboardEvent[] = []
-export function bufferUntil([   code,
-                                key,
-                                altKey,
-                                ctrlKey,
-                                metaKey,
-                                shiftKey]) {
-    const keyevent = new KeyboardEvent('keydown', {
-        code: code,
-        key: key,
-        altKey: altKey,
-        ctrlKey: ctrlKey,
-        metaKey: metaKey,
-        shiftKey: shiftKey,
-    })
-    logger.info("Received keyboardEvent for buffering", keyevent)
+let buffer: string[] = []
+export function bufferUntil([key]) {
+    logger.info("Received keyboardEvent for buffering " + key)
     if (window.document.activeElement === commandline_state.clInput) {
-        processKeyboardEvent(keyevent)
+        commandline_state.clInput.value += key
     }
     else {
-        buffer.push(keyevent);
+        buffer.push(key);
     }
 }
 

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -162,13 +162,13 @@ const noblur = () => setTimeout(() => commandline_state.clInput.focus(), 0)
 
 /** @hidden **/
 export function focus() {
-    logger.info("Called focus() after 2000ms")
-    Messaging.messageOwnTab("clInputFocused", "unused")
+    logger.debug("Called focus()")
+    Messaging.messageOwnTab("cl_input_focused", "unused")
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
     if (keysFromContentProcess.length !== 0) {
-        logger.info("Dispatching " + JSON.stringify(keysFromContentProcess));
+        logger.debug("Dispatching " + JSON.stringify(keysFromContentProcess));
         keysFromContentProcess.forEach(key => commandline_state.clInput.value += key)
         keysFromContentProcess = []
     }
@@ -176,7 +176,7 @@ export function focus() {
 
 let keysFromContentProcess: string[] = []
 export function bufferUntilClInputFocused([key]) {
-    logger.info("Received keyboardEvent for buffering " + key)
+    logger.debug("Received keyboardEvent for buffering " + key)
     if (window.document.activeElement === commandline_state.clInput) {
         commandline_state.clInput.value += key
     }
@@ -200,7 +200,6 @@ let prev_cmd_called_history = false
 // Save programmer time by generating an immediately resolved promise
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const QUEUE: Promise<any>[] = [(async () => {})()]
-logger.info("Setting event listeners of commandline_state.clInput")
 
 /** @hidden **/
 commandline_state.clInput.addEventListener(

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -166,21 +166,21 @@ export function focus() {
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
-    logger.debug("commandline_frame focus()")
+    logger.debug("commandline_frame clInput focus()")
     Messaging.messageOwnTab("buffered_page_keys", "").then((bufferedPageKeys : string[]) => {
-        let clInputStillFocused = window.document.activeElement === commandline_state.clInput;
+        const clInputStillFocused = window.document.activeElement === commandline_state.clInput;
         logger.debug("buffered_page_keys response received", bufferedPageKeys,
             "clInputStillFocused = " + clInputStillFocused)
         if (!clInputStillFocused)
             return
         if (bufferedPageKeys.length !== 0) {
             const currentClInputValue = commandline_state.clInput.value;
-            let initialClInputValue = commandline_state.initialClInputValue;
+            const initialClInputValue = commandline_state.initialClInputValue;
             logger.debug("Consuming buffered page keys", bufferedPageKeys,
                 "initialClInputValue = " + initialClInputValue,
                 "currentClInputValue = " + currentClInputValue);
-            // Native events are assumed to be characters added at the end of clInput.
-            // If the user edits the command (initial clInput value) before the buffered page keys are received, we are out of luck.
+            // Native events are assumed to be character keydowns events,
+            // i.e. characters appended at the end of clInput.
             // Insert page keys just after the command.
             commandline_state.clInput.value =
                 initialClInputValue

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -162,9 +162,42 @@ const noblur = () => setTimeout(() => commandline_state.clInput.focus(), 0)
 
 /** @hidden **/
 export function focus() {
-    commandline_state.clInput.focus()
-    commandline_state.clInput.removeEventListener("blur", noblur)
-    commandline_state.clInput.addEventListener("blur", noblur)
+    setTimeout(() => {
+        logger.info("Called focus() after 2000ms")
+        Messaging.messageOwnTab("clInputFocused", "unused")
+        commandline_state.clInput.focus()
+        commandline_state.clInput.removeEventListener("blur", noblur)
+        commandline_state.clInput.addEventListener("blur", noblur)
+        if (buffer.length !== 0) {
+            logger.info("Dispatching " + JSON.stringify(buffer));
+            buffer.forEach(e => processKeyboardEvent(e))
+            buffer.splice(-1)
+        }
+    }, 2000)
+}
+
+let buffer: KeyboardEvent[] = []
+export function bufferUntil([   code,
+                                key,
+                                altKey,
+                                ctrlKey,
+                                metaKey,
+                                shiftKey]) {
+    const keyevent = new KeyboardEvent('keydown', {
+        code: code,
+        key: key,
+        altKey: altKey,
+        ctrlKey: ctrlKey,
+        metaKey: metaKey,
+        shiftKey: shiftKey,
+    })
+    logger.info("Received keyboardEvent for buffering", keyevent)
+    if (window.document.activeElement === commandline_state.clInput) {
+        processKeyboardEvent(keyevent)
+    }
+    else {
+        buffer.push(keyevent);
+    }
 }
 
 /** @hidden **/
@@ -182,67 +215,72 @@ let prev_cmd_called_history = false
 // Save programmer time by generating an immediately resolved promise
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const QUEUE: Promise<any>[] = [(async () => {})()]
+logger.info("Setting event listeners of commandline_state.clInput")
 
 /** @hidden **/
 commandline_state.clInput.addEventListener(
     "keydown",
     function (keyevent: KeyboardEvent) {
         if (!keyevent.isTrusted) return
-        commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
-        const response = keyParser(commandline_state.keyEvents)
-        if (response.isMatch) {
-            keyevent.preventDefault()
-            keyevent.stopImmediatePropagation()
-        } else {
-            // Ideally, all keys that aren't explicitly bound to an ex command
-            // should be bound to a "self-insert" command that would input the
-            // key itself. Because it's not possible to generate events as if
-            // they originated from the user, we can't do this, but we still
-            // need to simulate it, in order to have history() work.
-            prev_cmd_called_history = false
-        }
-        if (response.value) {
-            commandline_state.keyEvents = []
-            history_called = false
-
-            // If excmds start with 'ex.' they're coming back to us anyway, so skip that.
-            // This is definitely a hack. Should expand aliases with exmode, etc.
-            // but this whole thing should be scrapped soon, so whatever.
-            if (response.value.startsWith("ex.")) {
-                const [funcname, ...args] = response.value.slice(3).split(/\s+/)
-
-                QUEUE[QUEUE.length - 1].then(() => {
-                    QUEUE.push(
-                        // Abuse async to wrap non-promises in a promise
-                        // eslint-disable-next-line @typescript-eslint/require-await
-                        (async () =>
-                            commandline_state.fns[
-                                funcname as keyof typeof commandline_state.fns
-                            ](
-                                args.length === 0 ? undefined : args.join(" "),
-                            ))(),
-                    )
-                    prev_cmd_called_history = history_called
-                })
-            } else {
-                // Send excmds directly to our own tab, which fixes the
-                // old bug where a command would be issued in one tab but
-                // land in another because the active tab had
-                // changed. Background-mode excmds will be received by the
-                // own tab's content script and then bounced through a
-                // shim to the background, but the latency increase should
-                // be acceptable becuase the background-mode excmds tend
-                // to be a touch less latency-sensitive.
-                Messaging.messageOwnTab("controller_content", "acceptExCmd", [
-                    response.value,
-                ]).then(_ => (prev_cmd_called_history = history_called))
-            }
-        } else {
-            commandline_state.keyEvents = response.keys
-        }
+        processKeyboardEvent(keyevent);
     },
     true,
 )
+
+function processKeyboardEvent(keyevent: KeyboardEvent) {
+    commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
+    const response = keyParser(commandline_state.keyEvents)
+    if (response.isMatch) {
+        keyevent.preventDefault()
+        keyevent.stopImmediatePropagation()
+    } else {
+        // Ideally, all keys that aren't explicitly bound to an ex command
+        // should be bound to a "self-insert" command that would input the
+        // key itself. Because it's not possible to generate events as if
+        // they originated from the user, we can't do this, but we still
+        // need to simulate it, in order to have history() work.
+        prev_cmd_called_history = false
+    }
+    if (response.value) {
+        commandline_state.keyEvents = []
+        history_called = false
+
+        // If excmds start with 'ex.' they're coming back to us anyway, so skip that.
+        // This is definitely a hack. Should expand aliases with exmode, etc.
+        // but this whole thing should be scrapped soon, so whatever.
+        if (response.value.startsWith("ex.")) {
+            const [funcname, ...args] = response.value.slice(3).split(/\s+/)
+
+            QUEUE[QUEUE.length - 1].then(() => {
+                QUEUE.push(
+                    // Abuse async to wrap non-promises in a promise
+                    // eslint-disable-next-line @typescript-eslint/require-await
+                    (async () =>
+                        commandline_state.fns[
+                            funcname as keyof typeof commandline_state.fns
+                            ](
+                            args.length === 0 ? undefined : args.join(" "),
+                        ))(),
+                )
+                prev_cmd_called_history = history_called
+            })
+        } else {
+            // Send excmds directly to our own tab, which fixes the
+            // old bug where a command would be issued in one tab but
+            // land in another because the active tab had
+            // changed. Background-mode excmds will be received by the
+            // own tab's content script and then bounced through a
+            // shim to the background, but the latency increase should
+            // be acceptable becuase the background-mode excmds tend
+            // to be a touch less latency-sensitive.
+            Messaging.messageOwnTab("controller_content", "acceptExCmd", [
+                response.value,
+            ]).then(_ => (prev_cmd_called_history = history_called))
+        }
+    } else {
+        commandline_state.keyEvents = response.keys
+    }
+}
 
 export function refresh_completions(exstr) {
     if (!commandline_state.activeCompletions) enableCompletions()

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -80,9 +80,9 @@ const commandline_state = {
      */
     isVisible: false,
     keyEvents: new Array<MinimalKey>(),
+    initialClInputValue: "",
     refresh_completions,
     state,
-    initialClInputValue: "",
 }
 
 // first theming of commandline iframe
@@ -294,6 +294,7 @@ commandline_state.clInput.addEventListener("input", () => {
     clInputValueChanged();
 })
 
+/** @hidden **/
 function clInputValueChanged() {
     const exstr = commandline_state.clInput.value
     contentState.current_cmdline = exstr

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -88,6 +88,7 @@ export function hide() {
     try {
         cmdline_iframe.classList.add("hidden")
         cmdline_iframe.setAttribute("style", "height: 0px !important;")
+        Messaging.messageOwnTab("commandline_frame", "hide")
     } catch (e) {
         // Using cmdline_logger here is OK because cmdline_logger won't try to
         // call hide(), thus we avoid the recursion that happens for show() and

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -63,7 +63,7 @@ export function show(hidehover = false) {
          *
          * Inspired by VVimpulation: https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5
          */
-        logger.debug("Called show()")
+        logger.debug("commandline_content show()")
         if (hidehover) {
             const a = window.document.createElement("A")
             ;(a as any).href = ""
@@ -96,6 +96,9 @@ export function hide() {
     }
 }
 
+/**
+ * TODO: Discuss removal of this method?
+ */
 export function focus() {
     try {
         // I don't think this is necessary because clInput is going to be focused.

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -98,6 +98,7 @@ export function hide() {
 
 export function focus() {
     try {
+        // I don't think this is necessary because clInput is going to be focused.
         // cmdline_iframe.focus()
     } catch (e) {
         // Note: We can't use cmdline_logger.error because it will try to log

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -88,7 +88,6 @@ export function hide() {
     try {
         cmdline_iframe.classList.add("hidden")
         cmdline_iframe.setAttribute("style", "height: 0px !important;")
-        Messaging.messageOwnTab("commandline_frame", "hide")
     } catch (e) {
         // Using cmdline_logger here is OK because cmdline_logger won't try to
         // call hide(), thus we avoid the recursion that happens for show() and

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -96,22 +96,6 @@ export function hide() {
     }
 }
 
-/**
- * TODO: Discuss removal of this method. We want clInput to be focused, not cmdline_iframe?
- */
-export function focus() {
-    try {
-        // I don't think this is necessary because clInput is going to be focused.
-        // cmdline_iframe.focus()
-    } catch (e) {
-        // Note: We can't use cmdline_logger.error because it will try to log
-        // the error in the commandline, which will need to focus() it again,
-        // which will throw again...
-        // cmdline_logger.error(e)
-        console.error(e)
-    }
-}
-
 export function blur() {
     try {
         cmdline_iframe.blur()

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -97,7 +97,7 @@ export function hide() {
 }
 
 /**
- * TODO: Discuss removal of this method?
+ * TODO: Discuss removal of this method. We want clInput to be focused, not cmdline_iframe?
  */
 export function focus() {
     try {

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -63,7 +63,7 @@ export function show(hidehover = false) {
          *
          * Inspired by VVimpulation: https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5
          */
-        logger.info("Called show()")
+        logger.debug("Called show()")
         if (hidehover) {
             const a = window.document.createElement("A")
             ;(a as any).href = ""

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -63,7 +63,7 @@ export function show(hidehover = false) {
          *
          * Inspired by VVimpulation: https://github.com/amedama41/vvimpulation/commit/53065d015d1e9a892496619b51be83771f57b3d5
          */
-
+        logger.info("Called show()")
         if (hidehover) {
             const a = window.document.createElement("A")
             ;(a as any).href = ""
@@ -98,7 +98,7 @@ export function hide() {
 
 export function focus() {
     try {
-        cmdline_iframe.focus()
+        // cmdline_iframe.focus()
     } catch (e) {
         // Note: We can't use cmdline_logger.error because it will try to log
         // the error in the commandline, which will need to focus() it again,

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -212,7 +212,7 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (exstr.startsWith("fillcmdline")) { // TODO That's ugly. I need a way to know if this command is going to open the command line. Is there a better way?
+                    if (exstr === "fillcmdline" || exstr === "fillcmdline_notrail") {
                         logger.debug("Starting buffering of page keys")
                         bufferingPageKeysBeginTime = performance.now()
                         mustBufferPageKeysForClInput = true

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -203,7 +203,7 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (exstr.startsWith("fillcmdline ")) { // Ugh. That's ugly. I needed a way to know if this command is going to open the cmdline.
+                    if (exstr.startsWith("fillcmdline ")) { // TODO That's ugly. I need a way to know if this command is going to open the command line. Is there a better way?
                         logger.debug("Starting buffering of page keys")
                         mustBufferPageKeysForClInput = true
                         bufferedPageKeys = []

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -193,7 +193,7 @@ function* ParserController() {
                 if (response.exstr) {
                     exstr = response.exstr
                     if (exstr.startsWith("fillcmdline ")) {
-                        logger.info("Setting bufferUntilClInputFocused to true")
+                        logger.debug("Setting bufferUntilClInputFocused to true")
                         bufferUntilClInputFocused = true
                     }
                     break
@@ -216,8 +216,8 @@ function* ParserController() {
         }
     }
 }
-Messaging.addListener("clInputFocused", () => {
-    logger.info("Callback clInputFocused")
+Messaging.addListener("cl_input_focused", () => {
+    logger.debug("Callback cl_input_focused")
     bufferUntilClInputFocused = false
 })
 let bufferUntilClInputFocused: boolean = false
@@ -226,12 +226,12 @@ generator.next()
 
 /** Feed keys to the ParserController */
 export function acceptKey(keyevent: KeyboardEvent) {
-    logger.info("bufferUntilClInputFocused = " + bufferUntilClInputFocused)
+    logger.debug("bufferUntilClInputFocused = " + bufferUntilClInputFocused)
     if (bufferUntilClInputFocused) {
         let isCharacterKey = keyevent.key.length == 1
             && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
         if (isCharacterKey) {
-            logger.info("Sending keyboardEvent for buffering ", keyevent)
+            logger.debug("Sending keyboardEvent for buffering ", keyevent)
             Messaging.messageOwnTab("commandline_frame", "bufferUntilClInputFocused", [keyevent.key]);
         }
         keyevent.preventDefault()

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -193,8 +193,8 @@ function* ParserController() {
                 if (response.exstr) {
                     exstr = response.exstr
                     if (exstr.startsWith("fillcmdline ")) { // Ugh. That's ugly. I needed a way to know if this command is going to open the cmdline.
-                        logger.debug("Setting bufferUntilClInputFocused to true")
-                        bufferUntilClInputFocused = true
+                        logger.debug("Setting clInputFocused to false")
+                        clInputFocused = false
                     }
                     break
                 } else {
@@ -218,16 +218,16 @@ function* ParserController() {
 }
 Messaging.addListener("cl_input_focused", () => {
     logger.debug("Callback cl_input_focused")
-    bufferUntilClInputFocused = false
+    clInputFocused = true
 })
-let bufferUntilClInputFocused: boolean = false
+let clInputFocused: boolean = true
 export const generator = ParserController() // var rather than let stops weirdness in repl.
 generator.next()
 
 /** Feed keys to the ParserController */
 export function acceptKey(keyevent: KeyboardEvent) {
-    logger.debug("bufferUntilClInputFocused = " + bufferUntilClInputFocused)
-    if (bufferUntilClInputFocused) {
+    logger.debug("clInputFocused = " + clInputFocused)
+    if (!clInputFocused) {
         let isCharacterKey = keyevent.key.length == 1
             && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
         if (isCharacterKey) {

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -192,7 +192,7 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (exstr.startsWith("fillcmdline ")) {
+                    if (exstr.startsWith("fillcmdline ")) { // Ugh. That's ugly. I needed a way to know if this command is going to open the cmdline.
                         logger.debug("Setting bufferUntilClInputFocused to true")
                         bufferUntilClInputFocused = true
                     }

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -232,10 +232,9 @@ function* ParserController() {
 export const generator = ParserController() // var rather than let stops weirdness in repl.
 generator.next()
 
-/** Feed keys to the ParserController */
+/** Feed keys to the ParserController, unless they should be buffered to be later fed to clInput */
 export function acceptKey(keyevent: KeyboardEvent) {
-    logger.debug("controller_content mustBufferPageKeysForClInput = " + mustBufferPageKeysForClInput)
-    if (mustBufferPageKeysForClInput) {
+    function bufferPageKeyForClInput(keyevent: KeyboardEvent) {
         let isCharacterKey = keyevent.key.length == 1
             && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
         if (isCharacterKey) {
@@ -245,6 +244,10 @@ export function acceptKey(keyevent: KeyboardEvent) {
         keyevent.preventDefault()
         keyevent.stopImmediatePropagation()
         canceller.push(keyevent)
-    } else
+    }
+    logger.debug("controller_content mustBufferPageKeysForClInput = " + mustBufferPageKeysForClInput)
+    if (mustBufferPageKeysForClInput)
+        bufferPageKeyForClInput(keyevent)
+    else
         return generator.next(keyevent)
 }

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -229,14 +229,7 @@ export function acceptKey(keyevent: KeyboardEvent) {
     logger.info("bufferUntilClInputFocused = " + bufferUntilClInputFocused)
     if (bufferUntilClInputFocused) {
         logger.info("Sending keyboardEvent for buffering " + keyevent.key)
-        Messaging.messageOwnTab("commandline_frame", "bufferUntil",
-            [keyevent.code,
-                keyevent.key,
-                keyevent.altKey,
-                keyevent.ctrlKey,
-                keyevent.metaKey,
-                keyevent.shiftKey]
-        );
+        Messaging.messageOwnTab("commandline_frame", "bufferUntil", [keyevent.key]);
         keyevent.preventDefault()
         keyevent.stopImmediatePropagation()
         canceller.push(keyevent)

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -206,7 +206,7 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (exstr.startsWith("fillcmdline ")) { // TODO That's ugly. I need a way to know if this command is going to open the command line. Is there a better way?
+                    if (exstr.startsWith("fillcmdline")) { // TODO That's ugly. I need a way to know if this command is going to open the command line. Is there a better way?
                         logger.debug("Starting buffering of page keys")
                         bufferingPageKeysBeginTime = performance.now()
                         mustBufferPageKeysForClInput = true

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -235,7 +235,7 @@ generator.next()
 /** Feed keys to the ParserController, unless they should be buffered to be later fed to clInput */
 export function acceptKey(keyevent: KeyboardEvent) {
     function bufferPageKeyForClInput(keyevent: KeyboardEvent) {
-        let isCharacterKey = keyevent.key.length == 1
+        const isCharacterKey = keyevent.key.length == 1
             && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
         if (isCharacterKey) {
             bufferedPageKeys.push(keyevent.key);

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -65,6 +65,8 @@ class KeyCanceller {
     }
 
     push(ke: KeyboardEvent) {
+        ke.preventDefault()
+        ke.stopImmediatePropagation()
         this.keyPress.push(ke)
         this.keyUp.push(ke)
     }
@@ -196,8 +198,6 @@ function* ParserController() {
                 )
 
                 if (response.isMatch && keyevent instanceof KeyboardEvent) {
-                    keyevent.preventDefault()
-                    keyevent.stopImmediatePropagation()
                     canceller.push(keyevent)
                 }
 
@@ -241,8 +241,6 @@ export function acceptKey(keyevent: KeyboardEvent) {
             bufferedPageKeys.push(keyevent.key);
             logger.debug("Buffering page keys", bufferedPageKeys)
         }
-        keyevent.preventDefault()
-        keyevent.stopImmediatePropagation()
         canceller.push(keyevent)
     }
     logger.debug("controller_content mustBufferPageKeysForClInput = " + mustBufferPageKeysForClInput)

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -195,6 +195,7 @@ function* ParserController() {
                     if (exstr.startsWith("fillcmdline ")) { // Ugh. That's ugly. I needed a way to know if this command is going to open the cmdline.
                         logger.debug("Setting clInputFocused to false")
                         clInputFocused = false
+                        bufferedClInputKeys = []
                     }
                     break
                 } else {
@@ -221,6 +222,7 @@ Messaging.addListener("cl_input_focused", () => {
     clInputFocused = true
 })
 let clInputFocused: boolean = true
+let bufferedClInputKeys: string[] = []
 export const generator = ParserController() // var rather than let stops weirdness in repl.
 generator.next()
 
@@ -231,8 +233,9 @@ export function acceptKey(keyevent: KeyboardEvent) {
         let isCharacterKey = keyevent.key.length == 1
             && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
         if (isCharacterKey) {
-            logger.debug("Sending keyboardEvent for buffering ", keyevent)
-            Messaging.messageOwnTab("commandline_frame", "bufferUntilClInputFocused", [keyevent.key]);
+            bufferedClInputKeys.push(keyevent.key);
+            logger.debug("Sending keyboardEvent for buffering ", bufferedClInputKeys)
+            Messaging.messageOwnTab("commandline_frame", "bufferUntilClInputFocused", [ bufferedClInputKeys ]);
         }
         keyevent.preventDefault()
         keyevent.stopImmediatePropagation()

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -228,8 +228,12 @@ generator.next()
 export function acceptKey(keyevent: KeyboardEvent) {
     logger.info("bufferUntilClInputFocused = " + bufferUntilClInputFocused)
     if (bufferUntilClInputFocused) {
-        logger.info("Sending keyboardEvent for buffering " + keyevent.key)
-        Messaging.messageOwnTab("commandline_frame", "bufferUntil", [keyevent.key]);
+        let isCharacterKey = keyevent.key.length == 1
+            && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
+        if (isCharacterKey) {
+            logger.info("Sending keyboardEvent for buffering ", keyevent)
+            Messaging.messageOwnTab("commandline_frame", "bufferUntilClInputFocused", [keyevent.key]);
+        }
         keyevent.preventDefault()
         keyevent.stopImmediatePropagation()
         canceller.push(keyevent)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3861,12 +3861,11 @@ export function sleep(time_ms: number) {
 /** @hidden */
 //#content
 export function showcmdline(focus = true) {
-    logger.debug("Called showcmdline")
+    logger.debug("excmds showcmdline()")
     const hidehover = true
     CommandLineContent.show(hidehover)
     let done = Promise.resolve()
     if (focus) {
-        CommandLineContent.focus()
         done = Messaging.messageOwnTab("commandline_frame", "focus")
     }
     return done

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3882,6 +3882,7 @@ export function hidecmdline() {
 export function fillcmdline(...strarr: string[]) {
     const str = strarr.join(" ")
     showcmdline(false)
+    logger.debug("excmds fillcmdline sending fillcmdline to commandline_frame")
     return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true/*trailspace*/, true/*focus*/])
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3861,7 +3861,7 @@ export function sleep(time_ms: number) {
 /** @hidden */
 //#content
 export function showcmdline(focus = true) {
-    logger.info("Called showcmdline")
+    logger.debug("Called showcmdline")
     const hidehover = true
     CommandLineContent.show(hidehover)
     let done = Promise.resolve()

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3882,16 +3882,16 @@ export function hidecmdline() {
 //#content
 export function fillcmdline(...strarr: string[]) {
     const str = strarr.join(" ")
-    showcmdline()
-    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str])
+    showcmdline(false)
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true/*trailspace*/, true/*focus*/])
 }
 
 /** Set the current value of the commandline to string *without* a trailing space */
 //#content
 export function fillcmdline_notrail(...strarr: string[]) {
     const str = strarr.join(" ")
-    showcmdline()
-    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false])
+    showcmdline(false)
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, , false/*trailspace*/, true/*focus*/])
 }
 
 /** Show and fill the command line without focusing it */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3891,7 +3891,7 @@ export function fillcmdline(...strarr: string[]) {
 export function fillcmdline_notrail(...strarr: string[]) {
     const str = strarr.join(" ")
     showcmdline(false)
-    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, , false/*trailspace*/, true/*focus*/])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false/*trailspace*/, true/*focus*/])
 }
 
 /** Show and fill the command line without focusing it */

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3861,6 +3861,7 @@ export function sleep(time_ms: number) {
 /** @hidden */
 //#content
 export function showcmdline(focus = true) {
+    logger.info("Called showcmdline")
     const hidehover = true
     CommandLineContent.show(hidehover)
     let done = Promise.resolve()

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -138,13 +138,6 @@ export function getCommandlineFns(cmdline_state: {
                 )
             cmdline_state.activeCompletions = undefined
             cmdline_state.isVisible = false
-            console.debug("Called hide_and_clear()")
-            cmdline_state.keysFromContentProcess = []
-            cmdline_state.consumedKeyCount = 0
-            cmdline_state.clInputFocused = false
-            cmdline_state.clInputNormalEventsReceived = false
-            cmdline_state.clInputInitialValue = ""
-            cmdline_state.contentProcessKeysReceivedAfterClInputFocused = 0
         },
 
         /**

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -139,8 +139,11 @@ export function getCommandlineFns(cmdline_state: {
             cmdline_state.activeCompletions = undefined
             cmdline_state.isVisible = false
             console.debug("Called hide_and_clear()")
+            cmdline_state.keysFromContentProcess = []
+            cmdline_state.consumedKeyCount = 0
             cmdline_state.clInputFocused = false
             cmdline_state.clInputNormalEventsReceived = false
+            cmdline_state.clInputInitialValue = ""
             cmdline_state.contentProcessKeysReceivedAfterClInputFocused = 0
         },
 

--- a/src/lib/commandline_cmds.ts
+++ b/src/lib/commandline_cmds.ts
@@ -138,6 +138,10 @@ export function getCommandlineFns(cmdline_state: {
                 )
             cmdline_state.activeCompletions = undefined
             cmdline_state.isVisible = false
+            console.debug("Called hide_and_clear()")
+            cmdline_state.clInputFocused = false
+            cmdline_state.clInputNormalEventsReceived = false
+            cmdline_state.contentProcessKeysReceivedAfterClInputFocused = 0
         },
 
         /**

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -15,6 +15,7 @@ export type TabMessageType =
     | "lock"
     | "alive"
     | "tab_changes"
+    | "clInputFocused"
 
 export type NonTabMessageType =
     | "owntab_background"

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -133,7 +133,7 @@ export async function message<
 /** Message the active tab of the currentWindow */
 export async function messageActiveTab(
     type: TabMessageType,
-    command: string,
+    command?: string,
     args?: any[],
 ) {
     return messageTab(await activeTabId(), type, command, args)
@@ -154,7 +154,7 @@ export async function messageTab(
 }
 
 let _ownTabId
-export async function messageOwnTab(type: TabMessageType, command, args?) {
+export async function messageOwnTab(type: TabMessageType, command?, args?) {
     if (_ownTabId === undefined) {
         _ownTabId = await ownTabId()
     }
@@ -165,7 +165,7 @@ export async function messageOwnTab(type: TabMessageType, command, args?) {
 
 export async function messageAllTabs(
     type: TabMessageType,
-    command: string,
+    command?: string,
     args?: any[],
 ) {
     const responses = []

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -16,6 +16,7 @@ export type TabMessageType =
     | "alive"
     | "tab_changes"
     | "buffered_page_keys"
+    | "commandline_frame_ready_to_receive_messages"
 
 export type NonTabMessageType =
     | "owntab_background"

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -15,7 +15,7 @@ export type TabMessageType =
     | "lock"
     | "alive"
     | "tab_changes"
-    | "cl_input_focused"
+    | "buffered_page_keys"
 
 export type NonTabMessageType =
     | "owntab_background"

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -15,7 +15,7 @@ export type TabMessageType =
     | "lock"
     | "alive"
     | "tab_changes"
-    | "clInputFocused"
+    | "cl_input_focused"
 
 export type NonTabMessageType =
     | "owntab_background"

--- a/src/lib/messaging.ts
+++ b/src/lib/messaging.ts
@@ -15,7 +15,7 @@ export type TabMessageType =
     | "lock"
     | "alive"
     | "tab_changes"
-    | "buffered_page_keys"
+    | "stop_buffering_page_keys"
     | "commandline_frame_ready_to_receive_messages"
 
 export type NonTabMessageType =


### PR DESCRIPTION
Typing `tgithub` does not always result in the command line input (clInput) receiving `tabopen github`. Sometimes, the first few characters following the command end up missing (for example, clInput will contain `tabopen thub`). 

1. When typing `t` in the page, the page process (controller_content.ts) sends `fillcmdline t` to the command line process.
2. In the command line process, `fillcmdline()` (commandline_frame.ts) triggers the focusing of clInput.
3. Once clInput is focused it can start receiving native keyboard events via a regular keydown listener.

From 2. up until 3., the page has the focus and can receive keyboard events (if the user is fast enough and/or their machine is slow enough). Those events are lost since they are never passed to the command line process.

The proposed solution makes the page (controller_content.ts) start buffering typed characters as soon as `fillcmdline t` is sent to the command line process, up until clInput is focused (commandline_frame.ts). When clInput is focused, the command line process consumes the content of the buffer and places it into clInput.

Possible improvement ideas:
- buffer non-character key presses like backspace (from the page process), and manually process them in the command line process
- if clInput receives a native Enter key event that is going to execute the command, delay its processing until the page keys buffer has been consumed and the command is actually complete. Same for tab key.
