### PR TITLE
Allow transparency on cmdline iframe on dark sites

### DIFF
--- a/src/static/commandline.html
+++ b/src/static/commandline.html
@@ -2,6 +2,7 @@
 <html class="TridactylOwnNamespace TridactylCommandline">
     <head>
         <meta charset="utf-8">
+        <meta name="color-scheme" content="light dark">
         <title>Tridactyl commandline</title>
 	<link rel="stylesheet" href="css/cleanslate.css">
 	<link rel="stylesheet" href="css/commandline.css">


### PR DESCRIPTION
To prevent the white flashing described in https://github.com/tridactyl/tridactyl/issues/5258

Just adds `<meta name="color-scheme" content="light dark">` to the command line which seems to be enough for dark mode sites to be happy with it being transparent.