### PR TITLE
Reset hint char styles when rapidly selecting hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -497,6 +497,7 @@ export function hintPage(
                 ) {
                     modeState.shiftHints()
                 }
+                removeFilteredCharClass()
             })
         }
     }
@@ -929,6 +930,12 @@ function addFilteredCharClass(hint: Hint, fstr: string) {
     for (let i = fstr.length; i < hint.flag.children.length; ++i) {
         hint.flag.children[i].className = ""
     }
+}
+
+/** Remove the filtered char class from all hints - for resetting the style when rapid hinting
+@hidden */
+function removeFilteredCharClass() {
+    document.querySelectorAll(".TridactylHintCharPressed").forEach(el => el.classList.remove("TridactylHintCharPressed"))
 }
 
 /** @hidden */


### PR DESCRIPTION
I neglected rapid hinting when adding styles to typed hint chars in https://github.com/tridactyl/tridactyl/pull/5226 -this simply adds a `querySelectorAll` in `hintPage` to find all chars with the new class and remove the class, so the hint flags will reset to their initial appearance every time a hint is selected.