### PR TITLE
favicon in reader

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -6223,6 +6223,7 @@ export async function readerurl() {
     document.querySelectorAll(".TridactylStatusIndicator").forEach(ind => ind.parentNode.removeChild(ind))
     const article = new Readability(document.cloneNode(true) as any as Document).parse()
     article["link"] = window.location.href
+    article["favicon"] = (await ownTab()).favIconUrl
     return browser.runtime.getURL("static/reader.html#" + btoa(encodeURIComponent(JSON.stringify(article))))
 }
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -45,6 +45,12 @@ async function updatePage() {
     } else {
         document.getElementById("tricanonlink")?.remove()
     }
+    if (article.favicon !== undefined) {
+        const icon = document.createElement("link")
+        icon.rel = "icon"
+        icon.href = article.favicon
+        document.head.appendChild(icon)
+    }
 }
 
 window.addEventListener("load", updatePage)


### PR DESCRIPTION
For #5281

When running `:reader`, adds the favicon URL associated with the tab to the `article` object. Then uses the URL as the href for a `<link rel="icon">` element when creating the elements on the `:reader` page in order to display the original page's icon in the tab bar.