### PR TITLE
Fix command name in docs

### DIFF
--- a/src/static/clippy/2-normal_mode.md
+++ b/src/static/clippy/2-normal_mode.md
@@ -31,7 +31,7 @@ Tridactyl uses a similar notation to Vim for keys with modifiers: `<C-x>` means 
 
 *   `<C-v>` sends the next keystroke to the current website, bypassing bindings
 
-All the keys in normal mode are bound to commands; for example, `j` is bound to `scrolline 10`. If you are ever curious as to what a key sequence does in normal mode, you can simply use `:bind [keys]` and the command line will tell you to which command they are bound.
+All the keys in normal mode are bound to commands; for example, `j` is bound to `scrollline 10`. If you are ever curious as to what a key sequence does in normal mode, you can simply use `:bind [keys]` and the command line will tell you to which command they are bound.
 
 ## Browser-wide binds
 


### PR DESCRIPTION
Missing `l` in `scrolline` command.