### PR TITLE
Attempt to restore Tridactyl if document.open, write or writeln are called

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -111,6 +111,7 @@ const visual = await import("@src/lib/visual")
 const metadata = await import("@src/.metadata.generated")
 const { tabTgroup } = await import("@src/lib/tab_groups")
 const completion_providers = await import("@src/completions/providers")
+const registry = await import("@src/content/element_registry")
 
 controller.setExCmds({
     "": excmds_content,
@@ -159,10 +160,30 @@ function listen(elem) {
         true,
     )
 }
-listen(window)
-document.addEventListener("readystatechange", _ =>
-    getAllDocumentFrames().forEach(f => listen(f)),
-)
+
+function listenInAllFrames() {
+    listen(window)
+    document.addEventListener("readystatechange", _ =>
+        getAllDocumentFrames().forEach(f => listen(f)),
+    )
+}
+
+// Grouped functions which hijack page functions
+function hookPageFunctions() {
+    try {
+        dom.setupFocusHandler()
+        dom.hijackPageListenerFunctions()
+        hijackDocumentDestroyingFunctions()
+    } catch (e) {
+        logger.warning("Could not hijack due to CSP:", e)
+    }
+}
+
+// Register essential functions - generally window listeners required for Tridactyl to function
+;[listenInAllFrames, addVisualModeListeners, hookPageFunctions].forEach(fn => registry.registerSetupFunction(fn))
+
+// Similar to essential functions above, except only needed to run if the original document is lost
+;[reinsertLostCSS].forEach(fn => registry.registerRestoreFunction(fn))
 
 // Prevent pages from automatically focusing elements on load
 config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
@@ -242,7 +263,7 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
 
 logger.info("Loaded commandline content?", commandline_content)
 
-const addVisualModeListeners = () => {
+function addVisualModeListeners() {
     document.addEventListener("selectionchange", () => {
         const selection = document.getSelection()
         if (
@@ -264,58 +285,46 @@ const addVisualModeListeners = () => {
     })
 }
 
+function reinsertLostCSS() {
+    webext.ownTabId().then(tabId => {
+        ["cleanslate","content","hint","viewsource"].forEach(file =>
+            webext.browserBg.tabs.insertCSS(tabId, {
+                file: browser.runtime.getURL("static/css/" + file + ".css")
+            }))
+    })
+    styling.theme(document.documentElement)
+}
+
 /**
 * Hook document.open/write/writeln to fix Tridactyl when they're called
 * Calls to these functions cause us to lose all elements and listeners
 * eg: htmlpreview.github.io sites like https://htmlpreview.github.io/?https://github.com/FiloSottile/age/blob/main/doc/age.1.html
 */
-const hijackDocumentDestroyingFunctions = () => {
-    const addListenersAndStyles = () => {
-        listen(window)
-
-        webext.ownTabId().then(tabId => {
-            ["cleanslate","content","hint","viewsource"].forEach(file =>
-                webext.browserBg.tabs.insertCSS(tabId, {
-                    file: browser.runtime.getURL("static/css/" + file + ".css")
-                }))
-        })
-
-        styling.theme(document.documentElement)
-        dom.setupFocusHandler()
-        dom.hijackPageListenerFunctions()
-        addVisualModeListeners()
-    }
-
-    // Store element refs before open/write/writeln is called
+function hijackDocumentDestroyingFunctions() {
     const preCall = () => {
-        const docEl = document.documentElement
-        const cmdln = document.querySelector("#cmdline_iframe")
-        const indicator = document.querySelector(".TridactylStatusIndicator")
-        // Remove these in case they interfere with the next document.write or writeln call
-        if (docEl.id === "TempTridactylDocumentElement") docEl.remove()
-        cmdln?.remove()
-        indicator?.remove()
-        return { docEl, cmdln, indicator }
+        registry.removeAllElements()
+        document.querySelector("#TempTridactylDocumentElement")?.remove()
+        return document.documentElement
     }
 
     // Restore elements after the call and listeners if the documentElement has changed
-    const postCall = (oldDocElems) => {
+    const postCall = (previousDocEl) => {
         if (!document.documentElement) {
             // There's no documentElement at all when document.open is called
             const tempDocEl = document.createElement("html")
             tempDocEl.id = "TempTridactylDocumentElement"
+            const tempHead = document.createElement("head")
+            const tempBody = document.createElement("body")
+            tempDocEl.appendChild(tempHead)
+            tempDocEl.appendChild(tempBody)
             document.appendChild(tempDocEl)
         }
-        if (oldDocElems.cmdln) document.documentElement.appendChild(oldDocElems.cmdln)
-        if (oldDocElems.indicator) {
-            // A <body> may not exist now
-            const parent = document.body || document.documentElement
-            parent.appendChild(oldDocElems.indicator)
-        }
+
+        registry.appendAllElements()
 
         // Add listeners for newly replaced document
-        if (document.documentElement !== oldDocElems.docEl) {
-            addListenersAndStyles()
+        if (document.documentElement !== previousDocEl) {
+            registry.callAllSetupFunctions()
         }
     }
 
@@ -330,20 +339,12 @@ const hijackDocumentDestroyingFunctions = () => {
             const pre = window._preDocWrite;
             const post = window._postDocWrite;
             return function (...args) {
-                const elems = pre();
+                const previousDocEl = pre();
                 const result = realFn.apply(this, args);
-                post(elems);
+                post(previousDocEl);
                 return result;
             }
         })(Document.prototype.${cur});`, "") + "delete window._preDocWrite;delete window._postDocWrite;")
-}
-
-try {
-    dom.setupFocusHandler()
-    dom.hijackPageListenerFunctions()
-    hijackDocumentDestroyingFunctions()
-} catch (e) {
-    logger.warning("Could not hijack due to CSP:", e)
 }
 
 if (
@@ -362,6 +363,8 @@ if (
         }
     })
 }
+
+registry.callAllSetupFunctions()
 
 // Really bad status indicator
 let statusIndicator
@@ -510,6 +513,8 @@ config.getAsync("modeindicator").then(mode => {
             statusIndicator.classList.remove("TridactylInvisble")
         }
     })
+
+    registry.registerElement(statusIndicator)
 })
 
 function protectSlash(e) {
@@ -546,8 +551,6 @@ window.addEventListener("load", () => {
     phoneHome()
 })
 
-addVisualModeListeners()
-
 // Try to catch the iframe/status indicator being removed by a script (React again)
 const checkElemsSurvived = () => {
     if (document.readyState === "complete") {
@@ -561,7 +564,6 @@ const checkElemsSurvived = () => {
     }
 }
 document.addEventListener("readystatechange", checkElemsSurvived)
-
 // Listen for statistics from each content script and send them to the
 // background for collection. Attach the observer to the window object
 // since there's apparently a bug that causes performance observers to

--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -3,6 +3,7 @@
 import Logger from "@src/lib/logging"
 import * as config from "@src/lib/config"
 import { theme } from "@src/content/styling"
+import * as registry from "@src/content/element_registry"
 const logger = new Logger("messaging")
 const cmdline_logger = new Logger("cmdline")
 
@@ -48,6 +49,7 @@ async function init() {
     if (noiframe === "false" && notridactyl !== "true" && !enabled) {
         hide()
         document.documentElement.appendChild(cmdline_iframe)
+        registry.registerElement(cmdline_iframe)
         enabled = true
         // first theming of page root
         await theme(window.document.querySelector(":root"))
@@ -79,8 +81,10 @@ export async function reactIsCrap(){
     cmdline_logger.warning("Possible react server-side render failure detected, starting iframe protection loop")
     while(true){
         if (cmdline_iframe.contentWindow == null) {
+            registry.unregisterElement(cmdline_iframe)
             makeIframe()
             document.documentElement.appendChild(cmdline_iframe)
+            registry.registerElement(cmdline_iframe)
         }
         await new Promise(resolve => setTimeout(resolve, 500))
     }

--- a/src/content/element_registry.ts
+++ b/src/content/element_registry.ts
@@ -1,0 +1,73 @@
+import { getSelector } from "@src/lib/dom"
+
+// If order matters (eg insert cmdline before mode indicator?), use an array
+// const tridactylElementRegistry = new Set()
+
+// In fact, let's use an array
+let tridactylElementRegistry = []
+
+let tridactylSetupFnRegistry = []
+
+export function registerElement(element: Element) {
+    if (tridactylElementRegistry.indexOf(element) === -1) {
+        tridactylElementRegistry.push(element)
+    }
+}
+
+export function unregisterElement(element: Element) {
+    tridactylElementRegistry = tridactylElementRegistry.filter(e => e !== element)
+}
+
+export function appendAndRegisterElement(element: Element, parentElement: Element) {
+    parentElement.appendChild(element)
+    registerElement(element)
+}
+
+// Call Element.remove on each element, but keep them in the registry
+export function removeAllElements() {
+    tridactylElementRegistry.forEach(element => {
+        element.remove()
+    })
+}
+
+// Call appendChild on each element's target parent, attempting to match its old parent
+export function appendAllElements() {
+    tridactylElementRegistry.forEach(element => {
+        const originalParent = element.parentElement
+        let newParent
+        if (originalParent) {
+            const parentSelector = getSelector(element.parentElement)
+            newParent = document.querySelector(parentSelector)
+        } else {
+            newParent = document.documentElement
+        }
+        newParent.appendChild(element)
+    })
+}
+
+export function registerSetupFunction(fn: any) {
+    if (tridactylSetupFnRegistry.indexOf(fn) === -1) {
+        tridactylSetupFnRegistry.push(fn)
+    }
+}
+
+// Separate functions which only need to be run if the original document was lost
+let restorativeFunctions = []
+export function registerRestoreFunction(fn: any) {
+    if (restorativeFunctions.indexOf(fn) === -1) {
+        restorativeFunctions.push(fn)
+    }
+}
+
+export function unregisterSetupFunction(fn: any) {
+    tridactylSetupFnRegistry = tridactylSetupFnRegistry.filter(f => f !== fn)
+}
+
+// Should usually only be called once, but may be called again (due to document.open / document.write)
+// merges "restorativeFunctions" into the fn registry so that they will be run on any subsequent calls
+export function callAllSetupFunctions() {
+    tridactylSetupFnRegistry.forEach(fn => fn())
+    restorativeFunctions.forEach(fn => tridactylSetupFnRegistry.push(fn))
+    restorativeFunctions = []
+}
+

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -497,6 +497,7 @@ export function hintPage(
                 ) {
                     modeState.shiftHints()
                 }
+                removeFilteredCharClass()
             })
         }
     }
@@ -929,6 +930,12 @@ function addFilteredCharClass(hint: Hint, fstr: string) {
     for (let i = fstr.length; i < hint.flag.children.length; ++i) {
         hint.flag.children[i].className = ""
     }
+}
+
+/** Remove the filtered char class from all hints - for resetting the style when rapid hinting
+@hidden */
+function removeFilteredCharClass() {
+    document.querySelectorAll(".TridactylHintCharPressed").forEach(el => el.classList.remove("TridactylHintCharPressed"))
 }
 
 /** @hidden */


### PR DESCRIPTION
Regarding https://github.com/tridactyl/tridactyl/issues/5259.

Some sites use the (deprecated) `document.open` / `document.write` / `document.writeln` functions which create entirely new `document` objects. Event listeners and elements are consequently lost.

This hijacks those functions to ~dispatch an event~ call an exported function before the `document` is replaced, allowing us to readd listeners, the commandline and status indicator.

I'm not sure that I've found every listener which needs re-listening.

This also assumes that `document.close` will be promptly called, as that's when everything will be readded.