### PR TITLE
Added path prefixes for bmarks

### DIFF
--- a/src/completions/Bmark.ts
+++ b/src/completions/Bmark.ts
@@ -9,22 +9,19 @@ class BmarkCompletionOption
 
     constructor(
         public value: string,
-        bmark: browser.bookmarks.BookmarkTreeNode,
-        allBookmarks: { string?: browser.bookmarks.BookmarkTreeNode },
+        bmark: providers.Bookmark,
     ) {
         super()
         if (!bmark.title) {
             bmark.title = new URL(bmark.url).host
         }
 
-        const path = this.buildBookmarkPath("", bmark, allBookmarks)
-
         // Push properties we want to fuzmatch on
-        this.fuseKeys.push(bmark.title, bmark.url)
+        this.fuseKeys.push(bmark.path, bmark.title, bmark.url)
 
         this.html = html`<tr class="BmarkCompletionOption option">
             <td class="prefix">${"".padEnd(2)}</td>
-            <td class="title">${path}${bmark.title}</td>
+            <td class="title">${bmark.path}${bmark.title}</td>
             <td class="content">
                 <a class="url" target="_blank" href=${bmark.url}
                     >${bmark.url}</a
@@ -32,28 +29,11 @@ class BmarkCompletionOption
             </td>
         </tr>`
     }
-
-    private buildBookmarkPath(
-        path: string,
-        bookmark: browser.bookmarks.BookmarkTreeNode,
-        allBookmarks: { string?: browser.bookmarks.BookmarkTreeNode },
-    ): string {
-        if (bookmark.parentId === "root________") {
-            return path
-        }
-        const parent = allBookmarks[bookmark.parentId]
-        return this.buildBookmarkPath(
-            `${parent.title}/${path}`,
-            parent,
-            allBookmarks,
-        )
-    }
 }
 
 export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
     public options: BmarkCompletionOption[]
     private shouldSetStateFromScore = true
