### PR TITLE
Hint nested & closed shadows

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -738,10 +738,9 @@ export function simulateClick(
     let usePopupBlockerWorkaround =
         (target as HTMLAnchorElement).target === "_blank" ||
         (target as HTMLAnchorElement).target === "_new"
-    const href =
-        target instanceof SVGAElement
-            ? target.href.animVal
-            : (target as HTMLAnchorElement).href
+    const href = (target instanceof SVGAElement)
+        ? target.href.animVal
+        : (target as HTMLAnchorElement).href;
     if (href?.startsWith("file:")) {
         // file URLS cannot be opend with browser.tabs.create
         // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#url


### PR DESCRIPTION
Updated `dom.getShadowElementsBySelector` to also check for shadow doms within shadow doms. I also swapped `.shadowRoot` for `.openOrClosedShadowRoot` because it allows getting elements from within closed shadows.

Without some extra work to get some styles working in shadows, hintable elements won't be styled.

Hinting should now work for pages with nested shadows. Here's an example: the [open uni homepage](https://www.open.ac.uk/) which has a bunch of unhintable elements.

Before:
<img width="547" height="162" alt="Screenshot 2025-09-09 at 19 23 42" src="https://github.com/user-attachments/assets/99a74114-171f-4710-aa5f-480092194a23" />

After:
<img width="555" height="162" alt="Screenshot 2025-09-09 at 19 25 22" src="https://github.com/user-attachments/assets/78c5cab1-6a59-4f0c-ba94-4d2249fcf0d2" />

