### PR TITLE
Enhance theming with hint element overlays

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -773,34 +773,32 @@ class Hint {
             for (const recti of clientRects) {
                 if (recti !== rect) {
                     const extraRect = document.createElement("div")
-                    extraRect.style.top = `${recti.top - rect.top}px`
-                    extraRect.style.left = `${recti.left - rect.left}px`
                     extraRect.style.cssText = `
-                        inset: ${recti.top - rect.top}px ${recti.left - rect.left}px;
-                        width: ${recti.width}px;
-                        height: ${recti.height}px;
+                        inset: ${recti.top - rect.top}px ${recti.left - rect.left}px !important;
+                        width: ${recti.width}px !important;
+                        height: ${recti.height}px !important;
                     `
                     mainRect.appendChild(extraRect)
                 } else {
                     mainRect.style.top = `${recti.top + window.scrollY}px`
                     mainRect.style.left = `${recti.left + window.scrollX}px`
                     mainRect.style.cssText = `
-                        inset: ${rect.top + window.scrollY}px ${rect.left + window.scrollX}px;
-                        width: ${rect.width}px;
-                        height: ${rect.height}px;
+                        inset: ${rect.top + window.scrollY}px ${rect.left + window.scrollX}px !important;
+                        width: ${rect.width}px !important;
+                        height: ${rect.height}px !important;
                         `
                 }
             }
 
             if (modeState.highlightHost) {
                 this.highlight = mainRect
-                this.highlight.classList.add("TridactylHintHighlight")
                 modeState.highlightHost.appendChild(this.highlight)
                 if (modeState.outlineHost) {
                     this.outline = mainRect.cloneNode(true) as HTMLElement
                     this.outline.classList.add("TridactylHintOutline")
                     modeState.outlineHost.appendChild(this.outline)
                 }
+                this.highlight.classList.add("TridactylHintHighlight")
             } else {
                 this.outline = mainRect
                 this.outline.classList.add("TridactylHintOutline")

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -576,8 +576,8 @@ export function hintPage(
     modeState.hud.appendChild(modeState.hudTranslate)
     document.documentElement.appendChild(modeState.hud)
     modeState.deOverlap()
-    window.removeEventListener("scroll", onscroll)
-    window.addEventListener("scroll", onscroll)
+    window.removeEventListener("scroll", updateHudOffset)
+    window.addEventListener("scroll", updateHudOffset)
 }
 
 /** @hidden */
@@ -768,8 +768,10 @@ class Hint {
         this.flag.classList.add("TridactylHint" + target.tagName)
         classes?.forEach(f => this.flag.classList.add(f))
 
+        // Optional add overlays
         if (modeState.highlightHost  || modeState.outlineHost) {
             const mainRect = document.createElement("div")
+            // Add all rectangles for highlights / outlines
             for (const recti of clientRects) {
                 if (recti !== rect) {
                     const extraRect = document.createElement("div")
@@ -911,31 +913,10 @@ class Hint {
         top: ${this._y}px !important;
         left: ${this._x}px !important;
         `
-        // Don't like all these conditionals. Use separate functions or something
-        /*
-        if (this.highlight) {
-            this.highlight.style.cssText = `
-            inset: ${this.rect.top}px ${this.rect.left}px !important;
-            width: ${this.rect.width}px !important;
-            height: ${this.rect.height}px !important;
-            `
-            console.log(this.highlight.style.cssText)
-
-            if (this.outline) {
-                this.outline.style.cssText = this.highlight.style.cssText
-            }
-        } else if (this.outline) {
-            this.outline.style.cssText = `
-            inset: ${this.rect.top}px ${this.rect.left}px !important;
-            width: ${this.rect.width}px !important;
-            height: ${this.rect.height}px !important;
-            `
-        }
-        */
     }
 }
 
-function onscroll() {
+function updateHudOffset() {
     modeState.hudTranslate.style.translate = `${-window.scrollX}px ${-window.scrollY}px`
 }
 
@@ -1182,12 +1163,12 @@ function filterHintsVimperator(query: string, reflow = false) {
  **/
 function reset() {
     if (modeState) {
-        window.removeEventListener("scroll", onscroll)
         modeState.cleanUpHints()
         modeState.resolveHinting()
     }
     modeState = undefined
     contentState.mode = "normal"
+    window.removeEventListener("scroll", updateHudOffset)
 }
 
 function popKey() {

--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -58,7 +58,7 @@ export async function theme(element) {
 
     const hintElemRules =
         (hintElemOptions.fg === "all"
-            ? "    color: var(--tridactyl-hint-active-fg) !important;\n"
+            ? "    color: var(--tridactyl-hint-fg) !important;\n"
             : "") +
         (hintElemOptions.bg === "all"
             ? "    background: var(--tridactyl-hint-bg) !important;\n"
@@ -78,13 +78,23 @@ export async function theme(element) {
             ? "    outline: var(--tridactyl-hint-active-outline) !important;\n"
             : "")
 
+    // If these are set to "none" they won't be added to the page at all so only need to handle active
+    const activeOverlayRules =
+        (hintElemOptions.overlay === "active"
+            ? ".TridactylHintHighlight { display:none; } .TridactylHintHighlightActive { display: block !important; }"
+            : "") +
+        (hintElemOptions.overlayoutline === "active"
+            ? ".TridactylHintOutline { display:none; } .TridactylHintOutlineActive { display: block !important; }"
+            : "")
+
     hintElemCss.code =
         (hintElemRules !== ""
             ? ".TridactylHintElem {\n" + hintElemRules + "}\n"
             : "") +
         (activeElemRules !== ""
             ? ".TridactylHintActive {\n" + activeElemRules + "}\n"
-            : "")
+            : "") +
+            activeOverlayRules
 
     if (hintElemCss.code !== "") {
         await browserBg.tabs.insertCSS(await ownTabId(), hintElemCss)
@@ -152,6 +162,7 @@ function retheme() {
 }
 
 config.addChangeListener("theme", retheme)
+config.addChangeListener("hintstyles", retheme)
 
 /**
  * DEPRECATED

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -6372,4 +6372,27 @@ export async function profilerename(oldName: string, newName: string) {
     }
 }
 
+/**
+ * Disable all hilighting of hintable elements when hinting.
+ * Only hint flags will remain, Vimium style.
+ */
+export function hintstylesnohighlights() {
+    ["fg","bg","outline","overlay","overlayoutline"].forEach(type => config.set("hintstyles", type, "none"))
+}
+
+/**
+ * Add highlights over the page when hinting and leave original elements unchanged.
+ */
+export function hintstylesoverlays() {
+    ["bg","outline"].forEach(type => config.set("hintstyles", type, "none"))
+    ;["fg", "overlay","overlayoutline"].forEach(type => config.set("hintstyles", type, "all"))
+}
+
+/**
+ * Style hintable elements directly when hinting.
+ */
+export function hintstylesdirect() {
+    ["fg","bg","outline"].forEach(type => config.set("hintstyles", type, "all"))
+    ;["overlay","overlayoutline"].forEach(type => config.set("hintstyles", type, "none"))
+}
 // }}}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1356,6 +1356,7 @@ export class default_config {
 
     /**
      * Which css styles to add for hint elements.
+     * Optionally add extra elements to the page to highlight hints using overlay and overlay outline.
      *
      * Use `hintstyles.fg` for text color, `hintstyles.bg` for background color, `hintstyles.outline` for outlines.
      * Values may be set to "all" to enable the style for all hints, "active" to enable the style only for the currently selected hint, or "none" to disable the style completely.
@@ -1367,6 +1368,8 @@ export class default_config {
         fg: "all",
         bg: "all",
         outline: "all",
+        overlay: "none",
+        overlayoutline: "none",
     }
 }
 

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -16,6 +16,12 @@ span.TridactylHint {
     z-index: 2147483646 !important;
 }
 
+span.TridactylHint.TridactylHintSpanActive {
+    color: var(--tridactyl-hintspan-active-fg) !important;
+    background-color: var(--tridactyl-hintspan-active-bg) !important;
+    border-color: var(--tridactyl-hintspan-active-border-color) !important;
+}
+
 span.TridactylHintCharPressed {
     color: var(--tridactyl-hintspan-pressed-fg) !important;
 }
@@ -43,4 +49,59 @@ span.TridactylJSHint {
 }
 .TridactylKilledElem {
     display: none !important;
+}
+
+div.TridactylHud {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100%;
+    height: 100%;
+    z-index: 2147483647 !important;
+    overflow: clip !important;
+    pointer-events: none;
+}
+
+div.TridactylHud > * {
+    pointer-events: all;
+}
+
+div.TridactylHudTranslation {
+    position: absolute !important;
+}
+
+div.TridactylHintHighlight,
+div.TridactylHintOutline,
+div.TridactylHintHighlightActive,
+div.TridactylHintOutlineActive {
+    position: absolute;
+}
+
+div.TridactylHintHighlight {
+    background: var(--tridactyl-hint-highlight-bg);
+}
+
+div.TridactylHintHighlightActive {
+    background: var(--tridactyl-hint-highlight-active-bg) !important;
+}
+
+div.TridactylHintOutline {
+    outline: var(--tridactyl-hint-highlight-outline);
+}
+
+div.TridactylHintOutlineActive {
+    outline: var(--tridactyl-hint-highlight-active-outline) !important;
+}
+
+div.TridactylHintHighlight *, div.TridactylHintOutline * {
+    position: absolute;
+    background: inherit;
+    outline: inherit;
+}
+
+div.TridactylHintHighlightHost {
+    opacity: var(--tridactyl-hint-highlight-opacity);
+}
+
+div.TridactylHintOutlineHost {
+    opacity: var(--tridactyl-hint-outline-opacity);
 }

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -77,7 +77,7 @@ div.TridactylHintOutlineActive {
 }
 
 div.TridactylHintHighlight {
-    background: var(--tridactyl-hint-highlight-bg);
+    background: var(--tridactyl-hint-highlight-bg) !important;
 }
 
 div.TridactylHintHighlightActive {

--- a/src/static/css/hint.css
+++ b/src/static/css/hint.css
@@ -6,7 +6,7 @@ span.TridactylHint {
     font-size: var(--tridactyl-hintspan-font-size) !important;
     font-weight: var(--tridactyl-hintspan-font-weight) !important;
     color: var(--tridactyl-hintspan-fg) !important;
-    background-color: var(--tridactyl-hintspan-bg) !important;
+    background: var(--tridactyl-hintspan-bg) !important;
     border-color: var(--tridactyl-hintspan-border-color) !important;
     border-width: var(--tridactyl-hintspan-border-width) !important;
     min-width: 0.75em !important;
@@ -18,7 +18,7 @@ span.TridactylHint {
 
 span.TridactylHint.TridactylHintSpanActive {
     color: var(--tridactyl-hintspan-active-fg) !important;
-    background-color: var(--tridactyl-hintspan-active-bg) !important;
+    background: var(--tridactyl-hintspan-active-bg) !important;
     border-color: var(--tridactyl-hintspan-active-border-color) !important;
 }
 
@@ -54,11 +54,11 @@ span.TridactylJSHint {
 div.TridactylHud {
     position: fixed !important;
     inset: 0 !important;
-    width: 100%;
-    height: 100%;
+    width: 100% !important;
+    height: 100% !important;
     z-index: 2147483647 !important;
     overflow: clip !important;
-    pointer-events: none;
+    pointer-events: none !important;
 }
 
 div.TridactylHud > * {
@@ -73,7 +73,7 @@ div.TridactylHintHighlight,
 div.TridactylHintOutline,
 div.TridactylHintHighlightActive,
 div.TridactylHintOutlineActive {
-    position: absolute;
+    position: absolute !important;
 }
 
 div.TridactylHintHighlight {
@@ -85,7 +85,7 @@ div.TridactylHintHighlightActive {
 }
 
 div.TridactylHintOutline {
-    outline: var(--tridactyl-hint-highlight-outline);
+    outline: var(--tridactyl-hint-highlight-outline) !important;
 }
 
 div.TridactylHintOutlineActive {
@@ -93,15 +93,12 @@ div.TridactylHintOutlineActive {
 }
 
 div.TridactylHintHighlight *, div.TridactylHintOutline * {
-    position: absolute;
-    background: inherit;
-    outline: inherit;
+    position: absolute !important;
+    background: inherit !important;
+    outline: inherit !important;
 }
 
 div.TridactylHintHighlightHost {
-    opacity: var(--tridactyl-hint-highlight-opacity);
+    opacity: var(--tridactyl-hint-highlight-opacity) !important;
 }
 
-div.TridactylHintOutlineHost {
-    opacity: var(--tridactyl-hint-outline-opacity);
-}

--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -39,7 +39,8 @@
     --tridactyl-hintspan-active-border-color: var(--tridactyl-hintspan-border-color);
 
     /* Element highlights */
-    --tridactyl-hint-active-fg: var(--tridactyl-fg);
+    --tridactyl-hint-fg: var(--tridactyl-fg);
+    --tridactyl-hint-active-fg: var(--tridactyl-hint-fg);
     --tridactyl-hint-active-bg: #88ff00;
     --tridactyl-hint-active-outline: 1px solid #cc0000;
 
@@ -51,8 +52,7 @@
     --tridactyl-hint-highlight-active-bg: var(--tridactyl-hint-active-bg);
     --tridactyl-hint-highlight-outline: var(--tridactyl-hint-outline);
     --tridactyl-hint-highlight-active-outline: var(--tridactyl-hint-active-outline);
-    --tridactyl-hint-highlight-opacity: 0.5;
-    --tridactyl-hint-outline-opacity: 1;
+    --tridactyl-hint-highlight-opacity: 0.25;
 
     /* :viewsource */
     --tridactyl-vs-bg: var(--tridactyl-bg);

--- a/src/static/themes/default/default.css
+++ b/src/static/themes/default/default.css
@@ -34,6 +34,10 @@
     --tridactyl-hintspan-border-style: solid;
     --tridactyl-hintspan-js-background: hsla(0, 0%, 65%);
 
+    --tridactyl-hintspan-active-fg: var(--tridactyl-hintspan-fg);
+    --tridactyl-hintspan-active-bg: var(--tridactyl-hintspan-bg);
+    --tridactyl-hintspan-active-border-color: var(--tridactyl-hintspan-border-color);
+
     /* Element highlights */
     --tridactyl-hint-active-fg: var(--tridactyl-fg);
     --tridactyl-hint-active-bg: #88ff00;
@@ -41,6 +45,14 @@
 
     --tridactyl-hint-bg: rgba(255, 255, 0, 0.25);
     --tridactyl-hint-outline: 1px solid #8f5902;
+
+    /* Element highlight overlays */
+    --tridactyl-hint-highlight-bg: var(--tridactyl-hint-bg);
+    --tridactyl-hint-highlight-active-bg: var(--tridactyl-hint-active-bg);
+    --tridactyl-hint-highlight-outline: var(--tridactyl-hint-outline);
+    --tridactyl-hint-highlight-active-outline: var(--tridactyl-hint-active-outline);
+    --tridactyl-hint-highlight-opacity: 0.5;
+    --tridactyl-hint-outline-opacity: 1;
 
     /* :viewsource */
     --tridactyl-vs-bg: var(--tridactyl-bg);

--- a/src/static/themes/vimium/vimium.css
+++ b/src/static/themes/vimium/vimium.css
@@ -1,0 +1,34 @@
+:root {
+	--tritheme-red: rgb(217,16,70);
+
+	--tridactyl-hintspan-fg: black;
+	--tridactyl-hintspan-bg: linear-gradient(0, rgb(255, 197, 66) 0, rgb(255,247,133) 100%);
+
+	--tridactyl-hintspan-active-fg: white;
+	--tridactyl-hintspan-active-bg: linear-gradient(0, rgb(180,8,50) 0, var(--tritheme-red) 100%);
+	--tridactyl-hintspan-active-border-color: rgb(190,0,25);
+	--tridactyl-hintspan-active-border-width: 1px;
+  
+  --tridactyl-hintspan-pressed-fg: rgb(212, 172, 58);
+
+	--tridactyl-hint-fg: var(--tritheme-red);
+	--tridactyl-hint-bg: rgba(255, 236, 118, 0.8);
+	--tridactyl-hint-outline: 1px solid #ecc44a;
+
+	--tridactyl-hint-active-fg: var(--tritheme-red);
+	--tridactyl-hint-active-bg: rgba(180, 16, 60, 0.8);
+	--tridactyl-hint-active-outline: 1px solid var(--tritheme-red);
+
+	--tridactyl-hint-highlight-bg: rgb(255, 236, 118);
+	--tridactyl-hint-highlight-active-bg: var(--tritheme-red);
+}
+
+span.TridactylHint {
+	box-shadow: rgba(0,0,0,0.3) 0 3px 7px 0 !important;
+	padding: 1px 3px 0 !important;
+	border-radius: 3px !important;
+}
+
+span.TridactylHintSpanActive > span.TridactylHintCharPressed {
+  color: rgb(120, 20, 20) !important;
+}


### PR DESCRIPTION
This adds two extra optional "hint hosts". In addition to the hint tags, there are two rectangles overlayed over every hintable element.

These can be enabled using `:set hintstyles.overlay all` and `:set hintstyles.overlayoutline all` (`all` or `active`).

Highlights and outlines are separated so that their container opacities can be independent, for maximum style. Reducing the container opacity rather than (or as well as) the individual highlights makes for good looking themes when many elements are stacked on top of each other.

---

### Important changes

I have been using these overlays for a while, but have just got around to preventing scrollbars being added due to the overlays extending outside of the screen.

This involved adding two extra "hud" elements: a fixed one to prevent overflow creating scrollbars, and an absolutely positioned one to offset everything according to `window.scrollY` and `window.scrollX`.

To allow elements to scroll with the page, I added a "scroll" listener.

If overlays and outlines are enabled, the number of elements added to the page to hint is tripled (or more as overlays add an element for every `clientRect` rather than just one) the number of elements added to the page. Along with the scroll listener, the main concern with merging this would be ensuring it doesn't impact performance too heavily. Currently, highlights and outlines are not added at all if they're disabled (set to "none") in config.

---

### Other changes

- Active "hintspan" styling - notice that the active hint's hint tag changes colour in the vimium and tokyonight examples below.

- Vimium theme included (to show off overlays and active hintspan rules)

- A listener for `hintstyles` config changes to update them without needing a refresh.

- Separate variables for active/inactive hint text colour: `--tridactyl-hint-fg` and `--tridactyl-hint-active-fg`

- helper excmds to set multiple `hintstyles` rules at once (three, beginning with `:hintstyles` to disable all, enable "direct" styling or overlays)

---

## Theme Examples

Hopefully these screen recordings give an idea of the difference between the overlays and changing the hintable elements' styles directly

### Default dark theme, with `:set hintstyles.fg none`

https://github.com/user-attachments/assets/f8758394-0afe-4b44-9ac7-84fae07e224e

### Default dark theme using overlays and still with `:set hintstyles.fg none`

https://github.com/user-attachments/assets/12bf7d3c-4690-4822-9a8f-ed113cf309d6

### A Vimium theme created with overlays in mind and `:set hintstyles.fg active`

https://github.com/user-attachments/assets/aabc1571-0d65-4e13-8d4a-6b75c877bc6f

---

[I use a theme](https://github.com/Chic-Tweetz/tridactyl/blob/amo/src/static/themes/tokyonight/tokyonight.css) with colours from [tokyonight](https://github.com/folke/tokyonight.nvim) which I really like. I've changed some CSS variable names so this would need some fiddling.

<img width="758" height="506" alt="Screenshot 2025-10-02 at 19 42 16" src="https://github.com/user-attachments/assets/7a3815b0-ef92-40c0-a6e5-60399cb380cc" />