-    private allBookmarks?: { string?: browser.bookmarks.BookmarkTreeNode }
 
     constructor(private _parent) {
         super(["bmarks"], "BmarkCompletionSource", "Bookmarks")
@@ -92,18 +72,9 @@ export class BmarkCompletionSource extends Completions.CompletionSourceFuse {
         }
 
         this.completion = undefined
-        this.allBookmarks =
-            this.allBookmarks || (await providers.getAllBookmarks())
         this.options = (await providers.getBookmarks(query))
             .slice(0, 10)
-            .map(
-                page =>
-                    new BmarkCompletionOption(
-                        option + page.url,
-                        page,
-                        this.allBookmarks,
-                    ),
-            )
+            .map(page => new BmarkCompletionOption(option + page.url, page))
 
         this.lastExstr = [prefix, query].join(" ")
         return this.updateChain()

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -172,7 +172,7 @@ export async function getCombinedHistoryBmarks(
     const combinedMap = new Map<string, any>(
         bookmarks.map(bmark => [
             bmark.url,
-            { title: bmark.title, url: bmark.url, bmark },
+            { title: `${bmark.path}${bmark.title}`, url: bmark.url, bmark },
         ]),
     )
     history.forEach(page => {

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -55,7 +55,13 @@ async function fuseBookmarksSearch(query: string): Promise<Bookmark[]> {
     allBookmarks = allBookmarks || (await collectBookmarks())
     bookmarksFuse =
         bookmarksFuse ||
-        new Fuse(allBookmarks, { keys: ["path", "title", "url"] })
+        new Fuse(allBookmarks, {
+            keys: ["path", "title", "url"],
+            findAllMatches: true,
+            ignoreLocation: true,
+            ignoreFieldNorm: true,
+            threshold: config.get("completionfuzziness"),
+        })
     return query ? bookmarksFuse.search(query).map(r => r.item) : allBookmarks
 }
 

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -101,7 +101,7 @@ function buildBookmarkPath(
 }
 
 /**
- * Remove folder nodes and bad URLs.
+ * Bookmark is not a folder and has valid URL.
  */
 function isValidBookmark(bookmark: Bookmark): boolean {
     try {

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -11,8 +11,10 @@ export function newtaburl() {
 
 export type Bookmark = { path: string } & browser.bookmarks.BookmarkTreeNode
 
+/**
+ * Search bookmarks, deduplicate and sort by most recent.
+ */
 export async function getBookmarks(query: string): Promise<Bookmark[]> {
-    // Search bookmarks, dedupe and sort by most recent.
     let bookmarks =
         config.get("bmarkfoldersearch") == "true"
             ? await fuseBookmarksSearch(query)
@@ -85,17 +87,23 @@ function flattenChildren(
 function buildBookmarkPath(
     path: string,
     bookmark: browser.bookmarks.BookmarkTreeNode,
-    allBookmarks: { string?: browser.bookmarks.BookmarkTreeNode },
+    bookmarksDictionary: { string?: browser.bookmarks.BookmarkTreeNode },
 ): string {
     if (!bookmark.parentId) {
         return path
     }
-    const parent = allBookmarks[bookmark.parentId]
-    return buildBookmarkPath(`${parent.title}/${path}`, parent, allBookmarks)
+    const parent = bookmarksDictionary[bookmark.parentId]
+    return buildBookmarkPath(
+        `${parent.title}/${path}`,
+        parent,
+        bookmarksDictionary,
+    )
 }
 
+/**
+ * Remove folder nodes and bad URLs.
+ */
 function isValidBookmark(bookmark: Bookmark): boolean {
-    // Remove folder nodes and bad URLs
     try {
         return !!new URL(bookmark.url)
     } catch (e) {

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -44,7 +44,7 @@ function buildBookmarkPath(
     bookmark: browser.bookmarks.BookmarkTreeNode,
     allBookmarks: { string?: browser.bookmarks.BookmarkTreeNode },
 ): string {
-    if (bookmark.id === "root________") {
+    if (!bookmark.parentId) {
         return path
     }
     const parent = allBookmarks[bookmark.parentId]

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -9,26 +9,6 @@ export function newtaburl() {
     return newtab !== null ? browser.runtime.getURL(newtab) : null
 }
 
-export async function getAllBookmarks(): Promise<{
-    string?: browser.bookmarks.BookmarkTreeNode
-}> {
-    const bookmarks = await browserBg.bookmarks.getTree()
-    const allBookmarks = bookmarks.flatMap(flattenChildren)
-    return allBookmarks.reduce((dict, bookmark) => {
-        dict[bookmark.id] = bookmark
-        return dict
-    }, {})
-}
-
-function flattenChildren(
-    node: browser.bookmarks.BookmarkTreeNode,
-): browser.bookmarks.BookmarkTreeNode[] {
-    if (!node.children) {
-        return [node]
-    }
-    return [node, ...node.children.flatMap(flattenChildren)]
-}
-
 export type Bookmark = { path?: string } & browser.bookmarks.BookmarkTreeNode
 
 let allBookmarks: Bookmark[]
@@ -48,6 +28,15 @@ async function collectBookmarks(): Promise<Bookmark[]> {
         }))
         .filter(isValidBookmark)
         .sort((a, b) => b.dateAdded - a.dateAdded)
+}
+
+function flattenChildren(
+    node: browser.bookmarks.BookmarkTreeNode,
+): browser.bookmarks.BookmarkTreeNode[] {
+    if (!node.children) {
+        return [node]
+    }
+    return [node, ...node.children.flatMap(flattenChildren)]
 }
 
 function buildBookmarkPath(

--- a/src/completions/providers.ts
+++ b/src/completions/providers.ts
@@ -8,6 +8,26 @@ export function newtaburl() {
     return newtab !== null ? browser.runtime.getURL(newtab) : null
 }
 
+export async function getAllBookmarks(): Promise<{
+    string?: browser.bookmarks.BookmarkTreeNode
+}> {
+    const bookmarks = await browserBg.bookmarks.getTree()
+    const allBookmarks = bookmarks.flatMap(flattenChildren)
+    return allBookmarks.reduce((dict, bookmark) => {
+        dict[bookmark.id] = bookmark
+        return dict
+    }, {})
+}
+
+function flattenChildren(
+    node: browser.bookmarks.BookmarkTreeNode,
+): browser.bookmarks.BookmarkTreeNode[] {
+    if (!node.children) {
+        return [node]
+    }
+    return [node, ...node.children.flatMap(flattenChildren)]
+}
+
 export async function getBookmarks(query: string) {
     // Search bookmarks, dedupe and sort by most recent.
     let bookmarks = await browserBg.bookmarks.search({ query })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1161,6 +1161,11 @@ export class default_config {
     bmarkweight = 100
 
     /**
+     * Should folders be shown and filtered in bookmarks searches.
+     */
+    bmarkfoldersearch: "true" | "false" = "false"
+
+    /**
      * When displaying searchurls in history completions, how many page views to pretend they have.
      */
     searchurlweight = 150

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1161,7 +1161,7 @@ export class default_config {
     bmarkweight = 100
 
     /**
-     * Should folders be shown and filtered in bookmarks searches.
+     * Should folders be shown and filtered in bookmark searches.
      */
     bmarkfoldersearch: "true" | "false" = "false"
 


### PR DESCRIPTION
## Changes
1. Added folder prefixes to bookmarks list:
    * `:bmarks`: 
    ![image](https://github.com/user-attachments/assets/60e63206-97a4-4519-a494-8c4bf6f406c3)
    * `:tabopen`:
    ![image](https://github.com/user-attachments/assets/06dcd9f8-e5b6-4e91-abf3-6bc33d847ac6)
2. Search looks for bookmark path in addition to title and URL. This is done by caching all bookmarks in memory, since Firefox doesn't search in path in its `browser.bookmarks.search()` function.
![image](https://github.com/user-attachments/assets/7ec72231-6a31-4949-b7ce-d2b4caed5702)
3. Added configuration property `bmarkfoldersearch` to disable this functionality by default.
    * `bmarkfoldersearch=false` works as before:
    ![image](https://github.com/user-attachments/assets/304722d8-4fd1-4a7f-8f4c-a64c6348036a)

Relates to #4721.

## TODO:
- [x] Add search by path
- [x] Limit recursion by undefined parent instead of magic constant for root
- [x] Add configuration property to disable folders by default
- [x] Include folders in "Bookmarks and History" view
- [x] Add screenshots for different scenarios