### PR TITLE
Fix selection across DOM node

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -401,33 +401,11 @@ export class default_config {
         S: "composite js document.getSelection().toString() | fillcmdline tabopen search",
         l: `js
             const sel = document.getSelection();
-            const oldFocusNode = sel.focusNode;
-            const oldFocusOffset = sel.focusOffset;
-
-            sel.modify("extend", "forward", "character");
-            if (sel.isCollapsed) {
-              sel.setBaseAndExtent(
-                oldFocusNode,
-                oldFocusOffset,
-                sel.focusNode,
-                sel.focusOffset + 1
-              );
-            }
+            tri.visual.extendByCharacter(sel, "forward");
         `,
         h: `js
             const sel = document.getSelection();
-            const oldFocusNode = sel.focusNode;
-            const oldFocusOffset = sel.focusOffset;
-
-            sel.modify("extend", "backward", "character");
-            if (sel.isCollapsed) {
-              sel.setBaseAndExtent(
-                oldFocusNode,
-                oldFocusOffset,
-                sel.focusNode,
-                sel.focusOffset - 1
-              );
-            }
+            tri.visual.extendByCharacter(sel, "backward");
         `,
         e: 'js document.getSelection().modify("extend","forward","word")',
         w: 'js document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","forward","word"); document.getSelection().modify("extend","backward","word"); document.getSelection().modify("extend","forward","character")',

--- a/src/lib/visual.ts
+++ b/src/lib/visual.ts
@@ -35,3 +35,25 @@ function getSelectionDirection(selection: Selection): boolean {
     range.setEnd(focusNode, selection.focusOffset)
     return !range.collapsed
 }
+
+export function extendByCharacter(
+    selection: Selection,
+    direction: string,
+): void {
+    const oldFocusNode = selection.focusNode
+    const oldFocusOffset = selection.focusOffset
+    const oldAnchorNode = selection.anchorNode
+    const oldAnchorOffset = selection.anchorOffset
+    if (!oldFocusNode) return
+
+    selection.modify("extend", direction, "character")
+    if (!selection.isCollapsed) return
+    selection.setBaseAndExtent(
+        oldAnchorNode,
+        oldAnchorOffset,
+        oldFocusNode,
+        oldFocusOffset,
+    )
+    reverseSelection(selection)
+    selection.modify("extend", direction, "character")
+}

--- a/src/lib/visual.ts
+++ b/src/lib/visual.ts
@@ -38,7 +38,7 @@ function getSelectionDirection(selection: Selection): boolean {
 
 export function extendByCharacter(
     selection: Selection,
-    direction: string,
+    direction: "forward" | "backward" | "left" | "right",
 ): void {
     const oldFocusNode = selection.focusNode
     const oldFocusOffset = selection.focusOffset

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -15,6 +15,13 @@ interface Window {
     scrollByPages(n: number): void
     eval(str: string): any
 }
+interface Selection {
+    modify(
+        alter: "move" | "extend",
+        direction: "forward" | "backward" | "left" | "right",
+        granularity: "character" | "word" | "line",
+    ): void
+}
 
 // Record that we've added a property with convenience objects to the
 // window object:
@@ -47,7 +54,7 @@ interface findResult {
 
 interface HTMLElement {
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
-    inert: boolean;
+    inert: boolean
 
     // Let's be future proof:
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
@@ -84,7 +91,7 @@ declare namespace browser.tabs {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d1180e5218a7bf69e6f0da5ac2e2584bd57a1cdf/types/firefox-webext-browser/index.d.ts
 interface WebExtEventBase<
     TAddListener extends (...args: any[]) => any,
-    TCallback
+    TCallback,
 > {
     addListener: TAddListener
 


### PR DESCRIPTION
Added function:
```
src/lib/visual.ts
export function extendByCharacter(
    selection: Selection,
    direction: string,
): void {
    const oldFocusNode = selection.focusNode
    const oldFocusOffset = selection.focusOffset
    const oldAnchorNode = selection.anchorNode
    const oldAnchorOffset = selection.anchorOffset
    if (!oldFocusNode) return

    selection.modify("extend", direction, "character")
    if (!selection.isCollapsed) return
    selection.setBaseAndExtent(
        oldAnchorNode,
        oldAnchorOffset,
        oldFocusNode,
        oldFocusOffset,
    )
    reverseSelection(selection)
    selection.modify("extend", direction, "character")
}
```