### PR TITLE
Add additional sh lint check for incompatible sed -i cases

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -5,5 +5,10 @@ if [ -x "$(command -v shellcheck)" ]; then
 else
 	echo "Warning: shellcheck is not installed, skipping shell scripts"
 fi
+incompatible_sed=$(! grep -RPn --color=always --exclude-dir=node_modules --exclude-dir=.git 'sed(?:\s-\w+)*\s-i(?!\S|\s"")')
+if [ "$incompatible_sed" ]; then
+	printf "\nWarning: avoid non-portable sed flag -i without backup extension, use -i.bak\n"
+	printf "%s\n\n" "$incompatible_sed"
+fi
 yarn run lint
 "$(yarn bin)/eslint" --rulesdir custom-eslint-rules --ext .ts .

--- a/scripts/changelog_mangler.sh
+++ b/scripts/changelog_mangler.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Replace issue numbers in brackets eg (#1337) with a link to the issue on the repository
-sed -i 's; (#\([0-9]*\)); ([#\1](https://github.com/tridactyl/tridactyl/issues/\1));g' CHANGELOG.md
+sed -i.bak 's; (#\([0-9]*\)); ([#\1](https://github.com/tridactyl/tridactyl/issues/\1));g' CHANGELOG.md

--- a/scripts/make_tutorial.sh
+++ b/scripts/make_tutorial.sh
@@ -16,5 +16,5 @@ do
     sed "/REPLACETHIS/,$ d" tutor.template.html > "$dest$fileroot.html"
     "$(yarn bin)/marked" "$page" >> "$dest$fileroot.html"
     sed "1,/REPLACETHIS/ d" tutor.template.html >> "$dest$fileroot.html"
-    sed -i "s|\.md|.html|g" "$dest$fileroot.html"
+    sed -i.bak "s|\.md|.html|g" "$dest$fileroot.html"
 done


### PR DESCRIPTION
## Changes
Fixes: #4889

Introduces additional warning lints if contributor uses only a GNU-compliant version of sed in-place command. An example of this warning as shown below (shows which scripts and line numbers).

![SCR-20240120-mxxq](https://github.com/tridactyl/tridactyl/assets/26207348/9c34b565-1538-4e30-bacb-50c85e1126ad)

## Test cases
[Regexr test cases](https://regexr.com/7qntv)

## Additional Discussion
* Because linting is done on ubuntu-latest (which always used GNU grep), I made the decision to keep the command to find theses cases simple instead portable. [See this Stack Overflow thread for more information.](https://stackoverflow.com/a/6565519/9262657)
* Depending on future incompatibility problems with other coreutil commands, it is worth thinking about whether we want to have a solution that can do this sort of linting for us. Our current script linter `shellcheck` does not check for these sort of compatibility issues or even detects userspaces. [See this issue on shellcheck for more information](https://github.com/koalaman/shellcheck/issues/2902)
    * I will stipulate that this only becomes a real problem for scripts called on from `scripts/build.sh` so every time that yarn run build or any other alias runs this script. So efforts should probably be focused on just checking or minimizing the incompatibility cases.