### PR TITLE
Add historycmdcount* configs to limit cmdHistory size

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -66,6 +66,16 @@ controller.setExCmds({
     hint: HintingCmds,
 })
 
+// limit the command history size
+setTimeout(async () => {
+    const alert = await config.getAsync('historycmdcountalert')
+    const limit = await config.getAsync('historycmdcountlimit')
+    const cmdHistory = state.cmdHistory
+    if (cmdHistory.length > alert) {
+        state.cmdHistory = cmdHistory.slice(-limit)
+    }
+}, 15 * 1000)
+
 // {{{ tri.contentLocation
 // When loading the background, use the active tab to know what the current content url is
 browser.tabs.query({ currentWindow: true, active: true }).then(t => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1172,6 +1172,16 @@ export class default_config {
     historyresults = 50
 
     /**
+     * Reduce the size (line count) of ex command history if the size is larger than the historycmdcountalert when tridactyl started. The size will be reduce to the historycmdcountlimit.
+     */
+    historycmdcountalert = 768
+
+    /**
+     * Reduce the size (line count) of ex command history if the size is larger than the historycmdcountalert when tridactyl started. The size will be reduce to the historycmdcountlimit.
+     */
+    historycmdcountlimit = 512
+
+    /**
      * When displaying bookmarks in history completions, how many page views to pretend they have.
      */
     bmarkweight = 100


### PR DESCRIPTION
Add config `historycmdcountalert` and `historycmdcountlimit` to limit `state.cmdHistory` size.

If `state.cmdHistory` size is larger then the historycmdcountalert when tridactyl start, tridactyl will reduce its size to the historycmdcountlimit.

The cmdHistory size check has a 15 seconds delay,
so the start up will not be to slow.

Feel free to change to a better config name or move the code snippet.