### PR TITLE
Buffer keys for the commandline for fillcmdline with args

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -219,7 +219,11 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (exstr === "fillcmdline" || exstr === "fillcmdline_notrail") {
+                    if (
+                        exstr.startsWith("fillcmdline") &&
+                        !exstr.startsWith("fillcmdline_tmp") &&
+                        !exstr.startsWith("fillcmdline_nofocus")
+                    ) {
                         logger.debug("Starting buffering of page keys")
                         bufferingPageKeysBeginTime = performance.now()
                         mustBufferPageKeysForClInput = true


### PR DESCRIPTION
Typing quickly after using a `fillcmdline` bind can cause keys to be missed and not typed into the cmdline.

#4809 helps, but only looks for exact binds for `fillcmdline` or `fillcmdline_notrail` so usually only the `:` bind.

This means binds like `o`'s `fillcmdline open` don't use the buffer.

This PR instead checks that the command begins with `fillcmdline`, excluding `_tmp` or `_nofocus`.

#4809 did actually use `.startsWith` originally but switched to exact matches to avoid the `tmp` and `nofocus` commands, inadvertently missing binds with args.