### PR TITLE
Add tabnextmru bound to ctrl+7

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2628,6 +2628,20 @@ export async function tabprev(increment = 1) {
 }
 
 /**
+ * Switch to the previously used tab, ignoring any tabs used within the last 10 seconds. Handy for flicking through previous tabs.
+ */
+//#background
+export async function tabnextmru() {
+    return browser.tabs.query({ currentWindow: true, hidden: false }).then(tabs => {
+        tabs.sort((a, b) => b.lastAccessed - a.lastAccessed)
+        console.log(tabs)
+        const mru_ish = tabs.findIndex(t => Date.now() - t.lastAccessed - 10000 > 0)
+        console.log(mru_ish)
+        return browser.tabs.update(tabs[(mru_ish > -1 ? mru_ish : 1)].id, { active: true })
+    })
+}
+
+/**
  * Pushes the current tab to another window. Only works for windows of the same type
  * (can't push a non-private tab to a private window or a private tab to
  * a non-private window).

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -428,6 +428,7 @@ export class default_config {
     browsermaps = {
         "<C-,>": "escapehatch",
         "<C-6>": "tab #",
+        "<C-7>": "tabnextmru",
         // "<CS-6>": "tab #", // banned by e2e tests
     }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,6 +37,10 @@
             }
         },
         "command_4": {
+            "suggested_key": {
+                "default": "MacCtrl+7",
+                "windows": "Alt+7"
+            },
             "description": "Internal use. See `:help bind`. Use `:bind --mode=browser` to change - do not change here."
         },
         "command_5": {


### PR DESCRIPTION
Related: #4580

press ctrl+7 repeatedly to navigate through previously used tabs. Any tab used within the last 10 seconds is ignored.

it works pretty well, I think. But it's a bit confusing that it messes up the order of the tabs in `:tab` with `:set tabsort mru` once you've finished.

Essentially what I want to do is:

1) flick through the 2-4 most recently used tabs to find the one I want
2) have ctrl+6 get me back to the tab I was first on, then use ctrl+6 repeatedly to switch between those two tabs.

I can do 1) but not 2) because it always becomes the last-but-one tab that I looked at when trying to find the tab I wanted.

I don't know why `b[tpress <Tab> repeatedly then <CR>]` is unsatisfying to me because in theory it should be a good enough solution.

Maybe when we have keydown/keyup binds I could have it so that:

1. hold down control
2. tap 7, `:tab` opens with first completion selected
3. tap 7 repeatedly to cycle selection
4. release control to accept selection and go to tab

But I'm not sure that is the real problem. Surely it can't just be the keybinds that are wrong...