### PR TITLE
fix: update MDN links to new URL structure

### DIFF
--- a/doc/escalating-privilege.md
+++ b/doc/escalating-privilege.md
@@ -3,13 +3,13 @@
 Useful workarounds and methods to get the power we want in the brave new world of webextensions.
 
 *   Function in newtab
-    *   [chrome_url_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
+    *   [chrome_url_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
 *   Function in home page
-    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
 *   (Downside for both is that we need to reimplement a useful home and newtab page)
 
 *   Shell and write access to filesystem
-    *   [Native_messaging](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging)
+    *   [Native_messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging)
 *   Hiding firefox chrome
 
     *   API proposal for hiding tabstrip (but not nav bar): [Bug 1332447](https://api-dev.bugzilla.mozilla.org/show_bug.cgi?id=1332447)
@@ -27,7 +27,7 @@ Useful workarounds and methods to get the power we want in the brave new world o
     *   Shadow DOM would probably be simpler than iframe, but not implemented yet [Bug 1205323](https://bugzilla.mozilla.org/show_bug.cgi?id=1205323)
 *   Commandline thru search suggestions on the omnibar (this is a bit mad)
 
-    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
 
 *   [Find API](https://bug1332144.bmoattachments.org/attachment.cgi?id=8905651)
 

--- a/doc/ideas.md
+++ b/doc/ideas.md
@@ -30,7 +30,7 @@ https://www.codementor.io/gmuresan/building-a-chrome-extension-reactjs-broccoli-
 
 # Useful links
 
-https://developer.chrome.com/extensions/commands https://github.com/lydell/webextension-keyboard https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
+https://developer.chrome.com/extensions/commands https://github.com/lydell/webextension-keyboard https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
 
 # Names
 
@@ -61,6 +61,6 @@ History seems to be window.history.go(), presumably in a content script?
 
 https://news.ycombinator.com/item?id=10120773 -- people complaining, could be handy
 
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/executeScript -- we aren't allowed to inject JS into, e.g. about: pages. This means no searching, no back/forward, no commandline: a user navigating to such a page would get trapped.
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript -- we aren't allowed to inject JS into, e.g. about: pages. This means no searching, no back/forward, no commandline: a user navigating to such a page would get trapped.
 
 https://www.w3schools.com/jsref/obj_window.asp -- commands that can be run in content.js


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates outdated MDN links to the new URL structure.

Changed:
- developer.mozilla.org/en-US/Add-ons/WebExtensions/* → developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*