### PR TITLE
Make `tabgrab` and `tabpush` move to next tabgrab

### DIFF
--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -84,6 +84,15 @@ export async function activeTab() {
     )[0]
 }
 
+export async function activeTabOnWindow(windowId?: number) {
+    return (
+        await browser.tabs.query({
+            windowId: windowId,
+            active: true
+        })
+    )[0]
+}
+
 export async function activeTabId() {
     return (await activeTab()).id
 }


### PR DESCRIPTION
Now `tabgrab` and `tabpush` will move the tab next to the current tab, except if the `tabopenpos` setting is set to `"last"`.

In order to make `tabpush` work, I had to create an additional function to get the active tab for a given window ID.

Closes #4773 