### PR TITLE
Allow styling typed letters separately when hinting

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -725,7 +725,12 @@ class Hint {
             height: rect.height,
         }
 
-        this.flag.textContent = name
+        // A span for each char so typed chars can be styled differently
+        for (const ch of name) {
+            let charspan = document.createElement("span")
+            charspan.textContent = ch
+            this.flag.appendChild(charspan)
+        }
         this.flag.className = "TridactylHint"
         if (config.get("hintuppercase") === "true") {
             this.flag.classList.add("TridactylHintUppercase")
@@ -748,7 +753,12 @@ class Hint {
 
     setName(n: string) {
         this.name = n
-        this.flag.textContent = this.name
+        this.flag.textContent = ""
+        for (const ch of n) {
+            let charspan = document.createElement("span")
+            charspan.textContent = ch
+            this.flag.appendChild(charspan)
+        }
     }
 
     // These styles would be better with pseudo selectors. Can we do custom ones?
@@ -910,6 +920,17 @@ function elementFilterableText(el: Element): string {
     return text.slice(0, 2048).toLowerCase() || ""
 }
 
+/** Apply a class to hint tag chars that have been typed so they can be styled.
+@hidden */
+function addFilteredCharClass(hint: Hint, fstr: string) {
+    for (let i = 0; i < fstr.length; ++i) {
+        hint.flag.children[i].className = "TridactylHintCharPressed"
+    }
+    for (let i = fstr.length; i < hint.flag.children.length; ++i) {
+        hint.flag.children[i].className = ""
+    }
+}
+
 /** @hidden */
 type HintFilter = (s: string) => void
 
@@ -935,6 +956,7 @@ function filterHintsSimple(fstr) {
                 foundMatch = true
             }
             h.hidden = false
+            addFilteredCharClass(h, fstr)
             active.push(h)
         }
     }
@@ -980,6 +1002,12 @@ function filterHintsVimperator(query: string, reflow = false) {
         const names = hintnames(hints.length)
         for (const [hint, name] of izip(hints, names)) {
             hint.name = name
+            hint.flag.textContent = ""
+            for (const ch of hint.name) {
+                let charspan = document.createElement("span")
+                charspan.textContent = ch
+                hint.flag.appendChild(charspan)
+            }
         }
     }
 
@@ -991,6 +1019,7 @@ function filterHintsVimperator(query: string, reflow = false) {
         if (run.isHintChar) {
             // Filter by label
             active = active.filter(hint => hint.name.startsWith(run.str))
+            active.forEach(hint => addFilteredCharClass(hint, run.str))
         } else {
             // By text
             active = active.filter(hint =>
@@ -1012,7 +1041,6 @@ function filterHintsVimperator(query: string, reflow = false) {
     for (const hint of modeState.hints) {
         if (active.includes(hint)) {
             hint.hidden = false
-            hint.flag.textContent = hint.name
         } else {
             hint.hidden = true
         }

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -727,7 +727,7 @@ class Hint {
 
         // A span for each char so typed chars can be styled differently
         for (const ch of name) {
-            let charspan = document.createElement("span")
+            const charspan = document.createElement("span")
             charspan.textContent = ch
             this.flag.appendChild(charspan)
         }
@@ -755,7 +755,7 @@ class Hint {
         this.name = n
         this.flag.textContent = ""
         for (const ch of n) {
-            let charspan = document.createElement("span")
+            const charspan = document.createElement("span")
             charspan.textContent = ch
             this.flag.appendChild(charspan)
         }
@@ -1004,7 +1004,7 @@ function filterHintsVimperator(query: string, reflow = false) {
             hint.name = name
             hint.flag.textContent = ""
             for (const ch of hint.name) {
-                let charspan = document.createElement("span")
+                const charspan = document.createElement("span")
                 charspan.textContent = ch
                 hint.flag.appendChild(charspan)
             }

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -16,11 +16,15 @@ span.TridactylHint {
     z-index: 2147483646 !important;
 }
 
+span.TridactylHintCharPressed {
+    color: var(--tridactyl-hintspan-pressed-fg) !important;
+}
+
 span.TridactylHintA {
     z-index: 2147483647 !important;
 }
 
-span.TridactylHintUppercase {
+span.TridactylHintUppercase, span.TridactylHintUppercase>span {
     text-transform: uppercase !important;
 }
 

--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -27,7 +27,7 @@
     --tridactyl-hintspan-font-size: var(--tridactyl-small-font-size);
     --tridactyl-hintspan-font-weight: bold;
     --tridactyl-hintspan-fg: white;
-    --tridactyl-hintspan-pressed-fg: grey;
+    --tridactyl-hintspan-pressed-fg: var(--tridactyl-hintspan-fg);
     --tridactyl-hintspan-bg: red;
     --tridactyl-hintspan-border-color: ButtonShadow;
     --tridactyl-hintspan-border-width: 0px;

--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -27,6 +27,7 @@
     --tridactyl-hintspan-font-size: var(--tridactyl-small-font-size);
     --tridactyl-hintspan-font-weight: bold;
     --tridactyl-hintspan-fg: white;
+    --tridactyl-hintspan-pressed-fg: grey;
     --tridactyl-hintspan-bg: red;
     --tridactyl-hintspan-border-color: ButtonShadow;
     --tridactyl-hintspan-border-width: 0px;


### PR DESCRIPTION
To facilitate the request in [this discussion](https://github.com/tridactyl/tridactyl/discussions/5225).

Changed hint spans to include a span for individual characters.
When there are multiple characters in a hint and the first n chars have been typed, those characters' spans are given a class, `TridactylHintCharTyped`.
A corresponding css var, `--tridactyl-hintspan-typed-fg` sets the colour for spans with the class so they can be coloured differently or hidden completely according to the current theme.

The css var needs to be overwritten by a theme otherwise it will be set to `--tridactyl-hintspan-fg` and have no effect. Here is an example with the `dark` theme with css var set to `grey`:

![447693162-46fb5202-8005-44f3-b105-670462292d37](https://github.com/user-attachments/assets/96253673-8445-48a1-9fef-0f2ec032162d)
