### PR TITLE
Trim filename before source when using `js` or `jsb`

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5873,7 +5873,7 @@ async function js_helper(str: string[]) {
     }
 
     if (doSource) {
-        let sourcePath = jsContent
+        let sourcePath = jsContent.trim()
         if (fromRC) {
             const sep = "/"
             const rcPath = (await Native.getrcpath("unix")).split(sep).slice(0, -1)


### PR DESCRIPTION
As discussed on Matrix, when using `js -d$ -r script.js $ arg1 arg2`, the code splits `$` and the filename ends as `"script.js "` with a space at the end.
It does work when used like `js -d$ -r script.js$ arg1 arg2`, with no space before the `$`.

To avoid breaking back compatibility we can't change how the arguments are processed and stored into vars, but we can trim the filename before reading it since no-one would realistically keep a space at the end of a filename.