### PR TITLE
Fix issue #4106

### DIFF
--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -6,7 +6,6 @@ span.TridactylHint {
     font-size: var(--tridactyl-hintspan-font-size) !important;
     font-weight: var(--tridactyl-hintspan-font-weight) !important;
     color: var(--tridactyl-hintspan-fg) !important;
-    background-color: var(--tridactyl-hintspan-bg) !important;
     border-color: var(--tridactyl-hintspan-border-color) !important;
     border-width: var(--tridactyl-hintspan-border-width) !important;
     min-width: 0.75em !important;

--- a/src/static/themes/dark/dark.css
+++ b/src/static/themes/dark/dark.css
@@ -306,3 +306,8 @@
 /* a:link:visited { */
 /*     --tridactyl-photon-colours-in-content-link-color-visited: #0a8dff; */
 /* } */
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -130,3 +130,8 @@
 
     --tridactyl-externaledit-bg: var(--tridactyl-logo) no-repeat center;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/greenmat/greenmat.css
+++ b/src/static/themes/greenmat/greenmat.css
@@ -95,3 +95,8 @@
     color: var(--tridactyl-fg);
     font-weight: bold;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/halloween/halloween.css
+++ b/src/static/themes/halloween/halloween.css
@@ -155,3 +155,8 @@ span.TridactylStatusIndicator {
     display: inline-block;
     overflow: hidden;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/midnight/midnight.css
+++ b/src/static/themes/midnight/midnight.css
@@ -127,3 +127,8 @@
     font-weight: 200 !important;
     padding: 5px !important;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/quake/quake.css
+++ b/src/static/themes/quake/quake.css
@@ -31,3 +31,8 @@
     box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 15px !important;
     opacity: 0.9;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/quakelight/quakelight.css
+++ b/src/static/themes/quakelight/quakelight.css
@@ -13,3 +13,8 @@
     left: 0% !important;
     box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 15px !important;
 }
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}

--- a/src/static/themes/shydactyl/shydactyl.css
+++ b/src/static/themes/shydactyl/shydactyl.css
@@ -121,3 +121,8 @@
 /* #Shydactyl-insert { */
 /*  border-color: yellow !important; */
 /* } */
+
+/* Delete to hide element highlighting */
+span.TridactylHint {
+    background-color: var(--tridactyl-hintspan-bg) !important;
+}


### PR DESCRIPTION
I guess this is a bit hacky, but removing the background colour under hint.css will make it easier for people to create their own themes should they want to disable element highlighting and keep the original background colour of the element.

I added the element highlighting to the existing themes instead. So the authors of those themes preferences are still preserved. I added a comment so anyone editing an existing theme knows to delete that section if they don't want element highlighting disabled.