### PR TITLE
Optimize completion display DOM updates

### DIFF
--- a/src/completions.ts
+++ b/src/completions.ts
@@ -310,7 +310,8 @@ export abstract class CompletionSourceFuse extends CompletionSource {
                 fragment.appendChild(option.html)
             }
         }
-        this.optionContainer.replaceChildren(fragment)
+        this.optionContainer.innerHTML = ""
+        this.optionContainer.appendChild(fragment)
         this.next(0)
     }
 

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -304,17 +304,13 @@ export abstract class CompletionSourceFuse extends CompletionSource {
 
     /** Call to replace the current display */
     updateDisplay() {
-        const newContainer = this.optionContainer.cloneNode(
-            false,
-        ) as HTMLElement
-
+        const fragment = document.createDocumentFragment()
         for (const option of this.options) {
-            if (option.state !== "hidden")
-                // This is probably slow: `.html` means the HTML parser will be invoked
-                newContainer.appendChild(option.html)
+            if (option.state !== "hidden") {
+                fragment.appendChild(option.html)
+            }
         }
-        this.optionContainer.replaceWith(newContainer)
-        this.optionContainer = newContainer
+        this.optionContainer.replaceChildren(fragment)
         this.next(0)
     }
 


### PR DESCRIPTION
## Summary
- Use DocumentFragment + replaceChildren() instead of cloneNode + replaceWith() for completion display updates
- Batches DOM operations and avoids creating a new container element on each update
- Based on todo_performance.md item 2