### PR TITLE
Fix simulateClick for <a>s inside <svg>s

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -730,7 +730,9 @@ export function simulateClick(
     let usePopupBlockerWorkaround =
         (target as HTMLAnchorElement).target === "_blank" ||
         (target as HTMLAnchorElement).target === "_new"
-    const href = (target as HTMLAnchorElement).href
+    const href = (target instanceof SVGAElement)
+        ? target.href.animVal
+        : (target as HTMLAnchorElement).href;
     if (href?.startsWith("file:")) {
         // file URLS cannot be opend with browser.tabs.create
         // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#url


### PR DESCRIPTION
`<a>`s inside `<svg>`s don't return a string with `.href`, so this extra check is required.

To test, you can try clicking [the post tags on my blog](https://ellie.clifford.lol/blog/) with Tridactyl. Trying to do so without this patch fails with `TypeError: href.startsWith is not a function`.