### PR TITLE
fix: prevent infinite loop on reader mode

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -39,6 +39,8 @@ const CONFIGNAME = "userconfig"
 const WAITERS = []
 /** @hidden */
 export let INITIALISED = false
+/** @hidden */
+let inGetURL = false
 
 /** @hidden */
 // make a naked object
@@ -1970,6 +1972,8 @@ export function mergeDeep(o1, o2) {
  * Gets a site-specific setting.
  */
 export function getURL(url: string, target: string[]) {
+    if (inGetURL) return undefined
+    inGetURL = true
     function _getURL(conf, url, target) {
         if (!conf.subconfigs) return undefined
         // For each key
@@ -2000,11 +2004,15 @@ export function getURL(url: string, target: string[]) {
                 }, undefined as any)
         )
     }
-    const user = _getURL(USERCONFIG, url, target)
-    const deflt = _getURL(DEFAULTS, url, target)
-    if (user === undefined || user === null) return deflt
-    if (typeof user !== "object" || typeof deflt !== "object") return user
-    return mergeDeepCull(deflt, user)
+    try {
+        const user = _getURL(USERCONFIG, url, target)
+        const deflt = _getURL(DEFAULTS, url, target)
+        if (user === undefined || user === null) return deflt
+        if (typeof user !== "object" || typeof deflt !== "object") return user
+        return mergeDeepCull(deflt, user)
+    } finally {
+        inGetURL = false
+    }
 }
 
 /** Get the value of the key target.


### PR DESCRIPTION
## Summary
- Add a reentrancy guard to `getURL()` to prevent infinite loops when the config system triggers itself during reader mode initialization
- This fixes 100% CPU usage when using Tridactyl's reader mode (at least happening with [my config](https://github.com/repparw/nix/blob/main/modules/hm/gui/browser/tridactyl.nix) ~~in beta 1.24.4pre7305~~ wrong!)

## Problem
When using Tridactyl's reader mode (`:reader`), Firefox would sometimes go to 100% CPU usage. The stack trace shows an infinite loop between:
- `getURL` → `_getURL` → `filter` → `get` → `getAsync` → message handler → `getURL` (repeats)

## Root Cause
The `getURL()` function can trigger config reads which indirectly call `getURL()` again, creating an infinite recursion. This is likely triggered by site-specific config patterns or the config initialization sequence.

## Fix
Added a simple reentrancy guard (`inGetURL`) that prevents recursive calls to `getURL()`. If a recursive call is detected, it returns `undefined` early, which allows the config system to fall back to default values.

## Testing
Tested with my config (which I think is related to the recursion I got in the first place)