### PR TITLE
Fix smooth scrolling in Firefox 141

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -83,11 +83,11 @@ class ScrollingData {
             // We need to ceil() because only highdpi screens have a decimal this.elem[this.pos]
             pixelToScrollTo = Math.ceil(pixelToScrollTo)
             // We *have* to make progress, otherwise we'll think the element can't be scrolled
-            if (pixelToScrollTo == this.elem[this.scrollDirection])
+            if (pixelToScrollTo == Math.ceil(this.elem[this.scrollDirection]))
                 pixelToScrollTo += 1
         } else {
             pixelToScrollTo = Math.floor(pixelToScrollTo)
-            if (pixelToScrollTo == this.elem[this.scrollDirection])
+            if (pixelToScrollTo == Math.floor(this.elem[this.scrollDirection]))
                 pixelToScrollTo -= 1
         }
         return pixelToScrollTo


### PR DESCRIPTION
This pull request fixes the issue: https://github.com/tridactyl/tridactyl/issues/5240 .

Relevant code:
https://github.com/tridactyl/tridactyl/blob/344fc9fad7d6787f8ec4425984740baa56d72abf/src/content/scrolling.ts#L88-L103

On Firefox 140 `this.elem[this.scrollDirection]` will always return an interger number. However, in Firefox 141, it sometimes returns a float.

The following assumptions are based on my testing in Firefox 141 and 140:

Assume:
`pixelToScrollTo = 564.7`
`this.elem[this.scrollDirection] = 564.7`

With `pixelToScrollTo = Math.ceil(pixelToScrollTo)`, we get:
`pixelToScrollTo = 565`

Thus, `pixelToScrollTo == this.elem[this.scrollDirection]` returns `false`, and the function will return 565.

https://github.com/tridactyl/tridactyl/blob/344fc9fad7d6787f8ec4425984740baa56d72abf/src/content/scrolling.ts#L106-L111

In the function `scrollStep`, we assign `pixelToScrollTo` to `this.elem[this.scrollDirection]`, but in Firefox 141, this doesn't work as expected. After the assignment, `this.elem[this.scrollDirection]` remains 564.7, so `prevScrollPos === this.elem[this.scrollDirection]` still holds true, and the function returns `false`.

I don't know why `this.elem[this.scrollDirection]` is a float in Firefox 141 but not in Firefox 140. I also don’t have a high-DPI display to test the behavior in Firefox 140 (e.g., what happens if `this.elem[this.scrollDirection]` is 564.7 and you assign it 565? If it behaves like Firefox 141, then the same problem would occur).

By using `Math.ceil(this.elem[this.scrollDirection])`, we ensure that the delta is always >= 1. I _think_ this works — and in my testing, it does.
