### PR TITLE
Fix CI Pipeline & E2E Tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
@@ -43,7 +43,7 @@ jobs:
       run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - name: Setup cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -51,42 +51,19 @@ jobs:
           ${{ runner.os }}-yarn-
 
     - name: Install deps
-      run: |
-        yarn install
-    - name: Install Firefox Dev Edition (Linux)
-      if: matrix.browser == 'firefox' && matrix.os == 'ubuntu'
-      run: |
-        sudo yarn global add get-firefox
-        get-firefox --platform linux --branch devedition --extract --target $HOME
-        echo "$HOME/firefox" >> $GITHUB_PATH
-    - name: Install Firefox ESR (Linux)
-      if: matrix.browser == 'firefoxesr' && matrix.os == 'ubuntu'
-      run: |
-        sudo yarn global add get-firefox
-        get-firefox --platform linux --branch esr --extract --target $HOME
-        echo "$HOME/firefox" >> $GITHUB_PATH
-    - name: Install Firefox Dev Edition (MacOS)
-      if: matrix.browser == 'firefox' && matrix.os == 'macos'
-      run: |
-        brew install --cask homebrew/cask-versions/firefox-developer-edition
-        echo "/Applications/Firefox Developer Edition.app/Contents/MacOS/" >> $GITHUB_PATH
-    - name: Install Firefox Dev Edition (Windows)
-      if: matrix.browser == 'firefox' && matrix.os == 'windows'
-      run: |
-        choco install firefox-dev --pre
-        echo "C:\Program Files\Firefox Dev Edition" >> $GITHUB_PATH
-    - name: Install Firefox ESR (Windows)
-      if: matrix.browser == 'firefoxesr' && matrix.os == 'windows'
-      run: |
-        choco install firefoxesr
-        echo "C:\Program Files\Mozilla Firefox" >> $GITHUB_PATH
+      run: yarn install
 
+    - name: Setup Firefox
+      uses: browser-actions/setup-firefox@v1
+      with:
+        firefox-version: ${{ matrix.browser == 'firefox' && 'latest' || 'latest-esr' }}
+  
     - name: Print Firefox version (Unix-like)
       if: matrix.os == 'ubuntu' || matrix.os == 'macos'
       run: firefox --version
 
     - name: Build and test (Firefox)
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       if: matrix.browser != 'chrome'
       env:
         HEADLESS: 1
@@ -97,9 +74,3 @@ jobs:
         shell: bash
         command: |
           yarn run clean && yarn run build --old-native && yarn make-zip && yarn jest
-    # - name: Test (Chrome, Linux)
-    #   if: matrix.browser == 'chrome' && matrix.os == 'ubuntu'
-    #   run: xvfb-run --auto-servernum npm run jest -- ${{ matrix.browser }} || xvfb-run --auto-servernum npm run jest -- ${{ matrix.browser }}
-    # - name: Test (Chrome, Windows/MacOs)
-    #   if: matrix.browser == 'chrome' && matrix.os != 'ubuntu'
-    #   run: npm run jest -- ${{ matrix.browser }} || npm run jest -- ${{ matrix.browser }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
       env:
         HEADLESS: 1
       with: 
-        max_attempts: 4
+        max_attempts: ${{ github.event_name == 'pull_request' && 5 || 10 }}
         timeout_minutes: 10
         retry_wait_seconds: 10
         shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,19 +36,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      shell: bash
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-    - name: Setup cache
-      uses: actions/cache@v4
+    - uses: actions/setup-node@v4
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+        node-version: 22
+        cache: 'yarn'
 
     - name: Install deps
       run: yarn install
@@ -64,11 +55,10 @@ jobs:
 
     - name: Build and test (Firefox)
       uses: nick-fields/retry@v3
-      if: matrix.browser != 'chrome'
       env:
         HEADLESS: 1
       with: 
-        max_attempts: 40
+        max_attempts: 4
         timeout_minutes: 10
         retry_wait_seconds: 10
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         step: [lint, unit, mozilla]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup
       run: yarn install
     - name: ${{ matrix.step }}

--- a/e2e_tests/e2e.test.ts
+++ b/e2e_tests/e2e.test.ts
@@ -6,40 +6,40 @@ import * as path from "path"
 import { Browser, Builder, By } from "selenium-webdriver"
 import { Options, Driver } from "selenium-webdriver/firefox"
 import * as Until from "selenium-webdriver/lib/until"
-import { getNewestFileIn, sendKeys } from "./utils"
+import { getNewestFileIn, sendKeys } from "./utils";
 
 jest.setTimeout(100000)
 
 // API docs because I waste too much time looking for them every time I go back to this:
 // https://seleniumhq.github.io/selenium/docs/api/javascript/
 
