### PR TITLE
fix: Update deprecated MDN URLs

### DIFF
--- a/doc/escalating-privilege.md
+++ b/doc/escalating-privilege.md
@@ -3,13 +3,13 @@
 Useful workarounds and methods to get the power we want in the brave new world of webextensions.
 
 *   Function in newtab
-    *   [chrome_url_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
+    *   [chrome_url_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides)
 *   Function in home page
-    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
 *   (Downside for both is that we need to reimplement a useful home and newtab page)
 
 *   Shell and write access to filesystem
-    *   [Native_messaging](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging)
+    *   [Native_messaging](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging)
 *   Hiding firefox chrome
 
     *   API proposal for hiding tabstrip (but not nav bar): [Bug 1332447](https://api-dev.bugzilla.mozilla.org/show_bug.cgi?id=1332447)
@@ -27,7 +27,7 @@ Useful workarounds and methods to get the power we want in the brave new world o
     *   Shadow DOM would probably be simpler than iframe, but not implemented yet [Bug 1205323](https://bugzilla.mozilla.org/show_bug.cgi?id=1205323)
 *   Commandline thru search suggestions on the omnibar (this is a bit mad)
 
-    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
+    *   [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides)
 
 *   [Find API](https://bug1332144.bmoattachments.org/attachment.cgi?id=8905651)
 

--- a/doc/ideas.md
+++ b/doc/ideas.md
@@ -30,7 +30,7 @@ https://www.codementor.io/gmuresan/building-a-chrome-extension-reactjs-broccoli-
 
 # Useful links
 
-https://developer.chrome.com/extensions/commands https://github.com/lydell/webextension-keyboard https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
+https://developer.chrome.com/extensions/commands https://github.com/lydell/webextension-keyboard https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#Background_scripts https://github.com/shinglyu/QuantumVim - Vimium style stuff in WebExtensions https://github.com/mishoo/UglifyJS2 - Minify JS: check that compiling to Firefox addon doesn't already do this https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API http://arcturo.github.io/library/coffeescript/ - Coffee Script textbook https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Getting_started_with_web-ext - web-ext will automatically reload a changed extension
 
 # Names
 
@@ -61,6 +61,6 @@ History seems to be window.history.go(), presumably in a content script?
 
 https://news.ycombinator.com/item?id=10120773 -- people complaining, could be handy
 
-https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/executeScript -- we aren't allowed to inject JS into, e.g. about: pages. This means no searching, no back/forward, no commandline: a user navigating to such a page would get trapped.
+https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript -- we aren't allowed to inject JS into, e.g. about: pages. This means no searching, no back/forward, no commandline: a user navigating to such a page would get trapped.
 
 https://www.w3schools.com/jsref/obj_window.asp -- commands that can be run in content.js

--- a/native/native_main.py
+++ b/native/native_main.py
@@ -49,7 +49,7 @@ def getMessage():
     "Each message is serialized using JSON, UTF-8 encoded and is preceded with
     a 32-bit value containing the message length in native byte order."
 
-    https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#App_side
+    https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_messaging#App_side
 
     """
     rawLength = sys.stdin.buffer.read(4)

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3483,7 +3483,7 @@ export async function containerclose(name: string) {
 }
 /** Creates a new container. Note that container names must be unique and that the checks are case-insensitive.
 
-    Further reading https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
+    Further reading https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 
     Example usage:
         - `:containercreate tridactyl green dollar`
@@ -5000,7 +5000,7 @@ export async function reseturl(pattern: string, mode: string, key: string) {
 /** Deletes various bits of Firefox or Tridactyl data
 
     The list of possible arguments can be found here:
-    https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browsingData/DataTypeSet
+    https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/DataTypeSet
 
     Additional Tridactyl-specific arguments are:
     - `commandline`: Removes the in-memory commandline history.

--- a/src/lib/containers.ts
+++ b/src/lib/containers.ts
@@ -3,7 +3,7 @@ import Fuse from "fuse.js"
 import * as Logging from "@src/lib/logging"
 const logger = new Logging.Logger("containers")
 
-// As per Mozilla specification: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
+// As per Mozilla specification: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 const ContainerColor = [
     "blue",
     "turquoise",
@@ -15,7 +15,7 @@ const ContainerColor = [
     "purple",
 ]
 
-// As per Mozilla specification: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
+// As per Mozilla specification: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/ContextualIdentity
 const ContainerIcon = [
     "fingerprint",
     "briefcase",

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -23,7 +23,7 @@ interface Window {
 }
 
 // This isn't an actual firefox type but it's nice to have one for this kind of object
-// https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/find/find
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/find/find
 interface findResult {
     count: number
     rangeData: Array<{


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
