### PR TITLE
Fix #1971: add listeners to same-origin iframes

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -196,6 +196,7 @@ function listenInIframe(frame: FrameElement) {
         if (!doc?.defaultView || observedIframeRoots.has(doc)) return
         listen(doc.defaultView)
         observeIframeRoot(doc)
+        dom.hijackPageAttachShadow(observeIframeRoot, doc.defaultView)
         dom.setupFocusHandler(doc)
     } catch (e) {
         logger.warning("Could not hijack iframe due to CSP:", e)
@@ -304,6 +305,7 @@ window["tri"] = Object.assign(Object.create(null), {
 logger.info("Loaded commandline content?", commandline_content)
 
 try {
+    dom.hijackPageAttachShadow(observeIframeRoot)
     dom.setupFocusHandler()
     dom.hijackPageListenerFunctions()
 } catch (e) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -173,10 +173,55 @@ function listen(elem: Window | HTMLElement | HTMLFrameElement) {
         true,
     )
 }
+
 listen(window)
-document.addEventListener("readystatechange", _ =>
-    getAllDocumentFrames().forEach(f => listen(f)),
-)
+listenInIframes()
+document.addEventListener("readystatechange", listenInIframes)
+createIframeObserver(document)
+
+// Add listeners to existing iframes
+function listenInIframes() {
+    getAllDocumentFrames().forEach(f => {
+        try {
+            if (f.contentDocument?.readyState === "complete") {
+                listen(f.contentWindow)
+                dom.setupFocusHandler(f.contentDocument, listen)
+                createIframeObserver(f.contentDocument)
+            } else {
+                f.addEventListener("load", () => {
+                    listen(f.contentWindow)
+                    dom.setupFocusHandler(f.contentDocument, listen)
+                    createIframeObserver(f.contentDocument)
+                })
+            }
+        } catch (e) {
+            logger.warning("Could not hijack iframe due to CSP:", e)
+        }
+    })
+}
+
+// Add listeners to iframes added to the DOM
+function createIframeObserver(doc = document) {
+    const iframeObserver = new MutationObserver((mutations, observer) => {
+        for (const mutation of mutations) {
+            if (mutation.type === "childList") {
+                for (const node of mutation.addedNodes) {
+                    if (node instanceof doc.defaultView.HTMLIFrameElement &&
+                        !node.src.startsWith("moz-extension:")
+                    ) {
+                        try {
+                            listen(node.contentWindow)
+                            dom.setupFocusHandler(node.contentDocument, listen)
+                            createIframeObserver(node.contentDocument)
+                        } catch(e) {}
+                    }
+                }
+            }
+        }
+    })
+    iframeObserver.observe(doc, { subtree: true, childList: true })
+    return iframeObserver
+}
 
 // Prevent pages from automatically focusing elements on load
 config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
@@ -257,7 +302,7 @@ window["tri"] = Object.assign(Object.create(null), {
 logger.info("Loaded commandline content?", commandline_content)
 
 try {
-    dom.setupFocusHandler()
+    dom.setupFocusHandler(document, listen)
     dom.hijackPageListenerFunctions()
 } catch (e) {
     logger.warning("Could not hijack due to CSP:", e)

--- a/src/content.ts
+++ b/src/content.ts
@@ -202,7 +202,7 @@ function listenInIframes() {
 
 // Add listeners to iframes added to the DOM
 function createIframeObserver(doc = document) {
-    const iframeObserver = new MutationObserver((mutations, observer) => {
+    const iframeObserver = new MutationObserver((mutations, _observer) => {
         for (const mutation of mutations) {
             if (mutation.type === "childList") {
                 for (const node of mutation.addedNodes) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -138,31 +138,66 @@ const guardedAcceptKey = (keyevent: KeyboardEvent) => {
 function listen(elem) {
     elem.removeEventListener("keydown", guardedAcceptKey, true)
     elem.removeEventListener(
-        "keypress",
-        ContentController.canceller.cancelKeyPress,
-        true,
-    )
-    elem.removeEventListener(
         "keyup",
         ContentController.canceller.cancelKeyUp,
         true,
     )
     elem.addEventListener("keydown", guardedAcceptKey, true)
     elem.addEventListener(
-        "keypress",
-        ContentController.canceller.cancelKeyPress,
-        true,
-    )
-    elem.addEventListener(
         "keyup",
         ContentController.canceller.cancelKeyUp,
         true,
     )
 }
+
 listen(window)
-document.addEventListener("readystatechange", _ =>
-    getAllDocumentFrames().forEach(f => listen(f)),
-)
+listenInIframes()
+document.addEventListener("readystatechange", listenInIframes)
+createIframeObserver(document)
+
+// Add listeners to existing iframes
+function listenInIframes() {
+    getAllDocumentFrames().forEach(f => {
+        try {
+            if (f.contentDocument?.readyState === "complete") {
+                listen(f.contentWindow)
+                dom.setupFocusHandler(f.contentDocument, listen)
+                createIframeObserver(f.contentDocument)
+            } else {
+                f.addEventListener("load", () => {
+                    listen(f.contentWindow)
+                    dom.setupFocusHandler(f.contentDocument, listen)
+                    createIframeObserver(f.contentDocument)
+                })
+            }
+        } catch (e) {
+            logger.warning("Could not hijack iframe due to CSP:", e)
+        }
+    })
+}
+
+// Add listeners to iframes added to the DOM
+function createIframeObserver(doc = document) {
+    const iframeObserver = new MutationObserver((mutations, observer) => {
+        for (const mutation of mutations) {
+            if (mutation.type === "childList") {
+                for (const node of mutation.addedNodes) {
+                    if (node instanceof doc.defaultView.HTMLIFrameElement &&
+                        !node.src.startsWith("moz-extension:")
+                    ) {
+                        try {
+                            listen(node.contentWindow)
+                            dom.setupFocusHandler(node.contentDocument, listen)
+                            createIframeObserver(node.contentDocument)
+                        } catch(e) {}
+                    }
+                }
+            }
+        }
+    })
+    iframeObserver.observe(doc, { subtree: true, childList: true })
+    return iframeObserver
+}
 
 // Prevent pages from automatically focusing elements on load
 config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
@@ -243,7 +278,7 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
 logger.info("Loaded commandline content?", commandline_content)
 
 try {
-    dom.setupFocusHandler()
+    dom.setupFocusHandler(document, listen)
     dom.hijackPageListenerFunctions()
 } catch (e) {
     logger.warning("Could not hijack due to CSP:", e)
@@ -367,7 +402,7 @@ config.getAsync("modeindicator").then(mode => {
         statusIndicator.className =
             "cleanslate TridactylStatusIndicator " + privateMode
         if (
-            dom.isTextEditable(document.activeElement) &&
+            dom.isTextEditable(dom.activeElement()) &&
             !["input", "ignore"].includes(mode)
         ) {
             result = "insert"
@@ -376,7 +411,7 @@ config.getAsync("modeindicator").then(mode => {
             // need to fix loss of focus by click: doesn't do anything here.
         } else if (
             mode === "insert" &&
-            !dom.isTextEditable(document.activeElement)
+            !dom.isTextEditable(dom.activeElement())
         ) {
             result = "normal"
             // statusIndicator.style.borderColor = "lightgray !important"

--- a/src/content.ts
+++ b/src/content.ts
@@ -178,7 +178,7 @@ function listenInIframes() {
 
 // Add listeners to iframes added to the DOM
 function createIframeObserver(doc = document) {
-    const iframeObserver = new MutationObserver((mutations, observer) => {
+    const iframeObserver = new MutationObserver((mutations, _observer) => {
         for (const mutation of mutations) {
             if (mutation.type === "childList") {
                 for (const node of mutation.addedNodes) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -27,7 +27,7 @@ import {
 import { CmdlineCmds } from "@src/content/commandline_cmds"
 import { EditorCmds } from "@src/content/editor"
 
-import { getAllDocumentFrames, activeElement } from "@src/lib/dom"
+import { activeElement } from "@src/lib/dom"
 
 import state from "@src/state"
 import { EditorCmds as editor } from "@src/content/editor"
@@ -175,53 +175,55 @@ function listen(elem: Window | HTMLElement | HTMLFrameElement) {
 }
 
 listen(window)
-listenInIframes()
-document.addEventListener("readystatechange", listenInIframes)
-createIframeObserver(document)
 
-// Add listeners to existing iframes
-function listenInIframes() {
-    getAllDocumentFrames().forEach(f => {
-        try {
-            if (f.contentDocument?.readyState === "complete") {
-                listen(f.contentWindow)
-                dom.setupFocusHandler(f.contentDocument, listen)
-                createIframeObserver(f.contentDocument)
-            } else {
-                f.addEventListener("load", () => {
-                    listen(f.contentWindow)
-                    dom.setupFocusHandler(f.contentDocument, listen)
-                    createIframeObserver(f.contentDocument)
-                })
-            }
-        } catch (e) {
-            logger.warning("Could not hijack iframe due to CSP:", e)
+type FrameElement = HTMLIFrameElement | HTMLFrameElement
+type IframeRoot = Document | ShadowRoot
+const observedIframeRoots = new WeakSet<IframeRoot>()
+const iframeObserver = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+            if (node.nodeType === Node.ELEMENT_NODE)
+                discoverIframes(node as Element)
         }
-    })
+    }
+})
+
+function listenInIframe(frame: FrameElement) {
+    frame.addEventListener("load", onIframeLoad)
+    try {
+        if (frame.src.startsWith("moz-extension:")) return
+        const doc = frame.contentDocument
+        if (!doc?.defaultView || observedIframeRoots.has(doc)) return
+        listen(doc.defaultView)
+        observeIframeRoot(doc)
+        dom.setupFocusHandler(doc)
+    } catch (e) {
+        logger.warning("Could not hijack iframe due to CSP:", e)
+    }
 }
 
-// Add listeners to iframes added to the DOM
-function createIframeObserver(doc = document) {
-    const iframeObserver = new MutationObserver((mutations, _observer) => {
-        for (const mutation of mutations) {
-            if (mutation.type === "childList") {
-                for (const node of mutation.addedNodes) {
-                    if (node instanceof doc.defaultView.HTMLIFrameElement &&
-                        !node.src.startsWith("moz-extension:")
-                    ) {
-                        try {
-                            listen(node.contentWindow)
-                            dom.setupFocusHandler(node.contentDocument, listen)
-                            createIframeObserver(node.contentDocument)
-                        } catch(e) {}
-                    }
-                }
-            }
-        }
-    })
-    iframeObserver.observe(doc, { subtree: true, childList: true })
-    return iframeObserver
+function onIframeLoad(event: Event) {
+    listenInIframe(event.currentTarget as FrameElement)
 }
+
+function discoverIframes(root: IframeRoot | Element) {
+    for (const element of [root as Element, ...root.querySelectorAll("*")]) {
+        if (["iframe", "frame"].includes(element.localName)) {
+            listenInIframe(element as FrameElement)
+        }
+        const shadowRoot = (element as HTMLElement).openOrClosedShadowRoot
+        if (shadowRoot) observeIframeRoot(shadowRoot)
+    }
+}
+
+function observeIframeRoot(root: IframeRoot) {
+    if (observedIframeRoots.has(root)) return
+    observedIframeRoots.add(root)
+    iframeObserver.observe(root, { subtree: true, childList: true })
+    discoverIframes(root)
+}
+
+observeIframeRoot(document)
 
 // Prevent pages from automatically focusing elements on load
 config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
@@ -302,7 +304,7 @@ window["tri"] = Object.assign(Object.create(null), {
 logger.info("Loaded commandline content?", commandline_content)
 
 try {
-    dom.setupFocusHandler(document, listen)
+    dom.setupFocusHandler()
     dom.hijackPageListenerFunctions()
 } catch (e) {
     logger.warning("Could not hijack due to CSP:", e)

--- a/src/content/controller_content.test.ts
+++ b/src/content/controller_content.test.ts
@@ -1,5 +1,11 @@
-import { acceptTrustedKey } from "@src/content/controller_content"
-import { guarded } from "@src/lib/keyseq"
+import { acceptTrustedKey, canceller } from "@src/content/controller_content"
+import { guarded, TrustedKeyboardEvent } from "@src/lib/keyseq"
+
+function keyEvent(target: HTMLElement, type: string) {
+    const event = new KeyboardEvent(type, { cancelable: true, code: "KeyX" })
+    target.dispatchEvent(event)
+    return event as TrustedKeyboardEvent
+}
 
 test.each(["keydown", "keyup"])(
     "synthetic %s events do not reach the key parser",
@@ -17,3 +23,21 @@ test.each(["keydown", "keyup"])(
         expect(accept).not.toHaveBeenCalled()
     },
 )
+
+test("keyup cancellation survives a focus change", () => {
+    const before = document.createElement("input")
+    const after = document.createElement("input")
+    canceller.push(keyEvent(before, "keydown"))
+
+    const keypress = keyEvent(after, "keypress")
+    canceller.cancelKeyPress(keypress)
+    expect(keypress.defaultPrevented).toBe(false)
+
+    const keyup = keyEvent(after, "keyup")
+    canceller.cancelKeyUp(keyup)
+    expect(keyup.defaultPrevented).toBe(true)
+
+    const staleKeypress = keyEvent(before, "keypress")
+    canceller.cancelKeyPress(staleKeypress)
+    expect(staleKeypress.defaultPrevented).toBe(false)
+})

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -46,6 +46,11 @@ function PrintableKey(k) {
     return result
 }
 
+function isKeyboardEvent(ke: any): ke is KeyboardEvent {
+    const win = ke.view
+    return win && ke instanceof win.KeyboardEvent
+}
+
 /**
  * KeyCanceller: keep track of keys that have been cancelled in the keydown
  * handler (which takes care of dispatching ex commands) and also cancel them
@@ -90,10 +95,9 @@ class KeyCanceller {
                 ke.composed === ke2.composed &&
                 ke.ctrlKey === ke2.ctrlKey &&
                 ke.metaKey === ke2.metaKey &&
-                ke.shiftKey === ke2.shiftKey &&
-                ke.target === ke2.target,
+                ke.shiftKey === ke2.shiftKey
         )
-        if (index >= 0 && ke instanceof KeyboardEvent) {
+        if (index >= 0 && isKeyboardEvent(ke)) {
             ke.preventDefault()
             ke.stopImmediatePropagation()
             kes.splice(index, 1)
@@ -154,23 +158,22 @@ function* ParserController() {
                 let shadowRoot = null
                 let textEditable = false
 
-                if (keyevent instanceof KeyboardEvent) {
-                    shadowRoot = deepestShadowRoot(
-                        (keyevent.target as Element).shadowRoot,
-                    )
+                if (isKeyboardEvent(keyevent)) {
+                    const target = (keyevent as KeyboardEvent).target as Element
+                    shadowRoot = deepestShadowRoot(target.shadowRoot)
 
                     textEditable =
                         shadowRoot === null
-                            ? isTextEditable(keyevent.target as Element)
+                            ? isTextEditable(target)
                             : isTextEditable(shadowRoot.activeElement)
                     // Accumulate key events. The parser will cut this
                     // down whenever it's not a valid prefix of a known
                     // binding, so it can't grow indefinitely unless you
                     // have a combination of maps that permits bindings of
                     // unbounded length.
-                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
+                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent as KeyboardEvent))
                 } else {
-                    keyEvents.push(keyevent)
+                    keyEvents.push(keyevent as MinimalKey)
                 }
 
                 // _just to be safe_, cache this to make the following
@@ -213,8 +216,8 @@ function* ParserController() {
                     response,
                 )
 
-                if (response.isMatch && keyevent instanceof KeyboardEvent) {
-                    canceller.push(keyevent)
+                if (response.isMatch && isKeyboardEvent(keyevent)) {
+                    canceller.push(keyevent as KeyboardEvent)
                 }
 
                 if (response.exstr) {

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -159,21 +159,22 @@ function* ParserController() {
                 let textEditable = false
 
                 if (isKeyboardEvent(keyevent)) {
-                    const target = (keyevent as KeyboardEvent).target as Element
-                    shadowRoot = deepestShadowRoot(target.shadowRoot)
+                    shadowRoot = deepestShadowRoot(
+                        (keyevent.target as Element).shadowRoot,
+                    )
 
                     textEditable =
                         shadowRoot === null
-                            ? isTextEditable(target)
+                            ? isTextEditable(keyevent.target as Element)
                             : isTextEditable(shadowRoot.activeElement)
                     // Accumulate key events. The parser will cut this
                     // down whenever it's not a valid prefix of a known
                     // binding, so it can't grow indefinitely unless you
                     // have a combination of maps that permits bindings of
                     // unbounded length.
-                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent as KeyboardEvent))
+                    keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
                 } else {
-                    keyEvents.push(keyevent as MinimalKey)
+                    keyEvents.push(keyevent)
                 }
 
                 // _just to be safe_, cache this to make the following
@@ -217,7 +218,7 @@ function* ParserController() {
                 )
 
                 if (response.isMatch && isKeyboardEvent(keyevent)) {
-                    canceller.push(keyevent as KeyboardEvent)
+                    canceller.push(keyevent)
                 }
 
                 if (response.exstr) {

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -88,7 +88,7 @@ class KeyCanceller {
                 ke.ctrlKey === ke2.ctrlKey &&
                 ke.metaKey === ke2.metaKey &&
                 ke.shiftKey === ke2.shiftKey &&
-                ke.target === ke2.target,
+                (ke.type === "keyup" || ke.target === ke2.target),
         )
         if (index < 0) return false
         kes.splice(index, 1)

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -825,16 +825,20 @@ export function getAbsoluteCentre(el) {
 // This is mainly for the benefit of the mode indicator when focused on an element in an iframe
 export function activeElement(doc = document) {
     let elem = doc.activeElement
-    while (true) {
+    while (elem) {
         while (elem.shadowRoot) {
-            elem = elem.shadowRoot.activeElement
-            if (!elem) return null
+            const shadowActiveElem = elem.shadowRoot.activeElement
+            if (!shadowActiveElem) return elem
+            elem = shadowActiveElem
         }
         if (elem.tagName !== "IFRAME") return elem
         try {
-            elem = (elem as HTMLIFrameElement).contentDocument.activeElement
+            const iframeActiveElem = (elem as HTMLIFrameElement).contentDocument.activeElement
+            if (!iframeActiveElem) return elem
+            elem = iframeActiveElem
         } catch (e) {
             return elem
         }
     }
+    return null
 }

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -39,7 +39,8 @@ export function isTextEditable(element: Element) {
         }
 
         // These properties are only defined on HTMLElements
-        if (element instanceof element.ownerDocument.defaultView.HTMLElement) {
+        const win = element.ownerDocument?.defaultView
+        if (win && element instanceof win.HTMLElement) {
             if (element.contentEditable === undefined) {
                 // This happens on e.g. svgs.
                 return false
@@ -382,7 +383,8 @@ export function isPainted(elem: HTMLElement) {
  * @param doc   The document the frames should be fetched from
  */
 export function getAllDocumentFrames(doc = document) {
-    if (!(doc instanceof ((doc.defaultView as any).HTMLDocument))) return []
+    const win = doc?.defaultView as any
+    if (!win || !(doc instanceof win.HTMLDocument)) return []
     const frames = (
         Array.from(doc.getElementsByTagName("iframe")) as HTMLIFrameElement[] &
             HTMLFrameElement[]
@@ -703,7 +705,10 @@ function hijackPageFocusFunction(win = window): void {
 }
 
 const focusListenerDocs = new WeakSet()
-export function setupFocusHandler(doc = document, onNewIframeFound = null): void {
+export function setupFocusHandler(doc = document): void {
+    const win = doc?.defaultView
+    if (!win || focusListenerDocs.has(doc)) return
+
     // Handles when a user selects an input
     const setFocus = elem => {
         if (isTextEditable(elem)) {
@@ -741,33 +746,17 @@ export function setupFocusHandler(doc = document, onNewIframeFound = null): void
         setFocus(elem)
     }
 
-    if (!focusListenerDocs.has(doc)) {
-        listen(doc)
+    listen(doc)
+    focusListenerDocs.add(doc)
 
-        // Use focusout to check if we've shifted focus to a new iframe we're yet to add listeners to
-        const winBlur = _ => {
-            getAllDocumentFrames(doc).forEach(f => {
-                try {
-                    if (f.contentDocument && !focusListenerDocs.has(f.contentDocument)) {
-                        if (onNewIframeFound) {
-                            onNewIframeFound(f.contentWindow)
-                        }
-                        setupFocusHandler(f.contentDocument, onNewIframeFound)
-                    }
-                } catch(_) {}
-            })
-        }
-
-        focusListenerDocs.add(doc)
-        doc.defaultView.addEventListener("focusout", winBlur)
-
-        // Run handler immediately if the newly found frame has focus
-        if (doc.hasFocus()) handler({ target: doc.activeElement })
+    // Run handler immediately if the newly found frame has focus
+    if (doc.hasFocus() && doc.activeElement) {
+        handler({ target: doc.activeElement })
     }
 
     // Handles when the page tries to select an input
     if (inContentScript()) {
-        hijackPageFocusFunction(doc.defaultView)
+        hijackPageFocusFunction(win)
     }
 }
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -39,7 +39,7 @@ export function isTextEditable(element: Element) {
         }
 
         // These properties are only defined on HTMLElements
-        if (element instanceof HTMLElement) {
+        if (element instanceof element.ownerDocument.defaultView.HTMLElement) {
             if (element.contentEditable === undefined) {
                 // This happens on e.g. svgs.
                 return false
@@ -294,7 +294,7 @@ export function isVisible(thing: Element | Range) {
  * @param doc   The document the frames should be fetched from
  */
 export function getAllDocumentFrames(doc = document) {
-    if (!(doc instanceof HTMLDocument)) return []
+    if (!(doc instanceof ((doc.defaultView as any).HTMLDocument))) return []
     const frames = (
         Array.from(doc.getElementsByTagName("iframe")) as HTMLIFrameElement[] &
             HTMLFrameElement[]
@@ -572,10 +572,13 @@ async function setInput(el) {
     state.prevInputs = arr.slice(Math.max(arr.length - 10, 0))
 }
 
+const hijackedPages = new WeakSet()
+const focusListenerDocs = new WeakSet()
+
 /** Replaces the page's HTMLElement.prototype.focus with our own, onPageFocus */
-function hijackPageFocusFunction(): void {
+function hijackPageFocusFunction(win = window): void {
     const exportedName = "onPageFocus"
-    exportFunction(onPageFocus, window, { defineAs: exportedName })
+    exportFunction(onPageFocus, win, { defineAs: exportedName })
 
     const eval_str = `HTMLElement.prototype.focus = ((realFocus, ${exportedName}) => {
         return function (...args) {
@@ -584,10 +587,10 @@ function hijackPageFocusFunction(): void {
         }
      })(HTMLElement.prototype.focus, ${exportedName})`
 
-    window.eval(eval_str + `;delete ${exportedName}`)
+    win.eval(eval_str + `;delete ${exportedName}`)
 }
 
-export function setupFocusHandler(): void {
+export function setupFocusHandler(doc = document, onNewIframeFound = null): void {
     // Handles when a user selects an input
     const setFocus = elem => {
         if (isTextEditable(elem)) {
@@ -618,10 +621,34 @@ export function setupFocusHandler(): void {
         }
         setFocus(elem)
     }
-    listen(document)
+
+    if (!focusListenerDocs.has(doc)) {
+        listen(doc)
+
+        // Use focusout to check if we've shifted focus to a new iframe we're yet to add listeners to
+        const winBlur = e => {
+            getAllDocumentFrames(doc).forEach(f => {
+                try {
+                    if (f.contentDocument && !focusListenerDocs.has(f.contentDocument)) {
+                        if (onNewIframeFound) {
+                            onNewIframeFound(f.contentWindow)
+                        }
+                        setupFocusHandler(f.contentDocument, onNewIframeFound)
+                    }
+                } catch(_) {}
+            })
+        }
+
+        focusListenerDocs.add(doc)
+        doc.defaultView.addEventListener("focusout", winBlur)
+
+        // Run handler immediately if the newly found frame has focus
+        if (doc.hasFocus()) handler({ target: doc.activeElement })
+    }
+
     // Handles when the page tries to select an input
     if (inContentScript()) {
-        hijackPageFocusFunction()
+        hijackPageFocusFunction(doc.defaultView)
     }
 }
 
@@ -794,5 +821,22 @@ export function getAbsoluteCentre(el) {
     return {
         x: pos.x + (window as any).mozInnerScreenX,
         y: pos.y + (window as any).mozInnerScreenY,
+    }
+}
+
+// This is mainly for the benefit of the mode indicator when focused on an element in an iframe
+export function activeElement(doc = document) {
+    let elem = doc.activeElement
+    while (true) {
+        while (elem.shadowRoot) {
+            elem = elem.shadowRoot.activeElement
+            if (!elem) return null
+        }
+        if (elem.tagName !== "IFRAME") return elem
+        try {
+            elem = (elem as HTMLIFrameElement).contentDocument.activeElement
+        } catch (e) {
+            return elem
+        }
     }
 }

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -627,6 +627,45 @@ export function hijackPageListenerFunctions(): void {
     window.eval(eval_str + `;delete ${exportedName}`)
 }
 
+const hijackedAttachShadows = new WeakSet()
+export function hijackPageAttachShadow(
+    onShadowRoot: (root: ShadowRoot) => void,
+    win = window,
+): void {
+    if (!inContentScript()) return
+    try {
+        const prototype = win.Element.prototype
+        const attachShadow = win.eval("p => p.attachShadow")(prototype)
+        if (typeof attachShadow !== "function" || hijackedAttachShadows.has(attachShadow)) return
+
+        const observeShadowRoot = (host: HTMLElement) => {
+            try {
+                // Xray input plus a native brand check rejects fake Elements.
+                Element.prototype.hasAttributes.apply(host)
+                const root = host.openOrClosedShadowRoot
+                if (root) onShadowRoot(root)
+            } catch {}
+        }
+        const wrapped = win.eval(`(prototype, realFunction, observe, apply) => {
+            const wrapped = function (...args) {
+                const result = apply(realFunction, this, args)
+                try { observe(this) } catch {}
+                return result
+            }
+            prototype.attachShadow = wrapped
+            return wrapped
+        }`)(
+            prototype,
+            attachShadow,
+            exportFunction(observeShadowRoot, win),
+            exportFunction(Reflect.apply, win),
+        )
+        hijackedAttachShadows.add(wrapped)
+    } catch (e) {
+        logger.warning("Could not hijack attachShadow:", e)
+    }
+}
+
 /** Focuses an input element and makes sure the cursor is put at the end of the input */
 export function focus(e: HTMLElement): void {
     e.focus()

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -39,7 +39,7 @@ export function isTextEditable(element: Element) {
         }
 
         // These properties are only defined on HTMLElements
-        if (element instanceof HTMLElement) {
+        if (element instanceof element.ownerDocument.defaultView.HTMLElement) {
             if (element.contentEditable === undefined) {
                 // This happens on e.g. svgs.
                 return false
@@ -382,7 +382,7 @@ export function isPainted(elem: HTMLElement) {
  * @param doc   The document the frames should be fetched from
  */
 export function getAllDocumentFrames(doc = document) {
-    if (!(doc instanceof HTMLDocument)) return []
+    if (!(doc instanceof ((doc.defaultView as any).HTMLDocument))) return []
     const frames = (
         Array.from(doc.getElementsByTagName("iframe")) as HTMLIFrameElement[] &
             HTMLFrameElement[]
@@ -687,10 +687,13 @@ async function setInput(el) {
     state.prevInputs = arr.slice(Math.max(arr.length - 10, 0))
 }
 
+const hijackedPages = new WeakSet()
+const focusListenerDocs = new WeakSet()
+
 /** Replaces the page's HTMLElement.prototype.focus with our own, onPageFocus */
-function hijackPageFocusFunction(): void {
+function hijackPageFocusFunction(win = window): void {
     const exportedName = "onPageFocus"
-    exportFunction(onPageFocus, window, { defineAs: exportedName })
+    exportFunction(onPageFocus, win, { defineAs: exportedName })
 
     const eval_str = `HTMLElement.prototype.focus = ((realFocus, ${exportedName}) => {
         return function (...args) {
@@ -699,10 +702,10 @@ function hijackPageFocusFunction(): void {
         }
      })(HTMLElement.prototype.focus, ${exportedName})`
 
-    window.eval(eval_str + `;delete ${exportedName}`)
+    win.eval(eval_str + `;delete ${exportedName}`)
 }
 
-export function setupFocusHandler(): void {
+export function setupFocusHandler(doc = document, onNewIframeFound = null): void {
     // Handles when a user selects an input
     const setFocus = elem => {
         if (isTextEditable(elem)) {
@@ -739,10 +742,34 @@ export function setupFocusHandler(): void {
         }
         setFocus(elem)
     }
-    listen(document)
+
+    if (!focusListenerDocs.has(doc)) {
+        listen(doc)
+
+        // Use focusout to check if we've shifted focus to a new iframe we're yet to add listeners to
+        const winBlur = e => {
+            getAllDocumentFrames(doc).forEach(f => {
+                try {
+                    if (f.contentDocument && !focusListenerDocs.has(f.contentDocument)) {
+                        if (onNewIframeFound) {
+                            onNewIframeFound(f.contentWindow)
+                        }
+                        setupFocusHandler(f.contentDocument, onNewIframeFound)
+                    }
+                } catch(_) {}
+            })
+        }
+
+        focusListenerDocs.add(doc)
+        doc.defaultView.addEventListener("focusout", winBlur)
+
+        // Run handler immediately if the newly found frame has focus
+        if (doc.hasFocus()) handler({ target: doc.activeElement })
+    }
+
     // Handles when the page tries to select an input
     if (inContentScript()) {
-        hijackPageFocusFunction()
+        hijackPageFocusFunction(doc.defaultView)
     }
 }
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -687,9 +687,6 @@ async function setInput(el) {
     state.prevInputs = arr.slice(Math.max(arr.length - 10, 0))
 }
 
-const hijackedPages = new WeakSet()
-const focusListenerDocs = new WeakSet()
-
 /** Replaces the page's HTMLElement.prototype.focus with our own, onPageFocus */
 function hijackPageFocusFunction(win = window): void {
     const exportedName = "onPageFocus"
@@ -705,6 +702,7 @@ function hijackPageFocusFunction(win = window): void {
     win.eval(eval_str + `;delete ${exportedName}`)
 }
 
+const focusListenerDocs = new WeakSet()
 export function setupFocusHandler(doc = document, onNewIframeFound = null): void {
     // Handles when a user selects an input
     const setFocus = elem => {
@@ -747,7 +745,7 @@ export function setupFocusHandler(doc = document, onNewIframeFound = null): void
         listen(doc)
 
         // Use focusout to check if we've shifted focus to a new iframe we're yet to add listeners to
-        const winBlur = e => {
+        const winBlur = _ => {
             getAllDocumentFrames(doc).forEach(f => {
                 try {
                     if (f.contentDocument && !focusListenerDocs.has(f.contentDocument)) {

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -572,9 +572,6 @@ async function setInput(el) {
     state.prevInputs = arr.slice(Math.max(arr.length - 10, 0))
 }
 
-const hijackedPages = new WeakSet()
-const focusListenerDocs = new WeakSet()
-
 /** Replaces the page's HTMLElement.prototype.focus with our own, onPageFocus */
 function hijackPageFocusFunction(win = window): void {
     const exportedName = "onPageFocus"
@@ -590,6 +587,7 @@ function hijackPageFocusFunction(win = window): void {
     win.eval(eval_str + `;delete ${exportedName}`)
 }
 
+const focusListenerDocs = new WeakSet()
 export function setupFocusHandler(doc = document, onNewIframeFound = null): void {
     // Handles when a user selects an input
     const setFocus = elem => {
@@ -626,7 +624,7 @@ export function setupFocusHandler(doc = document, onNewIframeFound = null): void
         listen(doc)
 
         // Use focusout to check if we've shifted focus to a new iframe we're yet to add listeners to
-        const winBlur = e => {
+        const winBlur = _ => {
             getAllDocumentFrames(doc).forEach(f => {
                 try {
                     if (f.contentDocument && !focusListenerDocs.has(f.contentDocument)) {


### PR DESCRIPTION
#1971 discusses the escape key not working on google docs - this is mainly because listeners aren't actually being added to iframes' `contentWindow`s but there are related problems which must be fixed to have keypresses behave correctly

There are several problems with iframe key and focus listeners currently:
- adding the iframe listeners correctly
- discovering all iframes
- `thing instanceof Thing` being unexpectedly false in various places due to `thing` originating from an iframe
- `keydown` events having a different target to corresponding `keyup` events causing them not to be cancelled

this PR:

adds listeners to iframes `contentWindow`s instead of the iframe elements

uses mutation observers to watch for iframes being added to the page or inside other iframes

replaces some uses of `thing instanceof Thing` with equivalent functions that work with objects from iframes  - this lets the key canceller cancel key events from iframes

removes the `target` check from the key canceller because the equivalent `keyup` for a given `keydown` may have a different `target` - particularly bad in cases like google docs where pressing escape to unfocus the document unfocuses it, then a `keyup` listener refocuses it! This may not be the best solution, that check may have been important in some cases?

---

also added an `activeElement` function which delves into iframes so the mode indicator can go to insert mode if a text editable element is focused in an iframe