### PR TITLE
Add magic udm=14 param to Google

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -768,7 +768,7 @@ export class default_config {
      *  ```
      */
     searchurls = {
-        google: "https://www.google.com/search?q=",
+        google: "https://www.google.com/search?udm=14&q=",
         scholar: "https://scholar.google.com/scholar?q=",
         bing: "https://www.bing.com/search?q=",
         duckduckgo: "https://duckduckgo.com/?q=",


### PR DESCRIPTION
At the time of writing, this hides the terrible AI overviews and some other stuff, just like selecting the 'Web' tab

I had heard these were terrible but had never seen them until recently. This PR removes all that for people using `:set searchengine google`

Curious to hear what others think before I merge this