### PR TITLE
Stop JS hint chars being prefixes of other hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -882,10 +882,12 @@ function buildHintsVimperator(
 ) {
     const hintablesfiltered = hintablesArray.map(h => ({ elements: h.elements.filter(el => Hint.isHintable(el)), hintclasses: h.hintclasses }))
     const totalhints = hintablesfiltered.reduce((n, h) => n + h.elements.length, 0)
+    const allnames = Array.from(
+        hintnames(totalhints + modeState.hints.length),
+    ).slice(modeState.hints.length)
+
     for (const hintables of hintablesfiltered) {
-        const names = Array.from(
-            hintnames(totalhints + modeState.hints.length),
-        ).slice(modeState.hints.length)
+        const names = allnames.slice(modeState.hints.length)
         for (const [el, name] of izip(hintables.elements, names)) {
             let ft = elementFilterableText(el)
             ft = vimpHelper.sanitiseHintText(ft)

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -478,27 +478,23 @@ export function hintPage(
     modeState = new HintState(filterHints, resolve, reject, rapid)
 
     if (!rapid) {
-        for (const hints of hintableElements) {
-            buildHints(hints, hint => {
-                modeState.cleanUpHints()
-                hint.result = onSelect(hint.target)
-                modeState.selectedHints.push(hint)
-                reset()
-            })
-        }
+        buildHints(hintableElements, hint => {
+            modeState.cleanUpHints()
+            hint.result = onSelect(hint.target)
+            modeState.selectedHints.push(hint)
+            reset()
+        })
     } else {
-        for (const hints of hintableElements) {
-            buildHints(hints, hint => {
-                hint.result = onSelect(hint.target)
-                modeState.selectedHints.push(hint)
-                if (
-                    modeState.selectedHints.length > 1 &&
-                    config.get("hintshift") === "true"
-                ) {
-                    modeState.shiftHints()
-                }
-            })
-        }
+        buildHints(hintableElements, hint => {
+            hint.result = onSelect(hint.target)
+            modeState.selectedHints.push(hint)
+            if (
+                modeState.selectedHints.length > 1 &&
+                config.get("hintshift") === "true"
+            ) {
+                modeState.shiftHints()
+            }
+        })
     }
 
     if (!modeState.hints.length) {
@@ -818,25 +814,28 @@ class Hint {
 
 /** @hidden */
 type HintBuilder = (
-    hintables: Hintables,
+    hintables: Hintables[],
     onSelect: HintSelectedCallback,
 ) => void
 
 /** @hidden */
 function buildHintsSimple(
-    hintables: Hintables,
+    hintablesArray: Hintables[],
     onSelect: HintSelectedCallback,
 ) {
-    const els = hintables.elements.filter(el => Hint.isHintable(el))
-    const names = Array.from(
-        hintnames(els.length + modeState.hints.length),
-    ).slice(modeState.hints.length)
-    for (const [el, name] of izip(els, names)) {
-        logger.debug({ el, name })
-        modeState.hintchars += name
-        modeState.hints.push(
-            new Hint(el, name, null, onSelect, hintables.hintclasses),
-        )
+    const hintablesfiltered = hintablesArray.map(h => ({ elements: h.elements.filter(el => Hint.isHintable(el)), hintclasses: h.hintclasses }))
+    const totalhints = hintablesfiltered.reduce((n, h) => n + h.elements.length, 0)
+    for (const hintables of hintablesfiltered) {
+        const names = Array.from(
+            hintnames(totalhints + modeState.hints.length),
+        ).slice(modeState.hints.length)
+        for (const [el, name] of izip(hintables.elements, names)) {
+            logger.debug({ el, name })
+            modeState.hintchars += name
+            modeState.hints.push(
+                new Hint(el, name, null, onSelect, hintables.hintclasses),
+            )
+        }
     }
 }
 
@@ -875,21 +874,24 @@ export const vimpHelper = {
 
 /** @hidden */
 function buildHintsVimperator(
-    hintables: Hintables,
+    hintablesArray: Hintables[],
     onSelect: HintSelectedCallback,
 ) {
-    const els = hintables.elements.filter(el => Hint.isHintable(el))
-    const names = Array.from(
-        hintnames(els.length + modeState.hints.length),
-    ).slice(modeState.hints.length)
-    for (const [el, name] of izip(els, names)) {
-        let ft = elementFilterableText(el)
-        ft = vimpHelper.sanitiseHintText(ft)
-        logger.debug({ el, name, ft })
-        modeState.hintchars += name + ft
-        modeState.hints.push(
-            new Hint(el, name, ft, onSelect, hintables.hintclasses),
-        )
+    const hintablesfiltered = hintablesArray.map(h => ({ elements: h.elements.filter(el => Hint.isHintable(el)), hintclasses: h.hintclasses }))
+    const totalhints = hintablesfiltered.reduce((n, h) => n + h.elements.length, 0)
+    for (const hintables of hintablesfiltered) {
+        const names = Array.from(
+            hintnames(totalhints + modeState.hints.length),
+        ).slice(modeState.hints.length)
+        for (const [el, name] of izip(hintables.elements, names)) {
+            let ft = elementFilterableText(el)
+            ft = vimpHelper.sanitiseHintText(ft)
+            logger.debug({ el, name, ft })
+            modeState.hintchars += name + ft
+            modeState.hints.push(
+                new Hint(el, name, ft, onSelect, hintables.hintclasses),
+            )
+        }
     }
 }
 

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -825,10 +825,13 @@ function buildHintsSimple(
 ) {
     const hintablesfiltered = hintablesArray.map(h => ({ elements: h.elements.filter(el => Hint.isHintable(el)), hintclasses: h.hintclasses }))
     const totalhints = hintablesfiltered.reduce((n, h) => n + h.elements.length, 0)
+
+    const allnames = Array.from(
+        hintnames(totalhints + modeState.hints.length),
+    ).slice(modeState.hints.length)
+
     for (const hintables of hintablesfiltered) {
-        const names = Array.from(
-            hintnames(totalhints + modeState.hints.length),
-        ).slice(modeState.hints.length)
+        const names = allnames.slice(modeState.hints.length)
         for (const [el, name] of izip(hintables.elements, names)) {
             logger.debug({ el, name })
             modeState.hintchars += name


### PR DESCRIPTION
For issues: [5149](https://github.com/tridactyl/tridactyl/issues/5149) and [5156](https://github.com/tridactyl/tridactyl/issues/5156).

Changes the way hint names are selected. When there are JS hints on a page, currently they don't affect the characters chosen for non-JS hints.

I've changed the HintBuilders to accept an array of Hintables objects (instead of a single Hintables object), and used the total number of hints to generate the hint names.