### PR TITLE
allow focusinput focus node in shadow-root

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2520,7 +2520,7 @@ export function focusinput(nth: number | string) {
 
     // either a number (not special) or we failed to find a special input when
     // asked and falling back is acceptable
-    if ((!inputToFocus || !document.contains(inputToFocus)) && fallbackToNumeric) {
+    if ((!inputToFocus || !inputToFocus.isConnected) && fallbackToNumeric) {
         const index = isNaN(nth as number) ? 0 : (nth as number)
         inputToFocus = DOM.getNthElement(INPUTTAGS_selectors, index, [DOM.isSubstantial])
     }


### PR DESCRIPTION
It seem that document.contains is to check whether 
the node is removed, but not to consider about the shadow root.
@glacambre right? I see you in 4119f0e54d3aafa3735f8c30d69446023846059a .

The isConnected property mean whether the node is
connect to a document or a shadow root that
connected to the root document.
It is enough to check whether the node is
removed.