### PR TITLE
Change preferHtml now defaults to false

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -357,7 +357,7 @@ export async function editor() {
 
     let ans
     try {
-        const editor = getEditor(elem, { preferHTML: true })
+        const editor = getEditor(elem, { preferHTML: false })
         const text = await editor.getContent()
         const pos = await editor.getCursor()
 


### PR DESCRIPTION
Sets the `preferHtml` option to false when using the editor adaptor