### PR TITLE
Add perf markers to hint filtering and fix perf commands

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -37,6 +37,7 @@ import { contentState } from "@src/content/state_content"
 import * as config from "@src/lib/config"
 import Logger from "@src/lib/logging"
 import * as R from "ramda"
+import * as Perf from "@src/perf"
 
 /** @hidden */
 const logger = new Logger("hinting")
@@ -1043,6 +1044,7 @@ type HintFilter = (s: string) => void
 /** Show only hints prefixed by fstr. Focus first match
 @hidden */
 function filterHintsSimple(fstr) {
+    const perfMarker = new Perf.Marker("Hinting", "filterHintsSimple").start()
     const active: Hint[] = []
     let foundMatch
 
@@ -1069,6 +1071,7 @@ function filterHintsSimple(fstr) {
     if (active.length === 1 && config.get("hintautoselect") === "true") {
         selectFocusedHint()
     }
+    perfMarker.end()
 }
 
 /** Partition the filter string into hintchars and content filter strings.
@@ -1083,6 +1086,7 @@ function filterHintsSimple(fstr) {
     @hidden
 */
 function filterHintsVimperator(query: string, reflow = false) {
+    const perfMarker = new Perf.Marker("Hinting", "filterHintsVimperator").start()
     /** Partition a query into a tagged array of substrings */
     function partitionquery(
         query,
@@ -1162,6 +1166,7 @@ function filterHintsVimperator(query: string, reflow = false) {
     if (active.length === 1 && config.get("hintautoselect") === "true") {
         selectFocusedHint(true)
     }
+    perfMarker.end()
 }
 
 /**

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5790,8 +5790,11 @@ export function buildFilterConfigs(filters: string[]): Perf.StatsFilterConfig[] 
 export async function perfdump(...filters: string[]) {
     const filterconfigs = buildFilterConfigs(filters)
     const entries = window.tri.statsLogger.getEntries(...filterconfigs)
-    console.log(filterconfigs)
-    return open("data:application/json;charset=UTF-8," + JSON.stringify(entries))
+    console.log("Filter configs:", filterconfigs)
+    console.log("Performance entries:", entries)
+    const jsonStr = JSON.stringify(entries, null, 2)
+    await clipboard("yank", jsonStr)
+    return fillcmdline_tmp(3000, `perfdump: ${entries.length} samples copied to clipboard. Check browser console for details.`)
 }
 
 /**
@@ -5811,8 +5814,9 @@ export async function perfhistogram(...filters: string[]) {
         return fillcmdline_tmp(3000, "perfhistogram: No samples found.")
     }
     const histogram = Perf.renderStatsHistogram(entries)
-    console.log(histogram)
-    return open("data:text/plain;charset=UTF-8;base64," + btoa(histogram))
+    console.log("Histogram:\n" + histogram)
+    await clipboard("yank", histogram)
+    return fillcmdline_tmp(3000, `perfhistogram: ${entries.length} samples. Histogram copied to clipboard. Check browser console for details.`)
 }
 
 // }}}

--- a/src/perf.ts
+++ b/src/perf.ts
@@ -340,6 +340,7 @@ export class StatsFilter {
 
     matches(entry: PerformanceEntry): boolean {
         const metricNameInfo = extractMetricName(entry.name)
+        if (!metricNameInfo) return false
         return !(
             (this.config.kind === "functionName" && this.config.functionName !== metricNameInfo.functionName) ||
             (this.config.kind === "ownerName" && this.config.ownerName !== metricNameInfo.ownerName) ||


### PR DESCRIPTION
## Summary

This PR adds performance profiling infrastructure for hint filtering and fixes bugs in the existing perf commands.

## Changes

### 1. Perf markers in hint filtering (`src/content/hinting.ts`)

Added `Perf.Marker` instrumentation to `filterHintsSimple` and `filterHintsVimperator` functions to measure hint filtering performance:
- `filterHintsSimple` - measures simple prefix-based hint filtering
- `filterHintsVimperator` - measures vimperator-style hint filtering with text matching

These markers allow benchmarking hint filtering performance before/after optimizations.

### 2. Fixed perfdump/perfhistogram commands (`src/excmds.ts`)

The original implementation used `open("data:...")` to display results, which is blocked by Firefox for extensions due to security restrictions. Changed to:
- Output to browser console for easy viewing
- Copy results to clipboard for pasting elsewhere
- Show a message in the command line with result summary

### 3. Fixed StatsFilter.matches() (`src/perf.ts`)

Fixed a bug where `StatsFilter.matches()` would crash when processing performance entries that don't match the expected `tri/Owner/Function:suffix` naming pattern. Added null check to handle entries that can't be parsed.

## Usage

To profile hint filtering performance:
```bash
:set perfcounters true
# Use hint filtering (press f and type to filter)
:perfhistogram Hinting/
```

This enables measuring and comparing hint filtering performance on pages with many links (e.g., GitHub file listings).