### PR TITLE
Allow XHTML pages

### DIFF
--- a/src/content/commandline_content.ts
+++ b/src/content/commandline_content.ts
@@ -40,7 +40,7 @@ async function init() {
     const noiframe = await config.getAsync("noiframe")
     const notridactyl = await config.getAsync("superignore")
 
-    if (document.contentType.includes("xml")) {
+    if (document.contentType != "application/xhtml+xml" && document.contentType.includes("xml")) {
         logger.info("Content type is xml; aborting iframe injection.")
         return
     }


### PR DESCRIPTION
Problem: Tridactyl doesn't work on XHTML sites, for example https://ncatlab.org/nlab/show/HomePage
Solution: Loose the XML content-type check
see https://en.wikipedia.org/wiki/XHTML