### PR TITLE
Added ability to move TST trees

### DIFF
--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -35,7 +35,10 @@ import { PreferenceCompletionSource } from "@src/completions/Preferences"
 import { RssCompletionSource } from "@src/completions/Rss"
 import { SessionsCompletionSource } from "@src/completions/Sessions"
 import { SettingsCompletionSource } from "@src/completions/Settings"
-import { BufferCompletionSource } from "@src/completions/Tab"
+import {
+    LinearBufferCompletionSource,
+    BufferTreeCompletionSource,
+} from "@src/completions/Tab"
 import { TabAllCompletionSource } from "@src/completions/TabAll"
 import { ThemeCompletionSource } from "@src/completions/Theme"
 import { TabHistoryCompletionSource } from "@src/completions/TabHistory"
@@ -120,7 +123,8 @@ export function enableCompletions() {
             BindingsCompletionSource,
             BmarkCompletionSource,
             TabAllCompletionSource,
-            BufferCompletionSource,
+            LinearBufferCompletionSource,
+            BufferTreeCompletionSource,
             ExcmdCompletionSource,
             ThemeCompletionSource,
             TabHistoryCompletionSource,

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -269,15 +269,15 @@ abstract class BufferCompletionSource extends Completions.CompletionSourceFuse {
 
     /**
      * Provide identifier, which will be used before tab title in the completion option.
-     * @param index of a tab calculated by Tridactyl
+     * @param index of the tab calculated by Tridactyl
      * @param tab Tab
      */
     protected abstract titlePrefix(index: number, tab: browser.tabs.Tab): number
 
     /**
      * Provide value, which will be used on tab completion (i.e. when user selects tab option using <Space> or <Enter>).
-     * @param index of a tab calculated by Tridactyl
-     * @param tab Tab
+     * @param titlePrefix identifier user before tab title
+     * @param isAlternative marker if completion value is for previous tab
      */
     protected abstract completionValue(
         titlePrefix: number,

--- a/src/completions/Tab.ts
+++ b/src/completions/Tab.ts
@@ -6,6 +6,9 @@ import * as Completions from "@src/completions"
 import * as config from "@src/lib/config"
 import * as Messaging from "@src/lib/messaging"
 
+// TODO: fix # value for TST
+// TODO: extract TST to a separate class
+
 class BufferCompletionOption
     extends Completions.CompletionOptionHTML
     implements Completions.CompletionOptionFuse {
@@ -95,7 +98,9 @@ export class BufferCompletionSource extends Completions.CompletionSourceFuse {
                 "tabrename",
                 "tabdiscard",
                 "pin",
-                "tstmovetree",
+                "tstmove",
+                "tstmoveafter",
+                "tstattach",
             ],
             "BufferCompletionSource",
             "Tabs",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -98,6 +98,7 @@ import { OpenMode } from "@src/lib/hint_util"
 import * as Proxy from "@src/lib/proxy"
 import * as arg from "@src/lib/arg_util"
 import * as R from "ramda"
+import * as treestyletab from "@src/interop/tst"
 
 /**
  * This is used to drive some excmd handling in `composite`.
@@ -2859,8 +2860,8 @@ export async function tabopen_helper({ addressarr = [], waitForDom = false }): P
         // and browser.search.search() seems to fix that problem.
         // See https://github.com/tridactyl/tridactyl/pull/4791.
         return openInNewTab(null, args, waitForDom)
-                   .then(tab => browser.tabs.get(tab.id))
-                   .then(tab => browser.search.search({tabId: tab.id, ...maybeURL}))
+            .then(tab => browser.tabs.get(tab.id))
+            .then(tab => browser.search.search({ tabId: tab.id, ...maybeURL }))
     }
 
     // Fall back to about:newtab
@@ -3055,7 +3056,7 @@ export async function tabcloseallto(side: string) {
 export async function tabdiscard(index: string) {
     let id: number
     if (index === "--all") {
-        return browser.tabs.query({}).then(ts => browser.tabs.discard(ts.map(t=>t.id)))
+        return browser.tabs.query({}).then(ts => browser.tabs.discard(ts.map(t => t.id)))
     } else if (index === undefined) {
         id = (await activeTab()).id
     } else {
@@ -3088,16 +3089,16 @@ export async function undo(item = "recent"): Promise<number> {
         item === "recent"
             ? s => s.window || (s.tab && s.tab.windowId === current_win_id)
             : item === "tab"
-            ? s => s.tab
-            : item === "tab_strict"
-            ? s => s.tab && s.tab.windowId === current_win_id
-            : item === "window"
-            ? s => s.window
-            : !isNaN(parseInt(item, 10))
-            ? s => (s.tab || s.window).sessionId === item
-            : () => {
-                  throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
-              } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
+              ? s => s.tab
+              : item === "tab_strict"
+                ? s => s.tab && s.tab.windowId === current_win_id
+                : item === "window"
+                  ? s => s.window
+                  : !isNaN(parseInt(item, 10))
+                    ? s => (s.tab || s.window).sessionId === item
+                    : () => {
+                          throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
+                      } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
     const session = sessions.find(predicate)
 
     if (session) {
@@ -3372,7 +3373,7 @@ export async function qall() {
 //#background
 export async function sidebaropen(...urllike: string[]) {
     const url = await queryAndURLwrangler(urllike)
-    if (typeof url === "string") return browser.sidebarAction.setPanel({panel: url})
+    if (typeof url === "string") return browser.sidebarAction.setPanel({ panel: url })
     throw new Error("Unsupported URL for sidebar. If it was a search term try `:set searchengine google` first")
 }
 
@@ -3382,7 +3383,7 @@ export async function sidebaropen(...urllike: string[]) {
  * `:bind --mode=browser <C-.> jsua browser.sidebarAction.open(); tri.excmds.sidebaropen("https://mail.google.com/mail/mu")`
  */
 //#background
-export async function jsua(){
+export async function jsua() {
     throw new Error(":jsua can only be called through `bind --mode=browser` binds, see `:help jsua`")
 }
 
@@ -3392,7 +3393,7 @@ export async function jsua(){
  * `:bind --mode=browser <C-.> sidebartoggle`
  */
 //#background
-export async function sidebartoggle(){
+export async function sidebartoggle() {
     throw new Error(":sidebartoggle can only be called through `bind --mode=browser` binds, see `:help sidebartoggle`")
 }
 
@@ -3947,7 +3948,7 @@ export function fillcmdline(...strarr: string[]) {
     const str = strarr.join(" ")
     showcmdline(false)
     logger.debug("excmds fillcmdline sending fillcmdline to commandline_frame")
-    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true/*trailspace*/, true/*focus*/])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true /*trailspace*/, true /*focus*/])
 }
 
 /** Set the current value of the commandline to string *without* a trailing space */
@@ -3955,7 +3956,7 @@ export function fillcmdline(...strarr: string[]) {
 export function fillcmdline_notrail(...strarr: string[]) {
     const str = strarr.join(" ")
     showcmdline(false)
-    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false/*trailspace*/, true/*focus*/])
+    return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false /*trailspace*/, true /*focus*/])
 }
 
 /** Show and fill the command line without focusing it */