+
 describe("webdriver", () => {
+
     function iframeLoaded(driver) {
         return driver.wait(Until.elementLocated(By.id("cmdline_iframe")))
     }
-
-    let driver: Driver
+    
+    let driver: Driver;
     beforeEach(async () => {
-        driver = await getDriver()
-    })
+        driver = await getDriver();
+    });
 
     afterEach(async () => {
-        await killDriver(driver)
-    })
+        await killDriver(driver);
+    });
 
     async function getDriver() {
-        const extensionPath = await getNewestFileIn(
-            path.resolve("web-ext-artifacts"),
-        )
+        const extensionPath = await getNewestFileIn(path.resolve("web-ext-artifacts"))
         if (extensionPath === undefined) {
-            throw new Error("Couldn't find extension path")
+            throw new Error("Couldn't find extension path");
         }
 
-        const options = new Options()
+        const options = (new Options())
         if (env["HEADLESS"]) {
-            options.addArguments("--headless")
+            options.addArguments("--headless");
         }
-        const driver = new Builder()
+        const driver= new Builder()
             .forBrowser(Browser.FIREFOX)
             .setFirefoxOptions(options)
             .build() as unknown as Driver
@@ -56,9 +56,7 @@ describe("webdriver", () => {
         // First, find out what profile the driver is using
         const profiles = fs.readdirSync(rootDir).map(p => path.join(rootDir, p))
         const driver = await getDriver()
-        const newProfiles = fs
-            .readdirSync(rootDir)
-            .map(p => path.join(rootDir, p))
+        const newProfiles = fs.readdirSync(rootDir).map(p => path.join(rootDir, p))
             .filter(p => p.match("moz") && !profiles.includes(p))
 
         // Tridactyl's tmp profile detection is broken on windows and OSX
@@ -73,61 +71,42 @@ describe("webdriver", () => {
     async function killDriver(driver: Driver) {
         try {
             await driver.close()
-        } catch (e) {}
+        } catch(e) {}
         try {
             await driver.quit()
-        } catch (e) {}
+        } catch(e) {}
     }
 
-    async function untilTabUrlMatches(
-        driver: Driver,
-        tabId: number,
-        pattern: string | RegExp,
-    ) {
+    async function untilTabUrlMatches(driver: Driver, tabId: number, pattern: string | RegExp) {
         let match
         do {
-            const result = await driver.executeScript(
-                `return tri.browserBg.tabs.get(${tabId})`,
-            )
-            if (
-                typeof result === "object" &&
-                result !== null &&
-                "url" in result
-            ) {
-                match = (result as { url: string }).url.match(pattern)
+            const result = await driver.executeScript(`return tri.browserBg.tabs.get(${tabId})`);
+            if (typeof result === 'object' && result !== null && 'url' in result) {
+                match = (result as { url: string }).url.match(pattern);
             } else {
-                throw new Error("Unexpected result structure")
+                throw new Error('Unexpected result structure');
             }
         } while (!match)
-        return match
+            return match
     }
 
-    async function newTabWithoutChangingOldTabs(driver, callback) {
-        const tabsBefore = await driver.executeScript(
-            "return tri.browserBg.tabs.query({})",
-        )
-        const result = await callback(tabsBefore)
+    async function newTabWithoutChangingOldTabs (driver, callback) {
+        const tabsBefore = await driver.executeScript("return tri.browserBg.tabs.query({})")
+        const result = await callback(tabsBefore);
         const tabsAfter = await driver.wait(async () => {
             let tabsAfter
             do {
-                tabsAfter = await driver.executeScript(
-                    "return tri.browserBg.tabs.query({})",
-                )
+                tabsAfter = await driver.executeScript("return tri.browserBg.tabs.query({})")
             } while (tabsAfter.length == tabsBefore.length)
-            return tabsAfter
+                return tabsAfter
         })
         // A single new tab has been created
         expect(tabsAfter.length).toBe(tabsBefore.length + 1)
 
         // None of the previous tabs changed, except maybe for their index
-        const newtab = tabsAfter.find(
-            tab2 => !tabsBefore.find(tab => tab.id == tab2.id),
-        )
+        const newtab = tabsAfter.find(tab2 => !tabsBefore.find(tab => tab.id == tab2.id))
         const notNewTabs = tabsAfter.slice()
-        notNewTabs.splice(
-            tabsAfter.findIndex(tab => tab == newtab),
-            1,
-        )
+        notNewTabs.splice(tabsAfter.findIndex(tab => tab == newtab), 1)
         const ignoreValues = {
             active: false, // the previously-active tab isn't necessarily active anymore
             highlighted: true, // changing tabs changes highlights
@@ -143,43 +122,35 @@ describe("webdriver", () => {
     }
 
     // A simple ternany doesn't work inline :(
-    function testbutskipplatforms(...platforms) {
+    function testbutskipplatforms(...platforms){
         if (platforms.includes(os.platform())) {
             return test.skip
         }
         return test
     }
 
+
     test("`:rssexec` works", async () => {
         try {
-            await sendKeys(
-                driver,
-                ":set rsscmd js " +
-                    "const elem=document.createElement('span');" +
-                    "elem.id='rsscmdExecuted';" +
-                    "elem.innerText=`%u`;" +
-                    "document.body.appendChild(elem)<CR>",
-            )
+            await sendKeys(driver, ":set rsscmd js "
+                + "const elem=document.createElement('span');"
+                + "elem.id='rsscmdExecuted';"
+                + "elem.innerText=`%u`;"
+                + "document.body.appendChild(elem)<CR>")
 
             // First, make sure completions are offered
-            await driver.get(
-                "file:///" + process.cwd() + "/e2e_tests/html/rss.html",
-            )
+            await driver.get("file:///" + process.cwd() + "/e2e_tests/html/rss.html")
             const iframe = await iframeLoaded(driver)
             await sendKeys(driver, ":rssexec ")
             await driver.switchTo().frame(iframe)
-            const elements = await driver.findElements(
-                By.className("RssCompletionOption"),
-            )
+            const elements = await driver.findElements(By.className("RssCompletionOption"))
             expect(elements.length).toBeGreaterThan(3)
             const url = await elements[0].getAttribute("innerText")
 
             // Then, make sure rsscmd is executed and has the right arguments
             await sendKeys(driver, "<Tab><CR>")
             await (driver.switchTo() as any).parentFrame()
-            const elem = await driver.wait(
-                Until.elementLocated(By.id("rsscmdExecuted")),
-            )
+            const elem = await driver.wait(Until.elementLocated(By.id("rsscmdExecuted")))
             expect(url).toMatch(await elem.getAttribute("innerText"))
         } catch (e) {
             fail(e)
@@ -188,19 +159,12 @@ describe("webdriver", () => {
 
     test("`:editor` works", async () => {
         try {
-            const addedText =
-                "There are %l lines and %c characters in this textarea."
+            const addedText = "There are %l lines and %c characters in this textarea."
 
             if (os.platform() == "win32") {
-                await sendKeys(
-                    driver,
-                    `:set editorcmd echo | set /p text="${addedText}" >> %f<CR>`,
-                )
+                await sendKeys(driver, `:set editorcmd echo | set /p text="${addedText}" >> %f<CR>`)
             } else {
-                await sendKeys(
-                    driver,
-                    `:set editorcmd /bin/echo -n '${addedText}' >> %f<CR>`,
-                )
+                await sendKeys(driver, `:set editorcmd /bin/echo -n '${addedText}' >> %f<CR>`)
             }
 
             const areaId = "editorTest"
@@ -213,71 +177,47 @@ describe("webdriver", () => {
             const text = "This is a line\nThis is another\nThis is a third."
             await sendKeys(driver, text + "<C-i>")
             await driver.sleep(1000)
-            expect(
-                await driver.executeScript(
-                    `return document.getElementById("${areaId}").value`,
-                ),
-            ).toEqual(
-                text +
-                    addedText
-                        .replace("%l", "3")
-                        .replace("%c", "" + text.split("\n")[2].length),
-            )
+            expect(await driver.executeScript(`return document.getElementById("${areaId}").value`))
+                .toEqual(text + addedText.replace("%l", "3").replace("%c", "" + text.split("\n")[2].length))
         } catch (e) {
             fail(e)
         }
     })
 
     testbutskipplatforms("darwin")("`:guiset` works", async () => {
-        const { driver, newProfiles } = await getDriverAndProfileDirs()
-        try {
-            // Then, make sure `:guiset` is offering completions
-            const iframe = await iframeLoaded(driver)
-            await sendKeys(driver, ":guiset ")
-            await driver.switchTo().frame(iframe)
-            const elements = await driver.findElements(
-                By.className("GuisetCompletionOption"),
-            )
-            expect(elements.length).toBeGreaterThan(0)
+            const { driver, newProfiles } = await getDriverAndProfileDirs()
+            try {
+                // Then, make sure `:guiset` is offering completions
+                const iframe = await iframeLoaded(driver)
+                await sendKeys(driver, ":guiset ")
+                await driver.switchTo().frame(iframe)
+                const elements = await driver.findElements(By.className("GuisetCompletionOption"))
+                expect(elements.length).toBeGreaterThan(0)
 
-            // Use whatever the first suggestion is
-            await sendKeys(driver, "<Tab> <Tab><CR>")
-            await driver.sleep(2000)
-            expect(
-                await driver.executeScript(
-                    `return document.getElementById("tridactyl-input").value`,
-                ),
-            ).toEqual(
-                "userChrome.css written. Please restart Firefox to see the changes.",
-            )
-            expect(
-                newProfiles.find(p =>
-                    fs
-                        .readdirSync(path.join(p, "chrome"))
-                        .find(files => files.match("userChrome.css$")),
-                ),
-            ).toBeDefined()
-        } catch (e) {
-            fail(e)
-        } finally {
-            await killDriver(driver)
-        }
+                // Use whatever the first suggestion is
+                await sendKeys(driver, "<Tab> <Tab><CR>")
+                await driver.sleep(2000)
+                expect(await driver.executeScript(`return document.getElementById("tridactyl-input").value`))
+                .toEqual("userChrome.css written. Please restart Firefox to see the changes.")
+                expect(newProfiles.find(p => fs
+                                        .readdirSync(path.join(p, "chrome"))
+                                        .find(files => files.match("userChrome.css$")))
+                      ).toBeDefined()
+            } catch (e) {
+                fail(e)
+            } finally {
+                await killDriver(driver)
+            }
     })
 
     test("`:colourscheme` works", async () => {
         try {
-            expect(
-                await driver.executeScript(
-                    `return document.documentElement.className`,
-                ),
-            ).toMatch("TridactylOwnNamespace TridactylThemeDefault")
+            expect(await driver.executeScript(`return document.documentElement.className`))
+                .toMatch("TridactylOwnNamespace TridactylThemeDefault")
             await sendKeys(driver, ":colourscheme dark<CR>")
             await driver.sleep(100)
-            expect(
-                await driver.executeScript(
-                    `return document.documentElement.className`,
-                ),
-            ).toMatch("TridactylOwnNamespace TridactylThemeDark")
+            expect(await driver.executeScript(`return document.documentElement.className`))
+                .toMatch("TridactylOwnNamespace TridactylThemeDark")
         } catch (e) {
             fail(e)
         }
@@ -288,9 +228,7 @@ describe("webdriver", () => {
         try {
             await sendKeys(driver, `:setpref a.b.c "d"<CR>`)
             await driver.sleep(2000)
-            const file = fs.readFileSync(path.join(newProfiles[0], "user.js"), {
-                encoding: "utf-8",
-            })
+            const file = fs.readFileSync(path.join(newProfiles[0], "user.js"), { encoding: "utf-8" })
             expect(file).toMatch(/user_pref\("a.b.c", "d"\);/)
         } catch (e) {
             fail(e)
@@ -298,20 +236,13 @@ describe("webdriver", () => {
     })
 
     test("`:tabopen<CR>` opens the newtab page.", async () => {
-        return newTabWithoutChangingOldTabs(driver, async tabsBefore => {
+        return newTabWithoutChangingOldTabs(driver, async (tabsBefore) => {
             await sendKeys(driver, ":tabopen<CR>")
         }).then(async ([newtab, _]) => {
             // The new tab is active
             expect(newtab.active).toEqual(true)
             // Its url is the newtab page's url
-            await driver.wait(
-                untilTabUrlMatches(
-                    driver,
-                    newtab.id,
-                    new RegExp("moz-extension://.*/static/newtab.html"),
-                ),
-                10000,
-            )
+            await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("moz-extension://.*/static/newtab.html")), 10000)
         })
     })
 
@@ -320,10 +251,7 @@ describe("webdriver", () => {
             await sendKeys(driver, ":tabopen https://example.org<CR>")
         }).then(async ([newtab, _]) => {
             expect(newtab.active).toEqual(true)
-            await driver.wait(
-                untilTabUrlMatches(driver, newtab.id, "https://example.org"),
-                10000,
-            )
+            await driver.wait(untilTabUrlMatches(driver, newtab.id, "https://example.org"), 10000)
         })
     })
 
@@ -332,78 +260,71 @@ describe("webdriver", () => {
             await sendKeys(driver, ":tabopen qwant https://example.org<CR>")
         }).then(async ([newtab, _]) => {
             expect(newtab.active).toEqual(true)
-            await driver.wait(
-                untilTabUrlMatches(
-                    driver,
-                    newtab.id,
-                    new RegExp("^https://www.qwant.com/.*example.org"),
-                ),
-                10000,
-            )
+            await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.qwant.com/.*example.org")), 10000)
         })
     })
 
-    //     test("`:tabopen test<CR>` opens google.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen test<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(true)
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/.*test")), 10000)
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen test<CR>` opens google.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen test<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(true)
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/.*test")), 10000)
+//         }).finally(() => killDriver(driver))
+//     })
 
-    //     test("`:tabopen example.org<CR>` opens example.org.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen example.org<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(true)
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "example.org"), 10000)
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen example.org<CR>` opens example.org.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen example.org<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(true)
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "example.org"), 10000)
+//         }).finally(() => killDriver(driver))
+//     })
 
-    //     test("`:tabopen search duckduckgo<CR>` opens google.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen search duckduckgo<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(true)
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*duckduckgo")), 10000)
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen search duckduckgo<CR>` opens google.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen search duckduckgo<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(true)
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*duckduckgo")), 10000)
+//         }).finally(() => killDriver(driver))
+//     })
 
-    //     test("`:tabopen -b about:blank<CR>` opens a background tab.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen -b about:blank<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(false)
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen -b about:blank<CR>` opens a background tab.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen -b about:blank<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(false)
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
+//         }).finally(() => killDriver(driver))
+//     })
 
-    //     test("`:tabopen -c work about:blank<CR>` opens about:blank in a container.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen -c work about:blank<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(true)
-    //             expect(newtab.cookieStoreId).toMatch("firefox-container-")
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen -c work about:blank<CR>` opens about:blank in a container.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen -c work about:blank<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(true)
+//             expect(newtab.cookieStoreId).toMatch("firefox-container-")
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
+//         }).finally(() => killDriver(driver))
+//     })
 
-    //     test("`:tabopen -b -c work search qwant<CR>` opens about:blank in a container.", async () => {
-    //         const driver = await getDriver()
-    //         return newTabWithoutChangingOldTabs(driver, async () => {
-    //             await sendKeys(driver, ":tabopen -b -c work search qwant<CR>")
-    //         }).then(async ([newtab, _]) => {
-    //             expect(newtab.active).toEqual(false)
-    //             expect(newtab.cookieStoreId).toMatch("firefox-container-")
-    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*qwant")))
-    //         }).finally(() => killDriver(driver))
-    //     })
+//     test("`:tabopen -b -c work search qwant<CR>` opens about:blank in a container.", async () => {
+//         const driver = await getDriver()
+//         return newTabWithoutChangingOldTabs(driver, async () => {
+//             await sendKeys(driver, ":tabopen -b -c work search qwant<CR>")
+//         }).then(async ([newtab, _]) => {
+//             expect(newtab.active).toEqual(false)
+//             expect(newtab.cookieStoreId).toMatch("firefox-container-")
+//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*qwant")))
+//         }).finally(() => killDriver(driver))
+//     })
 })
 
 // vim: tabstop=4 shiftwidth=4 expandtab

--- a/e2e_tests/e2e.test.ts
+++ b/e2e_tests/e2e.test.ts
@@ -1,45 +1,49 @@
-import "geckodriver"
-
 import * as process from "process"
 const env = process.env
 import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
-import * as webdriver from "selenium-webdriver"
+import { Browser, Builder, By } from "selenium-webdriver"
+import { Options, Driver } from "selenium-webdriver/firefox"
 import * as Until from "selenium-webdriver/lib/until"
-const {By} = webdriver
-import {Options} from "selenium-webdriver/firefox"
-
-import { getNewestFileIn, sendKeys } from "./utils";
+import { getNewestFileIn, sendKeys } from "./utils"
 
 jest.setTimeout(100000)
 
 // API docs because I waste too much time looking for them every time I go back to this:
 // https://seleniumhq.github.io/selenium/docs/api/javascript/
 
-
 describe("webdriver", () => {
-
     function iframeLoaded(driver) {
         return driver.wait(Until.elementLocated(By.id("cmdline_iframe")))
     }
 
+    let driver: Driver
+    beforeEach(async () => {
+        driver = await getDriver()
+    })
+
+    afterEach(async () => {
+        await killDriver(driver)
+    })
+
     async function getDriver() {
-        const extensionPath = await getNewestFileIn(path.resolve("web-ext-artifacts"))
+        const extensionPath = await getNewestFileIn(
+            path.resolve("web-ext-artifacts"),
+        )
         if (extensionPath === undefined) {
-            throw new Error("Couldn't find extension path");
+            throw new Error("Couldn't find extension path")
         }
 
-        const options = (new Options())
-                .setPreference("xpinstall.signatures.required", false)
-                .addExtensions(extensionPath)
+        const options = new Options()
         if (env["HEADLESS"]) {
-            options.headless();
+            options.addArguments("--headless")
         }
-        const driver = new webdriver.Builder()
-            .forBrowser("firefox")
+        const driver = new Builder()
+            .forBrowser(Browser.FIREFOX)
             .setFirefoxOptions(options)
-            .build()
+            .build() as unknown as Driver
+        await driver.installAddon(extensionPath, true)
         // Wait until addon is loaded and :tutor is displayed
         await iframeLoaded(driver)
         // And wait a bit more otherwise Tridactyl won't be happy
@@ -52,7 +56,9 @@ describe("webdriver", () => {
         // First, find out what profile the driver is using
         const profiles = fs.readdirSync(rootDir).map(p => path.join(rootDir, p))
         const driver = await getDriver()
-        const newProfiles = fs.readdirSync(rootDir).map(p => path.join(rootDir, p))
+        const newProfiles = fs
+            .readdirSync(rootDir)
+            .map(p => path.join(rootDir, p))
             .filter(p => p.match("moz") && !profiles.includes(p))
 
         // Tridactyl's tmp profile detection is broken on windows and OSX
@@ -64,42 +70,64 @@ describe("webdriver", () => {
         return { driver, newProfiles }
     }
 
-    async function killDriver(driver) {
+    async function killDriver(driver: Driver) {
         try {
             await driver.close()
-        } catch(e) {}
+        } catch (e) {}
         try {
             await driver.quit()
-        } catch(e) {}
+        } catch (e) {}
     }
 
-    async function untilTabUrlMatches(driver, tabId, pattern) {
+    async function untilTabUrlMatches(
+        driver: Driver,
+        tabId: number,
+        pattern: string | RegExp,
+    ) {
         let match
         do {
-            match = (await driver.executeScript(`return tri.browserBg.tabs.get(${tabId})`))
-                .url
-                .match(pattern)
+            const result = await driver.executeScript(
+                `return tri.browserBg.tabs.get(${tabId})`,
+            )
+            if (
+                typeof result === "object" &&
+                result !== null &&
+                "url" in result
+            ) {
+                match = (result as { url: string }).url.match(pattern)
+            } else {
+                throw new Error("Unexpected result structure")
+            }
         } while (!match)
-            return match
+        return match
     }
 
-    async function newTabWithoutChangingOldTabs (driver, callback) {
-        const tabsBefore = await driver.executeScript("return tri.browserBg.tabs.query({})")
-        const result = await callback(tabsBefore);
+    async function newTabWithoutChangingOldTabs(driver, callback) {
+        const tabsBefore = await driver.executeScript(
+            "return tri.browserBg.tabs.query({})",
+        )
+        const result = await callback(tabsBefore)
         const tabsAfter = await driver.wait(async () => {
             let tabsAfter
             do {
-                tabsAfter = await driver.executeScript("return tri.browserBg.tabs.query({})")
+                tabsAfter = await driver.executeScript(
+                    "return tri.browserBg.tabs.query({})",
+                )
             } while (tabsAfter.length == tabsBefore.length)
-                return tabsAfter
+            return tabsAfter
         })
         // A single new tab has been created
         expect(tabsAfter.length).toBe(tabsBefore.length + 1)
 
         // None of the previous tabs changed, except maybe for their index
-        const newtab = tabsAfter.find(tab2 => !tabsBefore.find(tab => tab.id == tab2.id))
+        const newtab = tabsAfter.find(
+            tab2 => !tabsBefore.find(tab => tab.id == tab2.id),
+        )
         const notNewTabs = tabsAfter.slice()
-        notNewTabs.splice(tabsAfter.findIndex(tab => tab == newtab), 1)
+        notNewTabs.splice(
+            tabsAfter.findIndex(tab => tab == newtab),
+            1,
+        )
         const ignoreValues = {
             active: false, // the previously-active tab isn't necessarily active anymore
             highlighted: true, // changing tabs changes highlights
@@ -115,53 +143,64 @@ describe("webdriver", () => {
     }
 
     // A simple ternany doesn't work inline :(
-    function testbutskipplatforms(...platforms){
+    function testbutskipplatforms(...platforms) {
         if (platforms.includes(os.platform())) {
             return test.skip
         }
         return test
     }
 
-
     test("`:rssexec` works", async () => {
-        const driver = await getDriver()
         try {
-            await sendKeys(driver, ":set rsscmd js "
-                + "const elem=document.createElement('span');"
-                + "elem.id='rsscmdExecuted';"
-                + "elem.innerText=`%u`;"
-                + "document.body.appendChild(elem)<CR>")
+            await sendKeys(
+                driver,
+                ":set rsscmd js " +
+                    "const elem=document.createElement('span');" +
+                    "elem.id='rsscmdExecuted';" +
+                    "elem.innerText=`%u`;" +
+                    "document.body.appendChild(elem)<CR>",
+            )
 
             // First, make sure completions are offered
-            await driver.get("file:///" + process.cwd() + "/e2e_tests/html/rss.html")
+            await driver.get(
+                "file:///" + process.cwd() + "/e2e_tests/html/rss.html",
+            )
             const iframe = await iframeLoaded(driver)
             await sendKeys(driver, ":rssexec ")
             await driver.switchTo().frame(iframe)
-            const elements = await driver.findElements(By.className("RssCompletionOption"))
+            const elements = await driver.findElements(
+                By.className("RssCompletionOption"),
+            )
             expect(elements.length).toBeGreaterThan(3)
             const url = await elements[0].getAttribute("innerText")
 
             // Then, make sure rsscmd is executed and has the right arguments
             await sendKeys(driver, "<Tab><CR>")
             await (driver.switchTo() as any).parentFrame()
-            const elem = await driver.wait(Until.elementLocated(By.id("rsscmdExecuted")))
+            const elem = await driver.wait(
+                Until.elementLocated(By.id("rsscmdExecuted")),
+            )
             expect(url).toMatch(await elem.getAttribute("innerText"))
         } catch (e) {
             fail(e)
-        } finally {
-            await killDriver(driver)
         }
     })
 
     test("`:editor` works", async () => {
-        const driver = await getDriver()
         try {
-            const addedText = "There are %l lines and %c characters in this textarea."
+            const addedText =
+                "There are %l lines and %c characters in this textarea."
 
             if (os.platform() == "win32") {
-                await sendKeys(driver, `:set editorcmd echo | set /p text="${addedText}" >> %f<CR>`)
+                await sendKeys(
+                    driver,
+                    `:set editorcmd echo | set /p text="${addedText}" >> %f<CR>`,
+                )
             } else {
-                await sendKeys(driver, `:set editorcmd /bin/echo -n '${addedText}' >> %f<CR>`)
+                await sendKeys(
+                    driver,
+                    `:set editorcmd /bin/echo -n '${addedText}' >> %f<CR>`,
+                )
             }
 
             const areaId = "editorTest"
@@ -174,8 +213,50 @@ describe("webdriver", () => {
             const text = "This is a line\nThis is another\nThis is a third."
             await sendKeys(driver, text + "<C-i>")
             await driver.sleep(1000)
-            expect(await driver.executeScript(`return document.getElementById("${areaId}").value`))
-                .toEqual(text + addedText.replace("%l", "3").replace("%c", "" + text.split("\n")[2].length))
+            expect(
+                await driver.executeScript(
+                    `return document.getElementById("${areaId}").value`,
+                ),
+            ).toEqual(
+                text +
+                    addedText
+                        .replace("%l", "3")
+                        .replace("%c", "" + text.split("\n")[2].length),
+            )
+        } catch (e) {
+            fail(e)
+        }
+    })
+
+    testbutskipplatforms("darwin")("`:guiset` works", async () => {
+        const { driver, newProfiles } = await getDriverAndProfileDirs()
+        try {
+            // Then, make sure `:guiset` is offering completions
+            const iframe = await iframeLoaded(driver)
+            await sendKeys(driver, ":guiset ")
+            await driver.switchTo().frame(iframe)
+            const elements = await driver.findElements(
+                By.className("GuisetCompletionOption"),
+            )
+            expect(elements.length).toBeGreaterThan(0)
+
+            // Use whatever the first suggestion is
+            await sendKeys(driver, "<Tab> <Tab><CR>")
+            await driver.sleep(2000)
+            expect(
+                await driver.executeScript(
+                    `return document.getElementById("tridactyl-input").value`,
+                ),
+            ).toEqual(
+                "userChrome.css written. Please restart Firefox to see the changes.",
+            )
+            expect(
+                newProfiles.find(p =>
+                    fs
+                        .readdirSync(path.join(p, "chrome"))
+                        .find(files => files.match("userChrome.css$")),
+                ),
+            ).toBeDefined()
         } catch (e) {
             fail(e)
         } finally {
@@ -183,45 +264,22 @@ describe("webdriver", () => {
         }
     })
 
-    testbutskipplatforms("darwin")("`:guiset` works", async () => {
-            const { driver, newProfiles } = await getDriverAndProfileDirs()
-            try {
-                // Then, make sure `:guiset` is offering completions
-                const iframe = await iframeLoaded(driver)
-                await sendKeys(driver, ":guiset ")
-                await driver.switchTo().frame(iframe)
-                const elements = await driver.findElements(By.className("GuisetCompletionOption"))
-                expect(elements.length).toBeGreaterThan(0)
-
-                // Use whatever the first suggestion is
-                await sendKeys(driver, "<Tab> <Tab><CR>")
-                await driver.sleep(2000)
-                expect(await driver.executeScript(`return document.getElementById("tridactyl-input").value`))
-                .toEqual("userChrome.css written. Please restart Firefox to see the changes.")
-                expect(newProfiles.find(p => fs
-                                        .readdirSync(path.join(p, "chrome"))
-                                        .find(files => files.match("userChrome.css$")))
-                      ).toBeDefined()
-            } catch (e) {
-                fail(e)
-            } finally {
-                await killDriver(driver)
-            }
-    })
-
     test("`:colourscheme` works", async () => {
-        const driver = await getDriver()
         try {
-            expect(await driver.executeScript(`return document.documentElement.className`))
-                .toMatch("TridactylOwnNamespace TridactylThemeDefault")
+            expect(
+                await driver.executeScript(
+                    `return document.documentElement.className`,
+                ),
+            ).toMatch("TridactylOwnNamespace TridactylThemeDefault")
             await sendKeys(driver, ":colourscheme dark<CR>")
             await driver.sleep(100)
-            expect(await driver.executeScript(`return document.documentElement.className`))
-                .toMatch("TridactylOwnNamespace TridactylThemeDark")
+            expect(
+                await driver.executeScript(
+                    `return document.documentElement.className`,
+                ),
+            ).toMatch("TridactylOwnNamespace TridactylThemeDark")
         } catch (e) {
             fail(e)
-        } finally {
-            await killDriver(driver)
         }
     })
 
@@ -230,108 +288,122 @@ describe("webdriver", () => {
         try {
             await sendKeys(driver, `:setpref a.b.c "d"<CR>`)
             await driver.sleep(2000)
-            const file = fs.readFileSync(path.join(newProfiles[0], "user.js"), { encoding: "utf-8" })
+            const file = fs.readFileSync(path.join(newProfiles[0], "user.js"), {
+                encoding: "utf-8",
+            })
             expect(file).toMatch(/user_pref\("a.b.c", "d"\);/)
         } catch (e) {
             fail(e)
-        } finally {
-            await killDriver(driver)
         }
     })
 
     test("`:tabopen<CR>` opens the newtab page.", async () => {
-        const driver = await getDriver()
-        return newTabWithoutChangingOldTabs(driver, async (tabsBefore) => {
+        return newTabWithoutChangingOldTabs(driver, async tabsBefore => {
             await sendKeys(driver, ":tabopen<CR>")
         }).then(async ([newtab, _]) => {
             // The new tab is active
             expect(newtab.active).toEqual(true)
             // Its url is the newtab page's url
-            await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("moz-extension://.*/static/newtab.html")), 10000)
-        }).finally(() => killDriver(driver))
+            await driver.wait(
+                untilTabUrlMatches(
+                    driver,
+                    newtab.id,
+                    new RegExp("moz-extension://.*/static/newtab.html"),
+                ),
+                10000,
+            )
+        })
     })
 
     test("`:tabopen https://example.org<CR>` opens example.org.", async () => {
-        const driver = await getDriver()
         return newTabWithoutChangingOldTabs(driver, async () => {
             await sendKeys(driver, ":tabopen https://example.org<CR>")
         }).then(async ([newtab, _]) => {
             expect(newtab.active).toEqual(true)
-            await driver.wait(untilTabUrlMatches(driver, newtab.id, "https://example.org"), 10000)
-        }).finally(() => killDriver(driver))
+            await driver.wait(
+                untilTabUrlMatches(driver, newtab.id, "https://example.org"),
+                10000,
+            )
+        })
     })
 
     test("`:tabopen qwant https://example.org<CR>` opens qwant.", async () => {
-        const driver = await getDriver()
         return newTabWithoutChangingOldTabs(driver, async () => {
             await sendKeys(driver, ":tabopen qwant https://example.org<CR>")
         }).then(async ([newtab, _]) => {
             expect(newtab.active).toEqual(true)
-            await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.qwant.com/.*example.org")), 10000)
-        }).finally(() => killDriver(driver))
+            await driver.wait(
+                untilTabUrlMatches(
+                    driver,
+                    newtab.id,
+                    new RegExp("^https://www.qwant.com/.*example.org"),
+                ),
+                10000,
+            )
+        })
     })
 
-//     test("`:tabopen test<CR>` opens google.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen test<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(true)
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/.*test")), 10000)
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen test<CR>` opens google.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen test<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(true)
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/.*test")), 10000)
+    //         }).finally(() => killDriver(driver))
+    //     })
 
-//     test("`:tabopen example.org<CR>` opens example.org.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen example.org<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(true)
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "example.org"), 10000)
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen example.org<CR>` opens example.org.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen example.org<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(true)
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "example.org"), 10000)
+    //         }).finally(() => killDriver(driver))
+    //     })
 
-//     test("`:tabopen search duckduckgo<CR>` opens google.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen search duckduckgo<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(true)
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*duckduckgo")), 10000)
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen search duckduckgo<CR>` opens google.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen search duckduckgo<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(true)
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*duckduckgo")), 10000)
+    //         }).finally(() => killDriver(driver))
+    //     })
 
-//     test("`:tabopen -b about:blank<CR>` opens a background tab.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen -b about:blank<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(false)
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen -b about:blank<CR>` opens a background tab.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen -b about:blank<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(false)
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
+    //         }).finally(() => killDriver(driver))
+    //     })
 
-//     test("`:tabopen -c work about:blank<CR>` opens about:blank in a container.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen -c work about:blank<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(true)
-//             expect(newtab.cookieStoreId).toMatch("firefox-container-")
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen -c work about:blank<CR>` opens about:blank in a container.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen -c work about:blank<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(true)
+    //             expect(newtab.cookieStoreId).toMatch("firefox-container-")
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, "about:blank"))
+    //         }).finally(() => killDriver(driver))
+    //     })
 
-//     test("`:tabopen -b -c work search qwant<CR>` opens about:blank in a container.", async () => {
-//         const driver = await getDriver()
-//         return newTabWithoutChangingOldTabs(driver, async () => {
-//             await sendKeys(driver, ":tabopen -b -c work search qwant<CR>")
-//         }).then(async ([newtab, _]) => {
-//             expect(newtab.active).toEqual(false)
-//             expect(newtab.cookieStoreId).toMatch("firefox-container-")
-//             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*qwant")))
-//         }).finally(() => killDriver(driver))
-//     })
+    //     test("`:tabopen -b -c work search qwant<CR>` opens about:blank in a container.", async () => {
+    //         const driver = await getDriver()
+    //         return newTabWithoutChangingOldTabs(driver, async () => {
+    //             await sendKeys(driver, ":tabopen -b -c work search qwant<CR>")
+    //         }).then(async ([newtab, _]) => {
+    //             expect(newtab.active).toEqual(false)
+    //             expect(newtab.cookieStoreId).toMatch("firefox-container-")
+    //             await driver.wait(untilTabUrlMatches(driver, newtab.id, new RegExp("^https://www.google.com/search.*qwant")))
+    //         }).finally(() => killDriver(driver))
+    //     })
 })
 
 // vim: tabstop=4 shiftwidth=4 expandtab

--- a/e2e_tests/e2e.test.ts
+++ b/e2e_tests/e2e.test.ts
@@ -80,6 +80,7 @@ describe("webdriver", () => {
         active: boolean
         id: number
         url?: string
+        cookieStoreId?: string
     }
 
     async function untilTabUrlMatches(
@@ -345,6 +346,36 @@ describe("webdriver", () => {
             driver,
             newTab.id,
             new RegExp("https?://duckduckgo.com/?.*/"),
+        )
+    })
+
+    test("`:tabopen -b about:blank<CR>` opens a background tab.", async () => {
+        const newTab = await newTabWithoutChangingOldTabs(driver, async () => {
+            await sendKeys(driver, ":tabopen -b about:blank<CR>")
+        })
+        expect(newTab.active).toEqual(false)
+        await untilTabUrlMatches(driver, newTab.id, "about:blank")
+    })
+
+    test("`:tabopen -c work about:blank<CR>` opens about:blank in a container.", async () => {
+        const newTab = await newTabWithoutChangingOldTabs(driver, async () => {
+            await sendKeys(driver, ":tabopen -c work about:blank<CR>")
+        })
+        expect(newTab.active).toEqual(true)
+        expect(newTab.cookieStoreId).toMatch("firefox-container-")
+        await untilTabUrlMatches(driver, newTab.id, "about:blank")
+    })
+
+    test("`:tabopen -b -c work search qwant<CR>` opens about:blank in a container.", async () => {
+        const newTab = await newTabWithoutChangingOldTabs(driver, async () => {
+            await sendKeys(driver, ":tabopen -b -c work search qwant<CR>")
+        })
+        expect(newTab.active).toEqual(false)
+        expect(newTab.cookieStoreId).toMatch("firefox-container-")
+        await untilTabUrlMatches(
+            driver,
+            newTab.id,
+            new RegExp("^https://www.google.com/search.*qwant"),
         )
     })
 })

--- a/e2e_tests/e2e.test.ts
+++ b/e2e_tests/e2e.test.ts
@@ -19,11 +19,11 @@ describe("webdriver", () => {
     }
 
     let driver: Driver
-    beforeAll(async () => {
+    beforeEach(async () => {
         driver = await getDriver()
     })
 
-    afterAll(async () => {
+    afterEach(async () => {
         await driver.quit()
     })
 
@@ -45,7 +45,7 @@ describe("webdriver", () => {
         await driver.installAddon(extensionPath, true)
         // Wait until addon is loaded and :tutor is displayed
         await iframeLoaded(driver)
-        const handles = (await driver.getAllWindowHandles())
+        const handles = await driver.getAllWindowHandles()
         // And wait a bit more otherwise Tridactyl won't be happy
         await driver.sleep(500)
         // Kill the original tab.

--- a/e2e_tests/utils.ts
+++ b/e2e_tests/utils.ts
@@ -48,7 +48,7 @@ const modToSelenium = {
 }
 
 export async function sendKeys(driver: WebDriver, keys: string) {
-    const delay = 500;
+    const delay = 100;
 
     async function sendSingleKey(key: string) {
         await driver.actions().sendKeys(key).perform();

--- a/e2e_tests/utils.ts
+++ b/e2e_tests/utils.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "fs"
 import * as path from "path"
-import { WebDriver, Key, Actions } from "selenium-webdriver"
+import { WebDriver, Key } from "selenium-webdriver"
 
 /** Returns the path of the newest file in directory */
 export async function getNewestFileIn(directory: string): Promise<string> {

--- a/e2e_tests/utils.ts
+++ b/e2e_tests/utils.ts
@@ -1,92 +1,95 @@
-import { promises as fs } from 'fs';
+import { promises as fs } from "fs"
 import * as path from "path"
 import { WebDriver, Key, Actions } from "selenium-webdriver"
 
 /** Returns the path of the newest file in directory */
-export async function getNewestFileIn(directory: string): Promise<string | undefined> {
+export async function getNewestFileIn(directory: string): Promise<string> {
     try {
         // Get list of files
-        const names = await fs.readdir(directory);
+        const names = await fs.readdir(directory)
 
         // Get their stat structs
-        const stats = await Promise.all(names.map(async (name) => {
-            const filePath = path.join(directory, name);
-            const stat = await fs.stat(filePath);
-            return { path: filePath, mtime: stat.mtime };
-        }));
+        const stats = await Promise.all(
+            names.map(async name => {
+                const filePath = path.join(directory, name)
+                const stat = await fs.stat(filePath)
+                return { path: filePath, mtime: stat.mtime }
+            }),
+        )
 
         // Sort by most recent and return the path of the newest file
-        return stats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime())[0]?.path;
+        return stats.sort((a, b) => b.mtime.getTime() - a.mtime.getTime())[0]
+            ?.path
     } catch (error) {
-        console.error(`Error reading directory ${directory}:`, error);
-        return undefined;
+        console.error(`Error reading directory ${directory}:`, error)
+        throw new Error("Couldn't find extension path")
     }
 }
 
 const vimToSelenium = {
-    "Down": Key.ARROW_DOWN,
-    "Left": Key.ARROW_LEFT,
-    "Right": Key.ARROW_RIGHT,
-    "Up": Key.ARROW_UP,
-    "BS": Key.BACK_SPACE,
-    "Del": Key.DELETE,
-    "End": Key.END,
-    "CR": Key.ENTER,
-    "Esc": Key.ESCAPE,
-    "Home": Key.HOME,
-    "PageDown": Key.PAGE_DOWN,
-    "PageUp": Key.PAGE_UP,
-    "Tab": Key.TAB,
-    "lt": "<",
+    Down: Key.ARROW_DOWN,
+    Left: Key.ARROW_LEFT,
+    Right: Key.ARROW_RIGHT,
+    Up: Key.ARROW_UP,
+    BS: Key.BACK_SPACE,
+    Del: Key.DELETE,
+    End: Key.END,
+    CR: Key.ENTER,
+    Esc: Key.ESCAPE,
+    Home: Key.HOME,
+    PageDown: Key.PAGE_DOWN,
+    PageUp: Key.PAGE_UP,
+    Tab: Key.TAB,
+    lt: "<",
 }
 
 const modToSelenium = {
-    "A": Key.ALT,
-    "C": Key.CONTROL,
-    "M": Key.META,
-    "S": Key.SHIFT,
+    A: Key.ALT,
+    C: Key.CONTROL,
+    M: Key.META,
+    S: Key.SHIFT,
 }
 
 export async function sendKeys(driver: WebDriver, keys: string) {
-    const delay = 100;
+    const delay = 100
 
     async function sendSingleKey(key: string) {
-        await driver.actions().sendKeys(key).perform();
-        await driver.sleep(delay);
+        await driver.actions().sendKeys(key).perform()
+        await driver.sleep(delay)
     }
 
     async function sendSpecialKey(specialKey: string) {
-        const noBrackets = specialKey.slice(1, -1);
+        const noBrackets = specialKey.slice(1, -1)
         if (noBrackets.includes("-")) {
-            const [modifiers, key] = noBrackets.split("-");
-            const mods = modifiers.split("").map(mod => modToSelenium[mod]);
-            let actions = driver.actions();
+            const [modifiers, key] = noBrackets.split("-")
+            const mods = modifiers.split("").map(mod => modToSelenium[mod])
+            let actions = driver.actions()
             for (const mod of mods) {
-                actions = actions.keyDown(mod);
+                actions = actions.keyDown(mod)
             }
-            actions = actions.sendKeys(vimToSelenium[key] || key);
+            actions = actions.sendKeys(vimToSelenium[key] || key)
             for (const mod of mods) {
-                actions = actions.keyUp(mod);
+                actions = actions.keyUp(mod)
             }
-            await actions.perform();
+            await actions.perform()
         } else {
-            await sendSingleKey(vimToSelenium[noBrackets] || noBrackets);
+            await sendSingleKey(vimToSelenium[noBrackets] || noBrackets)
         }
     }
 
-    keys = keys.replace(":", "<S-;>");
-    const regexp = /<[^>-]+-?[^>]*>/g;
-    const specialKeys = keys.match(regexp) || [];
-    const regularKeys = keys.split(regexp);
+    keys = keys.replace(":", "<S-;>")
+    const regexp = /<[^>-]+-?[^>]*>/g
+    const specialKeys = keys.match(regexp) || []
+    const regularKeys = keys.split(regexp)
 
     for (let i = 0; i < Math.max(specialKeys.length, regularKeys.length); i++) {
         if (i < regularKeys.length && regularKeys[i]) {
             for (const key of regularKeys[i].split("")) {
-                await sendSingleKey(key);
+                await sendSingleKey(key)
             }
         }
         if (i < specialKeys.length) {
-            await sendSpecialKey(specialKeys[i]);
+            await sendSpecialKey(specialKeys[i])
         }
     }
 }


### PR DESCRIPTION
This PR fixes the CI pipeline. ~~It stacks on top of https://github.com/tridactyl/tridactyl/pull/5056.~~

To achieve this I:
* Changed how the extension is installed. It's now done using `installAddOn`.
* Changed how Firefox is installed in CI by using a native Github action.
* Cleaned up the `utils` and `e2e.test` so that they use `async`/`await` for readability and have more readable logic.
* Fixed the flaky test calling `qwant` which is not registered as a search provider on the master branch.

The tests are now stable which lets me cut the retries down and help the pipeline execute more quickly!