### PR TITLE
Disable hyphenation for code elements in newtab.css

### DIFF
--- a/src/static/css/newtab.css
+++ b/src/static/css/newtab.css
@@ -91,6 +91,7 @@ code {
     /* font-size: 85%; */
     font-size: 10pt;
     border-radius: 3px;
+    hyphens: none;
 }
 
 img {


### PR DESCRIPTION
Otherwise things like `:bind J newtab` can end up hyphenated across a linebreak as `new-tab`.

![image](https://github.com/user-attachments/assets/b841c910-27d2-4650-b54a-58efc22d4e78)
