### PR TITLE
Expose node-qrcode as global variable in text2qr command page

### DIFF
--- a/src/qrCodeGenerator.ts
+++ b/src/qrCodeGenerator.ts
@@ -1,8 +1,9 @@
 import QRCode from "../vendor/qrcode/qrcode"
 import * as Logging from "@src/lib/logging"
-import {browserBg, activeTab} from "./lib/webext"
+import { browserBg, activeTab } from "./lib/webext"
 
 const logger = new Logging.Logger("qrcode-display")
+window["QRCode"] = QRCode
 
 function displayError() {
     const errorDisplay: HTMLDivElement =
@@ -33,12 +34,14 @@ function setUpPage() {
     })
 
     if (timeout && timeout > 0) {
-        setTimeout(function() {
-            activeTab().then((tabInfo) => {
-                browserBg.tabs.remove(tabInfo.id)
-            }).catch((error) => {
-                logger.error("Unable to close tab" + error)
-            })
+        setTimeout(function () {
+            activeTab()
+                .then(tabInfo => {
+                    browserBg.tabs.remove(tabInfo.id)
+                })
+                .catch(error => {
+                    logger.error("Unable to close tab" + error)
+                })
         }, timeout * 1000)
     }
 }


### PR DESCRIPTION
so user can do whatever they want with it.

web-driver test maybe because I does not install the native messanger.
ts-lint fail, I don't know how to fix it.

```
~/tridactyl/src/qrCodeGenerator.ts
  1:1  error  Definition for rule 'unsupported-apis' was not found  unsupported-apis

✖ 1 problem (1 error, 0 warnings)
```