### PR TITLE
Reinsert iframe on bad websites that delete it (mostly ones using react server-side rendering)

### DIFF
--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -17,17 +17,21 @@ const cmdline_logger = new Logger("cmdline")
 
 // inject the commandline iframe into a content page
 
-const cmdline_iframe = window.document.createElementNS(
-    "http://www.w3.org/1999/xhtml",
-    "iframe",
-) as HTMLIFrameElement
-cmdline_iframe.className = "cleanslate"
-cmdline_iframe.setAttribute(
-    "src",
-    browser.runtime.getURL("static/commandline.html"),
-)
-cmdline_iframe.setAttribute("id", "cmdline_iframe")
-cmdline_iframe.setAttribute("loading", "lazy")
+let cmdline_iframe: HTMLIFrameElement
+function makeIframe() {
+    cmdline_iframe = window.document.createElementNS(
+        "http://www.w3.org/1999/xhtml",
+        "iframe",
+    ) as HTMLIFrameElement
+    cmdline_iframe.className = "cleanslate"
+    cmdline_iframe.setAttribute(
+        "src",
+        browser.runtime.getURL("static/commandline.html"),
+    )
+    cmdline_iframe.setAttribute("id", "cmdline_iframe")
+    cmdline_iframe.setAttribute("loading", "lazy")
+}
+makeIframe()
 
 let enabled = false
 
@@ -41,6 +45,16 @@ async function init() {
         enabled = true
         // first theming of page root
         await theme(window.document.querySelector(":root"))
+        reactIsCrap()
+    }
+}
+async function reactIsCrap(){
+    while(true){
+        if (cmdline_iframe.contentWindow == null) {
+            makeIframe()
+            document.documentElement.appendChild(cmdline_iframe)
+        }
+        await new Promise(resolve => setTimeout(resolve, 500))
     }
 }
 


### PR DESCRIPTION
todo:

- check that a mutation observer couldn't do the same thing more cheaply (doesn't seem to work on the iframe itself but maybe it would on a parent?)
- consider renaming the function
- if mutation observer doesn't work, make it like `preventautofocusjackhammer` and have it only run on websites where config tells it to


@glacambre sorry to ping you but I think you have some knowledge of MutationObservers - do you know how we can use them to tell when our iframe has been vandalised?