### PR TITLE
Focus after tabdetach

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2990,7 +2990,16 @@ export async function tabduplicate(index?: number) {
 */
 //#background
 export async function tabdetach(index?: number) {
-    return browser.windows.create({ tabId: await idFromIndex(index) })
+    const tabId = await idFromIndex(index)
+    const currentTab = await browser.tabs.get(tabId)
+    const tempTab = (await browser.windows.create({ incognito: currentTab.incognito })).tabs[0]
+    await browser.tabs.move(tabId, { index: -1, windowId: tempTab.windowId })
+    browser.tabs.remove(tempTab.id)
+    browser.tabs.update(tabId, { active: true })
+    return browser.windows.get(tempTab.windowId)
+
+    // Above is a workaround for the original not giving the page focus in the new window
+    // return browser.windows.create({ tabId: await idFromIndex(index) })
 }
 
 /** Toggle fullscreen state

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2990,6 +2990,7 @@ export async function tabduplicate(index?: number) {
 */
 //#background
 export async function tabdetach(index?: number) {
+    // Workaround for detached tabs not getting focus (issue #5273)
     const tabId = await idFromIndex(index)
     const currentTab = await browser.tabs.get(tabId)
     const tempTab = (await browser.windows.create({ incognito: currentTab.incognito })).tabs[0]
@@ -2997,9 +2998,6 @@ export async function tabdetach(index?: number) {
     browser.tabs.remove(tempTab.id)
     browser.tabs.update(tabId, { active: true })
     return browser.windows.get(tempTab.windowId)
-
-    // Above is a workaround for the original not giving the page focus in the new window
-    // return browser.windows.create({ tabId: await idFromIndex(index) })
 }
 
 /** Toggle fullscreen state


### PR DESCRIPTION
Discussed in #5273: the window created by `:tabdetach` doesn't give focus to the page so Tridactyl hotkeys don't work. This workaround creates a new window before moving the tab into it and removing the initial tab from the new window.

This seems to be caused by a Firefox issue so this can be reverted if it's fixed.