### PR TITLE
allow for empty or plaintext-only contenteditable values

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2453,7 +2453,7 @@ input:not([disabled]):not([readonly]):-moz-any(
 textarea:not([disabled]):not([readonly]),
 object,
 [role='application'],
-[contenteditable='true'][role='textbox']
+[contenteditable][role='textbox']:not([contenteditable='false'])
 `
 
 /** Password field selectors

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -44,7 +44,7 @@ export function isTextEditable(element: Element) {
                 // This happens on e.g. svgs.
                 return false
             }
-            if (element.contentEditable.toUpperCase() === "TRUE") {
+            if (element.isContentEditable) {
                 return true
             }
         }


### PR DESCRIPTION
Discussed in #5267, the `contenteditable` attribute can be set to `'true'`, `'false'` or `'plaintext-only`', or it is set to `'inherit'` if given an invalid value. Empty values are treated as `'true'`.

This PR swaps a check for it being `'true'` with a check of the element's `isContentEditable` property and changes the related selector in `INPUTTAGS_selectors` to look for anything with a `contenteditable` value that's not `'false'`.

This should make Tridactyl correctly enter input mode for more `contenteditable` elements.