### PR TITLE
Reinsert the iframe if it's removed before document.readyState "complete"

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -316,7 +316,7 @@ config.getAsync("modeindicator").then(mode => {
 
     // This listener makes the modeindicator disappear when the mouse goes over it
     statusIndicator.addEventListener("mouseenter", ev => {
-        const target = ev.target as any
+        const target = ev.target
         const rect = target.getBoundingClientRect()
         target.classList.add("TridactylInvisible")
         const onMouseOut = ev => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -267,6 +267,7 @@ if (
 }
 
 // Really bad status indicator
+let statusIndicator
 config.getAsync("modeindicator").then(mode => {
     if (mode !== "true") return
 
@@ -284,7 +285,7 @@ config.getAsync("modeindicator").then(mode => {
         }
     }`
 
-    const statusIndicator = document.createElement("span")
+    statusIndicator = document.createElement("span")
     const privateMode = browser.extension.inIncognitoContext
         ? "TridactylPrivate"
         : ""
@@ -467,6 +468,20 @@ document.addEventListener("selectionchange", () => {
         contentState.mode = "visual"
     }
 })
+
+// Try to catch the iframe/status indicator being removed by a script (React again)
+const checkElemsSurvived = () => {
+    if (document.readyState === "complete") {
+        commandline_content.ensureIframeExists()
+
+        if (statusIndicator !== undefined)
+            document.body.appendChild(statusIndicator)
+
+        // We only want to check the iframe survived between "interactive" and "complete"
+        document.removeEventListener("readystatechange", checkElemsSurvived)
+    }
+}
+document.addEventListener("readystatechange", checkElemsSurvived)
 
 // Listen for statistics from each content script and send them to the
 // background for collection. Attach the observer to the window object

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -74,10 +74,10 @@ async function init() {
             const completeHandler = () => {
                 if (document.readyState === "complete") {
                     ensureIframeExists()
-                    window.removeEventListener("readystatechange", completeHandler)
+                    document.removeEventListener("readystatechange", completeHandler)
                 }
             }
-            window.addEventListener("readystatechange", completeHandler)
+            document.addEventListener("readystatechange", completeHandler)
         }
     }
 }
@@ -111,7 +111,6 @@ init().catch(() => {
 
 function ensureIframeExists() {
     if (!cmdline_iframe.isConnected) {
-        console.log("iframe was not connected! putting it back...")
         document.documentElement.appendChild(cmdline_iframe)
     }
 }

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -69,16 +69,6 @@ async function init() {
                 ).observe(cmdline_iframe.parentNode, { childList: true, subtree: true })
             }
         })
-        // React sites can replace the documentElement between readyState "interactive" and "complete"
-        if (document.readyState !== "complete") {
-            const completeHandler = () => {
-                if (document.readyState === "complete") {
-                    ensureIframeExists()
-                    document.removeEventListener("readystatechange", completeHandler)
-                }
-            }
-            document.addEventListener("readystatechange", completeHandler)
-        }
     }
 }
 
@@ -109,8 +99,8 @@ init().catch(() => {
     )
 })
 
-function ensureIframeExists() {
-    if (!cmdline_iframe.isConnected) {
+export function ensureIframeExists() {
+    if (cmdline_iframe && !cmdline_iframe.isConnected) {
         document.documentElement.appendChild(cmdline_iframe)
     }
 }


### PR DESCRIPTION
Another attempt to stop React sites removing the cmdline as mentioned in issue [5050](https://github.com/tridactyl/tridactyl/issues/5050).

These pages mentioned in the issue:
https://www.opensourcealternative.to/alternativesto/davinci-resolve
https://shopify.dev/docs/api/admin-graphql

are still affected and attempting to open the commandline causes keypresses to be ignored.

The `documentElement` is replaced causing the iframe to disappear before it can load. If the iframe is removed once `document.readyState` is `"complete"`, this change will add it back.
I also added a check in the `show` function, though in testing just listening for the ready state was enough.