### PR TITLE
Make iframe inert when not visible

### DIFF
--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -114,6 +114,7 @@ export function show(hidehover = false) {
             document.body.removeChild(a)
         }
 
+        cmdline_iframe.inert = false;
         cmdline_iframe.classList.remove("hidden")
         const height =
             cmdline_iframe.contentWindow.document.body.offsetHeight + "px"
@@ -128,6 +129,7 @@ export function show(hidehover = false) {
 
 export function hide() {
     try {
+        cmdline_iframe.inert = true;
         cmdline_iframe.classList.add("hidden")
         cmdline_iframe.setAttribute("style", "height: 0px !important;")
     } catch (e) {

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -46,6 +46,9 @@ interface findResult {
 }
 
 interface HTMLElement {
+    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+    inert: boolean;
+
     // Let's be future proof:
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
     focus(options?: any): void


### PR DESCRIPTION
This prevents it from being accidentally focused when it's not meant to be. https://web.dev/articles/inert#offscreen_or_hidden_dom_elements

Inert was added in FF 112 which is earlier than FF 114, which seems to be the minimum supported version?

This was mainly solving an issue with slack where opening the command line and then closing it would cause slack to "restore focus to the last focused element" which in this case is the command line iframe. This is called anytime the slack window gains focus, but focusing the iframe causes it to lose focus which makes it actually impossible to focus anything after that.