### PR TITLE
Do not parse numbers as IPs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,16 +59,15 @@ If you want to use advanced features such as edit-in-Vim, you'll also need to in
 
 **Snap and Flatpak:** Native Messaging support here is fairly recent and may require:
 
-* Upgrading to a beta version of Firefox (`>= 106.0b6`)
-* Enabling webextension permissions: `flatpak permission-set webextensions tridactyl snap.firefox yes`
-* Rebooting your system (and likely nothing short of it)
+-   Upgrading to a beta version of Firefox (`>= 106.0b6`)
+-   Enabling webextension permissions: `flatpak permission-set webextensions tridactyl snap.firefox yes`
+-   Rebooting your system (and likely nothing short of it)
 
 See [this call for testing thread](https://discourse.ubuntu.com/t/call-for-testing-native-messaging-support-in-the-firefox-snap/29759) and [this PR](https://github.com/tridactyl/tridactyl/pull/4406) for more details and troubleshooting tips.
 
 **Firejail** will require explicit path whitelisting, but should be feasible based on https://github.com/netblue30/firejail/issues/2109.
 
-For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above.
-With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
+For other containerized installs, see troubleshooting steps in https://github.com/tridactyl/tridactyl/issues/2406 and the links above. With packaging that does support Native Messaging, the trick is usually ensuring the containerized app has permission to run the executable and can find the [manifest json file](https://wiki.mozilla.org/WebExtensions/Native_Messaging#Host_Manifests).
 
 ### Migrating between beta and stable builds
 
@@ -130,8 +129,7 @@ Find mode is still incomplete and uses the Firefox feature "Quick Find". This wi
 -   `/` then `<C-f>` — open the Find in page search box
 -   `<C-g>`/`<C-G>` — find the next/previous instance of the last find operation (note: these are the standard Firefox shortcuts)
 
-Please note that Tridactyl overrides Firefox's `<C-f>` search, replacing it with a binding to go to the next part of the page. 
-If you want to be able to use `<C-f>` to search for things, use `<C-f>` after opening the Quick Find box (`/`), or any input field such as the address bar or search bar (use default browser shortcuts to activate these). To allow usage of `<C-f>` at any time, use `unbind <C-f>` to unset the scrollpage binding.
+Please note that Tridactyl overrides Firefox's `<C-f>` search, replacing it with a binding to go to the next part of the page. If you want to be able to use `<C-f>` to search for things, use `<C-f>` after opening the Quick Find box (`/`), or any input field such as the address bar or search bar (use default browser shortcuts to activate these). To allow usage of `<C-f>` at any time, use `unbind <C-f>` to unset the scrollpage binding.
 
 #### Bookmarks and quickmarks
 
@@ -146,7 +144,7 @@ If you want to use Firefox's default `<C-b>` binding to open the bookmarks sideb
 
 -   `m a-zA-Z` — set a local mark (lowercase letter), or a global mark (uppercase letter)
 -   `` ` a-zA-Z `` — jump to a local mark (lowercase letter), or a global mark (uppercase letter)
--   ``` `` ``` — jump to the location before the last mark jump
+-   ` `` ` — jump to the location before the last mark jump
 
 #### Navigating to new pages:
 
@@ -299,7 +297,7 @@ You can bind your own shortcuts in normal mode with the `:bind` command. For exa
 
 -   How do I prevent websites from stealing focus?
 
-    There are two ways:  the first one is `:seturl [URL regex] allowautofocus false` (if you do this you'll probably also want to set `browser.autofocus` to false in `about:config`). This will prevent the page's `focus()` function from working and could break javascript text editors such as Ace or CodeMirror; you could equally run `:set allowautofocus false` and then use `:seturl [URL regex for sites with text editors you use] allowautofocus true`. The second method is `:seturl [URL regex] preventautofocusjackhammer true` which will repeatedly check that the page has not stolen focus at the cost of some CPU cycles, so use it sparingly. It works on more websites than `allowautofocus false`.
+    There are two ways: the first one is `:seturl [URL regex] allowautofocus false` (if you do this you'll probably also want to set `browser.autofocus` to false in `about:config`). This will prevent the page's `focus()` function from working and could break javascript text editors such as Ace or CodeMirror; you could equally run `:set allowautofocus false` and then use `:seturl [URL regex for sites with text editors you use] allowautofocus true`. The second method is `:seturl [URL regex] preventautofocusjackhammer true` which will repeatedly check that the page has not stolen focus at the cost of some CPU cycles, so use it sparingly. It works on more websites than `allowautofocus false`.
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -330,7 +330,7 @@ yarn run build
 
 Each time package.json or yarn.lock change after you checkout or pull, our git hook will try to run `yarn install` again. If it doesn't you should do it manually.
 
-Addon is built in tridactyl/build. Load it as a temporary addon in firefox with `about:debugging` or see [Development loop](#Development-loop).
+Addon is built in `build/`. Load it as a [temporary addon](https://extensionworkshop.com/documentation/develop/temporary-installation-in-firefox/) in firefox with `about:debugging` or see [Development loop](#Development-loop).
 
 If you want to install a local copy of the add-on into your developer or nightly build of Firefox then you can enable installing unsigned add-ons and then build it like so:
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -45,7 +45,7 @@ eslintUgly() {
         tmpfile="$tmpdir/$jsfile"
         mkdir -p "$(dirname "$tmpfile")"
         staged "$jsfile" > "$tmpfile"
-        "$(yarn bin)/eslint" --no-ignore --quiet -o /dev/null "$tmpfile" || acc="$jsfile"$'\n'"$acc"
+        "$(yarn bin)/eslint" --rulesdir custom-eslint-rules --no-ignore --quiet -o /dev/null "$tmpfile" || acc="$jsfile"$'\n'"$acc"
     done
     rm -rf "$tmpdir"
     echo "$acc"

--- a/scripts/pretty.sh
+++ b/scripts/pretty.sh
@@ -40,7 +40,7 @@ main() {
 	lock .git/index.lock
 	case "$file" in
 	  *.md | *.css) prettier --write "$file";;
-	  *) prettier --write "$file"; eslint --fix "$file";;
+	  *) prettier --write "$file"; eslint --rulesdir custom-eslint-rules --fix "$file";;
 	esac
 	unlock .git/index.lock
 	git add "$file"
@@ -60,7 +60,7 @@ main() {
 		mv "$tmpfile" "$file";;
 	    *)
 	      staged "$file" > "$tmpfile"
-	      eslint -c ../.eslintrc.js --fix -o /dev/null "$tmpfile" &&
+	      eslint --rulesdir custom-eslint-rules -c ../.eslintrc.js --fix -o /dev/null "$tmpfile" &&
 		mv "$tmpfile" "$file";;
 	  esac
 	  chmod --reference="../$file" "$file" # match permissions

--- a/src/lib/webext.ts
+++ b/src/lib/webext.ts
@@ -366,21 +366,29 @@ export async function queryAndURLwrangler(
         return { engine: engine.name, query: rest }
     }
 
-    // Maybe it's a domain without protocol
-    try {
-        const url = new URL("http://" + address)
-        // Ignore unlikely domains
-        if (
-            // the endsWith check must be on address, because URL adds a
-            // trailing slash which would always match
-            address.endsWith("/") ||
-            url.hostname.indexOf(".") > 0 ||
-            url.port ||
-            url.password
-        ) {
-            return url.href
-        }
-    } catch (e) {}
+    // Maybe it's a host (ip, domain) without a protocol
+    //
+    // if the address looks like a number (e.g. 538, 3.14), then do *not* consider it as a potential
+    // host (see #5081)
+    // uses +str to first attempt parsing the address into a number, and then check whether the
+    // result is NaN; this is required as Typescript, unlike JavaScript, only allows numbers as
+    // arguments to NaN (see https://stackoverflow.com/q/42120046)
+    if (isNaN(+address)) {
+        try {
+            const url = new URL("http://" + address)
+            // Ignore unlikely domains
+            if (
+                // the endsWith check must be on address, because URL adds a
+                // trailing slash which would always match
+                address.endsWith("/") ||
+                url.hostname.indexOf(".") > 0 ||
+                url.port ||
+                url.password
+            ) {
+                return url.href
+            }
+        } catch (e) {}
+    }
 
     // Let's default to the user's search engine then
 


### PR DESCRIPTION
Fix #5081

The fix itself is in 5d24ab72d85fa2a01ae0f5734e98b4b38f278c41. I tested it locally and can confirm the following work as expected (the first two open my search engine, the third one goes to `http://1.1.1.1`):

```
:open 538
:open 3.14
:open 1.1.1.1
```

There are a couple unrelated commits on this branch because things didn't work out-of-the-box for me, happy to split those into their own PR (or remove them altogether), just lmk.