### PR TITLE
Style Hints According to Config

### DIFF
--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -19,7 +19,6 @@ function prefixTheme(name) {
 // At the moment elements are only ever `:root` and so this array and stuff is all a bit overdesigned.
 const THEMED_ELEMENTS = []
 
-// PARIS: optional hint styles
 let insertedHintElemCSS = false
 const hintElemCss = {
     allFrames: true,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -95,12 +95,10 @@ export class default_config {
                 F: "hint -bc [tabindex]:not(.two)>div,a",
             },
         },
-        "^https://teams.microsoft.com": {
-            // #5054
+        "^https://teams.microsoft.com": { // #5054
             superignore: "true",
         },
-        "^https://teams.live.com": {
-            // #5054
+        "^https://teams.live.com": { // #5054
             superignore: "true",
         },
     }
@@ -1788,7 +1786,7 @@ export const keyboardlayouts = {
         KeyY: ["", "!"],
     },
     workman: {
-        Quote: ["'", '"'],
+        Quote: ["'", "\""],
         Digit8: ["8", "*"],
         Digit1: ["1", "!"],
         Digit2: ["2", "@"],
@@ -1834,7 +1832,7 @@ export const keyboardlayouts = {
         KeyM: ["l", "L"],
         Comma: [",", "<"],
         Period: [".", ">"],
-        Slash: ["/", "?"],
+        Slash: ["/", "?"]
     },
 }
 
@@ -2327,8 +2325,8 @@ export async function update() {
                 local?.storageloc !== undefined
                     ? local.storageloc
                     : sync?.storageloc !== undefined
-                      ? sync.storageloc
-                      : "sync"
+                    ? sync.storageloc
+                    : "sync"
             if (current_storageloc == "sync") {
                 await pull()
             } else if (current_storageloc != "local") {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -95,10 +95,12 @@ export class default_config {
                 F: "hint -bc [tabindex]:not(.two)>div,a",
             },
         },
-        "^https://teams.microsoft.com": { // #5054
+        "^https://teams.microsoft.com": {
+            // #5054
             superignore: "true",
         },
-        "^https://teams.live.com": { // #5054
+        "^https://teams.live.com": {
+            // #5054
             superignore: "true",
         },
     }
@@ -1334,6 +1336,15 @@ export class default_config {
      * Whether to show article url in the document.title of Reader View.
      */
     readerurlintitle: "true" | "false" = "false"
+
+    /**
+     *  Which css styles to add for hint elements.
+     **/
+    hintstyles: { [key: string]: "all" | "active" | "none" } = {
+        fg: "active",
+        bg: "active",
+        outline: "all",
+    }
 }
 
 const platform_defaults = {
@@ -1777,7 +1788,7 @@ export const keyboardlayouts = {
         KeyY: ["", "!"],
     },
     workman: {
-        Quote: ["'", "\""],
+        Quote: ["'", '"'],
         Digit8: ["8", "*"],
         Digit1: ["1", "!"],
         Digit2: ["2", "@"],
@@ -1823,7 +1834,7 @@ export const keyboardlayouts = {
         KeyM: ["l", "L"],
         Comma: [",", "<"],
         Period: [".", ">"],
-        Slash: ["/", "?"]
+        Slash: ["/", "?"],
     },
 }
 
@@ -2316,8 +2327,8 @@ export async function update() {
                 local?.storageloc !== undefined
                     ? local.storageloc
                     : sync?.storageloc !== undefined
-                    ? sync.storageloc
-                    : "sync"
+                      ? sync.storageloc
+                      : "sync"
             if (current_storageloc == "sync") {
                 await pull()
             } else if (current_storageloc != "local") {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1336,11 +1336,17 @@ export class default_config {
     readerurlintitle: "true" | "false" = "false"
 
     /**
-     *  Which css styles to add for hint elements.
-     **/
+     * Which css styles to add for hint elements.
+     *
+     * Use `hintstyles.fg` for text color, `hintstyles.bg` for background color, `hintstyles.outline` for outlines.
+     * Values may be "all" to enable the style for all hints, "active" for styles only the currently selected hint, or "none" to disable the style completely.
+     *
+     * For example, run
+     *`:set hintstyles.bg none` to remove background colors from all hints.
+     */
     hintstyles: { [key: string]: "all" | "active" | "none" } = {
-        fg: "active",
-        bg: "active",
+        fg: "all",
+        bg: "all",
         outline: "all",
     }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1342,7 +1342,7 @@ export class default_config {
      * Values may be set to "all" to enable the style for all hints, "active" to enable the style only for the currently selected hint, or "none" to disable the style completely.
      *
      * For example, run
-     *`:set hintstyles.bg none` to remove background colors from all hints.
+     *`:set hintstyles.bg none` and reload the page to remove background colors from all hints.
      */
     hintstyles: { [key: string]: "all" | "active" | "none" } = {
         fg: "all",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1339,7 +1339,7 @@ export class default_config {
      * Which css styles to add for hint elements.
      *
      * Use `hintstyles.fg` for text color, `hintstyles.bg` for background color, `hintstyles.outline` for outlines.
-     * Values may be "all" to enable the style for all hints, "active" for styles only the currently selected hint, or "none" to disable the style completely.
+     * Values may be set to "all" to enable the style for all hints, "active" to enable the style only for the currently selected hint, or "none" to disable the style completely.
      *
      * For example, run
      *`:set hintstyles.bg none` to remove background colors from all hints.

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -26,7 +26,6 @@ span.TridactylHintUppercase {
 
 .TridactylHintElem,
 .TridactylHintActive {
-    color: var(--tridactyl-hint-active-fg) !important !important;
     animation: none !important;
     transition: unset !important;
 }

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -31,16 +31,6 @@ span.TridactylHintUppercase {
     transition: unset !important;
 }
 
-.TridactylHintElem {
-    background-color: var(--tridactyl-hint-bg) !important;
-    outline: var(--tridactyl-hint-outline) !important;
-}
-
-.TridactylHintActive {
-    background-color: var(--tridactyl-hint-active-bg) !important;
-    outline: var(--tridactyl-hint-active-outline) !important;
-}
-
 div.TridactylHintHost {
     position: static !important !important;
 }


### PR DESCRIPTION
As discussed in https://github.com/tridactyl/tridactyl/issues/4106 and others, hint element styles can't be completely disabled in themes.
This adds a config key, `hintstyles` so that styles are only added if they are enabled, otherwise the original page style remains intact.
Outlines, backgrounds and font colour can individually be enabled/disabled, or only added to active hint using `set hintstyles.bg`, `hintstyles.outline` and `hintstyles.fg`. Values can be `all`, `active`, or `none`