### PR TITLE
Check hintable elements' clientRects still exist when building hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -503,6 +503,7 @@ export function hintPage(
         reset()
         return
     }
+    modeState.hints.forEach(hint => hint.hidden = false)
 
     // There are multiple hints. Normally we would just show all of them, but
     // we try to be clever here. Automatically select the first one if all the
@@ -741,7 +742,6 @@ class Hint {
         this.y = window.scrollY + top
 
         modeState.hintHost.appendChild(this.flag)
-        this.hidden = false
     }
 
     public static isHintable(target: Element): boolean {

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -227,6 +227,7 @@ export function isVisible(thing: Element | Range) {
             thing = thing.parentElement
         }
     }
+    if (thing.getClientRects().length === 0) return false
     const clientRect = thing.getBoundingClientRect()
     switch (true) {
         case !clientRect:


### PR DESCRIPTION
This fixes the issue described in #5333 and #5282, probably caused by my changes in #5262.

`isVisible` now returns false if elements have no `clientRect` and hints all have their `hidden` property set to false in a loop instead of as they're constructed