@@ -6208,3 +6209,11 @@ export async function elementunhide() {
     elem.className = elem.className.replace("TridactylKilledElem", "")
 }
 // vim: tabstop=4 shiftwidth=4 expandtab
+
+/**
+ * Move the current TST tree to be just in front of the tab specified.
+ */
+//#background
+export async function tstmovetree(tabId: string) {
+    treestyletab.moveTreeBefore(Number(tabId))
+}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3089,16 +3089,16 @@ export async function undo(item = "recent"): Promise<number> {
         item === "recent"
             ? s => s.window || (s.tab && s.tab.windowId === current_win_id)
             : item === "tab"
-              ? s => s.tab
-              : item === "tab_strict"
-                ? s => s.tab && s.tab.windowId === current_win_id
-                : item === "window"
-                  ? s => s.window
-                  : !isNaN(parseInt(item, 10))
-                    ? s => (s.tab || s.window).sessionId === item
-                    : () => {
-                          throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
-                      } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
+            ? s => s.tab
+            : item === "tab_strict"
+            ? s => s.tab && s.tab.windowId === current_win_id
+            : item === "window"
+            ? s => s.window
+            : !isNaN(parseInt(item, 10))
+            ? s => (s.tab || s.window).sessionId === item
+            : () => {
+                  throw new Error(`[undo] Invalid argument: ${item}. Must be one of "recent, "tab", "tab_strict", "window" or a sessionId (by selecting a session using the undo completion).`)
+              } // this won't throw an error if there isn't anything in the session list, but I don't think that matters
     const session = sessions.find(predicate)
 
     if (session) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -6230,6 +6230,6 @@ export async function tstmoveafter(tabId: string) {
  * Attach current tree as a child to the selected parent.
  */
 //#background
-export async function tstattach(tabId: string) {
-    treestyletab.attachTree(Number(tabId))
+export async function tstattach(parentTabId: string) {
+    treestyletab.attachTree(Number(parentTabId))
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -6214,6 +6214,22 @@ export async function elementunhide() {
  * Move the current TST tree to be just in front of the tab specified.
  */
 //#background
-export async function tstmovetree(tabId: string) {
+export async function tstmove(tabId: string) {
     treestyletab.moveTreeBefore(Number(tabId))
+}
+
+/**
+ * Move the current TST tree to be right after the tab specified.
+ */
+//#background
+export async function tstmoveafter(tabId: string) {
+    treestyletab.moveTreeAfter(Number(tabId))
+}
+
+/**
+ * Attach current tree as a child to the selected parent.
+ */
+//#background
+export async function tstattach(tabId: string) {
+    treestyletab.attachTree(Number(tabId))
 }

--- a/src/interop/tst.ts
+++ b/src/interop/tst.ts
@@ -1,0 +1,10 @@
+import * as ExtensionInfo from "@src/lib/extension_info"
+
+export async function moveTreeBefore(tabId: number) {
+    await ExtensionInfo.messageExtension("tree_style_tab", {
+        type: "move-before",
+        tab: "current",
+        referenceTabId: tabId,
+        followChildren: true,
+    })
+}

--- a/src/interop/tst.ts
+++ b/src/interop/tst.ts
@@ -1,4 +1,5 @@
 import * as ExtensionInfo from "@src/lib/extension_info"
+import { browserBg } from "@src/lib/webext"
 
 export async function moveTreeBefore(tabId: number) {
     await ExtensionInfo.messageExtension("tree_style_tab", {
@@ -6,5 +7,23 @@ export async function moveTreeBefore(tabId: number) {
         tab: "current",
         referenceTabId: tabId,
         followChildren: true,
+    })
+}
+
+export async function moveTreeAfter(tabId: number) {
+    await ExtensionInfo.messageExtension("tree_style_tab", {
+        type: "move-after",
+        tab: "current",
+        referenceTabId: tabId,
+        followChildren: true,
+    })
+}
+
+export async function attachTree(parentTabId: number) {
+    const currentTab = (await browserBg.tabs.query({ active: true }))[0]
+    await ExtensionInfo.messageExtension("tree_style_tab", {
+        type: "attach",
+        child: currentTab.id,
+        parent: parentTabId,
     })
 }

--- a/src/interop/tst.ts
+++ b/src/interop/tst.ts
@@ -20,7 +20,9 @@ export async function moveTreeAfter(tabId: number) {
 }
 
 export async function attachTree(parentTabId: number) {
-    const currentTab = (await browserBg.tabs.query({ active: true }))[0]
+    const currentTab = (
+        await browserBg.tabs.query({ currentWindow: true, active: true })
+    )[0]
     await ExtensionInfo.messageExtension("tree_style_tab", {
         type: "attach",
         child: currentTab.id,

--- a/src/lib/extension_info.ts
+++ b/src/lib/extension_info.ts
@@ -5,13 +5,20 @@
 
  */
 
+import Logger from "./logging"
+
 /** Friendly-names of extensions that are used in different places so
     that we can refer to them with more readable and less magic ids.
  */
 export const KNOWN_EXTENSIONS: { [name: string]: string } = {
     temp_containers: "{c607c8df-14a7-4f28-894f-29e8722976af}",
     multi_account_containers: "@testpilot-containers",
+    tree_style_tab: "treestyletab@piro.sakura.ne.jp",
 }
+
+type KnownExtensionId = keyof typeof KNOWN_EXTENSIONS
+
+const logger = new Logger("extensions")
 
 /** List of currently installed extensions.
  */
@@ -83,4 +90,12 @@ export async function listExtensions() {
     return Object.keys(installedExtensions)
         .map(key => installedExtensions[key])
         .filter(obj => obj.optionsUrl.length > 0)
+}
+
+export async function messageExtension(id: KnownExtensionId, message: any) {
+    try {
+        return await browser.runtime.sendMessage(KNOWN_EXTENSIONS[id], message)
+    } catch (e) {
+        logger.error("Failed to communicate with extension ", id, e)
+    }
 }


### PR DESCRIPTION
It's annoying that it's impossible to move TST trees using keyboard commands (i.e. `:tabmove` works with indices, which are irrelevant in tree representation). Also, scripts don't help with this issue, since moving tabs to arbitrary position without completion is hard if not impossible.

Added 3 commans:
* `:tstmove` - same as `:tabmove` but moves the whole tree.
* `:tstmoveafter` - moves tree after the tab specified.
* `:tstattach` - attached current tree as a last child of the tab specified.

Tab representation is the same as before (linear) the main difference in logic is that TST commands use tab ID instead of indices.

Relates to #377.