### PR TITLE
Add TrustedKeyboardEvent and compel usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,9 @@ module.exports = {
                     "String": {
                         "message": "Avoid using the `String` type. Did you mean `string`?"
                     },
+                    "KeyboardEvent": {
+                        "message": "Use `TrustedKeyboardEvent` to prevent remote code injection from hostile pages."
+                    },
                     "Symbol": {
                         "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
                     }
@@ -270,5 +273,23 @@ module.exports = {
                 "@typescript-eslint/prefer-regexp-exec": "off",
             },
         },
+        {
+            "files":["src/content.ts", "src/commandline_frame.ts"],
+            "rules": {
+                "@typescript-eslint/ban-types":[
+                    "error",
+                    {
+                        "types": {
+                            "TrustedKeyboardEvent": {
+                                "message": "Events must be validated with `isTrustedKeyboardEvent` at runtime"
+                            },
+                            "KeyboardEvent": {
+                                "message": "Use `Event` instead"
+                            },
+                        }
+                    }
+                ]
+            }
+        }
     ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,9 +285,11 @@ module.exports = {
         {
             "files": ["src/content.ts", "src/commandline_frame.ts"],
             "rules": {
+                "@typescript-eslint/no-explicit-any": "error",
                 "@typescript-eslint/ban-types": [
                     "error",
                     {
+                        "extendDefaults": true,
                         "types": {
                             "TrustedKeyboardEvent": {
                                 "message": "Events must be validated with `isTrustedKeyboardEvent` at runtime"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -276,6 +276,7 @@ module.exports = {
         {
             "files":["src/content.ts", "src/commandline_frame.ts"],
             "rules": {
+                "@typescript-eslint/no-explicit-any": "error",
                 "@typescript-eslint/ban-types":[
                     "error",
                     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,6 +70,9 @@ module.exports = {
                     "String": {
                         "message": "Avoid using the `String` type. Did you mean `string`?"
                     },
+                    "KeyboardEvent": {
+                        "message": "Use `TrustedKeyboardEvent` to prevent remote code injection from hostile pages."
+                    },
                     "Symbol": {
                         "message": "Avoid using the `Symbol` type. Did you mean `symbol`?"
                     }
@@ -279,5 +282,23 @@ module.exports = {
                 "@typescript-eslint/prefer-regexp-exec": "off",
             },
         },
+        {
+            "files": ["src/content.ts", "src/commandline_frame.ts"],
+            "rules": {
+                "@typescript-eslint/ban-types": [
+                    "error",
+                    {
+                        "types": {
+                            "TrustedKeyboardEvent": {
+                                "message": "Events must be validated with `isTrustedKeyboardEvent` at runtime"
+                            },
+                            "KeyboardEvent": {
+                                "message": "Use `Event` instead"
+                            },
+                        },
+                    },
+                ],
+            },
+        }
     ],
 };

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -231,7 +231,7 @@ let prev_cmd_called_history = false
 
 // Save programmer time by generating an immediately resolved promise
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const QUEUE: Promise<any>[] = [(async () => {})()]
+const QUEUE: Promise<void>[] = [(async () => {})()]
 
 /** @hidden **/
 commandline_state.clInput.addEventListener(
@@ -315,7 +315,7 @@ export function refresh_completions(exstr) {
 }
 
 /** @hidden **/
-let onInputPromise: Promise<any> = Promise.resolve()
+let onInputPromise: Promise<void | void[]> = Promise.resolve()
 /** @hidden **/
 commandline_state.clInput.addEventListener("input", () => {
     logger.debug("commandline_frame clInput input event listener")
@@ -456,7 +456,7 @@ Messaging.addListener(
 // object since there's apparently a bug that causes performance
 // observers to be GC'd even if they're still the target of a
 // callback.
-;(window as any).tri = Object.assign(window.tri || {}, {
+window["tri"] = Object.assign(window.tri || {}, {
     perfObserver: perf.listenForCounters(),
 })
 

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -56,7 +56,11 @@ import * as genericParser from "@src/parsers/genericmode"
 import * as perf from "@src/perf"
 import state, * as State from "@src/state"
 import * as R from "ramda"
-import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
+import {
+    MinimalKey,
+    minimalKeyFromKeyboardEvent,
+    isTrustedKeyboardEvent,
+} from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
 import { ProfileCompletionSource } from "@src/completions/Profile"
 
@@ -246,8 +250,8 @@ const QUEUE: Promise<any>[] = [(async () => {})()]
 /** @hidden **/
 commandline_state.clInput.addEventListener(
     "keydown",
-    function (keyevent: KeyboardEvent) {
-        if (!keyevent.isTrusted) return
+    function (keyevent: Event) {
+        if (!isTrustedKeyboardEvent(keyevent)) return
         logger.debug(
             "commandline_frame clInput keydown event listener",
             keyevent,

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -245,7 +245,7 @@ let prev_cmd_called_history = false
 
 // Save programmer time by generating an immediately resolved promise
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const QUEUE: Promise<any>[] = [(async () => {})()]
+const QUEUE: Promise<void>[] = [(async () => {})()]
 
 /** @hidden **/
 commandline_state.clInput.addEventListener(
@@ -330,7 +330,7 @@ export function refresh_completions(exstr) {
 }
 
 /** @hidden **/
-let onInputPromise: Promise<any> = Promise.resolve()
+let onInputPromise: Promise<void | void[]> = Promise.resolve()
 /** @hidden **/
 commandline_state.clInput.addEventListener("input", () => {
     logger.debug("commandline_frame clInput input event listener")
@@ -473,7 +473,7 @@ Messaging.addListener(
 // object since there's apparently a bug that causes performance
 // observers to be GC'd even if they're still the target of a
 // callback.
-;(window as any).tri = Object.assign(window.tri || {}, {
+window["tri"] = Object.assign(window.tri || {}, {
     perfObserver: perf.listenForCounters(),
 })
 

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -56,7 +56,11 @@ import * as genericParser from "@src/parsers/genericmode"
 import * as perf from "@src/perf"
 import state, * as State from "@src/state"
 import * as R from "ramda"
-import { MinimalKey, minimalKeyFromKeyboardEvent } from "@src/lib/keyseq"
+import {
+    MinimalKey,
+    minimalKeyFromKeyboardEvent,
+    isTrustedKeyboardEvent,
+} from "@src/lib/keyseq"
 import { TabGroupCompletionSource } from "@src/completions/TabGroup"
 import { ProfileCompletionSource } from "@src/completions/Profile"
 
@@ -220,9 +224,12 @@ const QUEUE: Promise<any>[] = [(async () => {})()]
 /** @hidden **/
 commandline_state.clInput.addEventListener(
     "keydown",
-    function (keyevent: KeyboardEvent) {
-        if (!keyevent.isTrusted) return
-        logger.debug("commandline_frame clInput keydown event listener", keyevent)
+    function (keyevent: Event) {
+        if (!isTrustedKeyboardEvent(keyevent)) return
+        logger.debug(
+            "commandline_frame clInput keydown event listener",
+            keyevent,
+        )
         commandline_state.keyEvents.push(minimalKeyFromKeyboardEvent(keyevent))
         const response = keyParser(commandline_state.keyEvents)
         if (response.isMatch) {

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -179,21 +179,28 @@ const noblur = () => setTimeout(() => commandline_state.clInput.focus(), 0)
 /** @hidden **/
 export function focus() {
     function consumeBufferedPageKeys(bufferedPageKeys: string[]) {
-        const clInputStillFocused = window.document.activeElement === commandline_state.clInput;
-        logger.debug("stop_buffering_page_keys response received, bufferedPageKeys = ", bufferedPageKeys,
-            "clInputStillFocused = " + clInputStillFocused)
+        const clInputStillFocused =
+            window.document.activeElement === commandline_state.clInput
+        logger.debug(
+            "stop_buffering_page_keys response received, bufferedPageKeys = ",
+            bufferedPageKeys,
+            "clInputStillFocused = " + clInputStillFocused,
+        )
         if (bufferedPageKeys.length !== 0) {
-            const currentClInputValue = commandline_state.clInput.value;
-            const initialClInputValue = commandline_state.initialClInputValue;
-            logger.debug("Consuming buffered page keys", bufferedPageKeys,
+            const currentClInputValue = commandline_state.clInput.value
+            const initialClInputValue = commandline_state.initialClInputValue
+            logger.debug(
+                "Consuming buffered page keys",
+                bufferedPageKeys,
                 "initialClInputValue = " + initialClInputValue,
-                "currentClInputValue = " + currentClInputValue);
+                "currentClInputValue = " + currentClInputValue,
+            )
             // Native events are assumed to be character keydown events,
             // i.e. characters appended at the end of clInput.
             commandline_state.clInput.value =
-                initialClInputValue
-                + bufferedPageKeys.join("")
-                + currentClInputValue.substring(initialClInputValue.length)
+                initialClInputValue +
+                bufferedPageKeys.join("") +
+                currentClInputValue.substring(initialClInputValue.length)
             // Update completion.
             clInputValueChanged()
         }
@@ -201,8 +208,13 @@ export function focus() {
     commandline_state.clInput.focus()
     commandline_state.clInput.removeEventListener("blur", noblur)
     commandline_state.clInput.addEventListener("blur", noblur)
-    logger.debug("commandline_frame clInput focus(), activeElement is clInput: " + (window.document.activeElement === commandline_state.clInput))
-    Messaging.messageOwnTab("stop_buffering_page_keys").then(consumeBufferedPageKeys)
+    logger.debug(
+        "commandline_frame clInput focus(), activeElement is clInput: " +
+            (window.document.activeElement === commandline_state.clInput),
+    )
+    Messaging.messageOwnTab("stop_buffering_page_keys").then(
+        consumeBufferedPageKeys,
+    )
 }
 
 /** @hidden **/
@@ -307,7 +319,7 @@ let onInputPromise: Promise<any> = Promise.resolve()
 /** @hidden **/
 commandline_state.clInput.addEventListener("input", () => {
     logger.debug("commandline_frame clInput input event listener")
-    clInputValueChanged();
+    clInputValueChanged()
 })
 
 /** @hidden **/
@@ -389,7 +401,15 @@ export function fillcmdline(
     trailspace = true,
     ffocus = true,
 ) {
-    logger.debug("commandline_frame fillcmdline(newcommand = " + newcommand + " trailspace = " + trailspace + " ffocus = " + ffocus + ")")
+    logger.debug(
+        "commandline_frame fillcmdline(newcommand = " +
+            newcommand +
+            " trailspace = " +
+            trailspace +
+            " ffocus = " +
+            ffocus +
+            ")",
+    )
     if (trailspace) commandline_state.clInput.value = newcommand + " "
     else commandline_state.clInput.value = newcommand
     commandline_state.initialClInputValue = commandline_state.clInput.value

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,10 +1,10 @@
 /** Content script entry point */
 
 // We need to grab a lock because sometimes Firefox will decide to insert the content script in the page multiple times
-if ((window as any).tridactyl_content_lock !== undefined) {
+if (window["tridactyl_content_lock"] !== undefined) {
     throw Error("Trying to load Tridactyl, but it's already loaded.")
 }
-;(window as any).tridactyl_content_lock = "locked"
+window["tridactyl_content_lock"] = "locked"
 
 // Be careful: typescript elides imports that appear not to be used if they're
 // assigned to a name.  If you want an import just for its side effects, make
@@ -47,7 +47,7 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
         //
         // Broken atm - on https://github.com/tridactyl/tridactyl/pull/3938 clicking onto issues doesn't do anything and we get "permission denied to access object"
 
-        const realwindow = (window as any).wrappedJSObject ?? window // wrappedJSObject not defined on extension pages
+        const realwindow = window["wrappedJSObject"] ?? window // wrappedJSObject not defined on extension pages
 
         const triPushState = (
             hist =>
@@ -140,31 +140,27 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
     // eslint-disable-next-line @typescript-eslint/require-await
     messaging.addListener("alive", async () => true)
 
-    const guardedAcceptKey = (maybekeyevent: Event) => {
-        if (!keyseq.isTrustedKeyboardEvent(maybekeyevent)) return
-        ContentController.acceptKey(maybekeyevent)
-    }
-    function listen(elem) {
-        elem.removeEventListener("keydown", guardedAcceptKey, true)
+    function listen(elem: Window | HTMLElement | HTMLFrameElement) {
+        elem.removeEventListener("keydown", keyseq.guarded(ContentController.acceptKey), true)
         elem.removeEventListener(
             "keypress",
-            ContentController.canceller.cancelKeyPress,
+            keyseq.guarded(ContentController.canceller.cancelKeyPress),
             true,
         )
         elem.removeEventListener(
             "keyup",
-            ContentController.canceller.cancelKeyUp,
+            keyseq.guarded(ContentController.canceller.cancelKeyUp),
             true,
         )
-        elem.addEventListener("keydown", guardedAcceptKey, true)
+        elem.addEventListener("keydown", keyseq.guarded(ContentController.acceptKey), true)
         elem.addEventListener(
             "keypress",
-            ContentController.canceller.cancelKeyPress,
+            keyseq.guarded(ContentController.canceller.cancelKeyPress),
             true,
         )
         elem.addEventListener(
             "keyup",
-            ContentController.canceller.cancelKeyUp,
+            keyseq.guarded(ContentController.canceller.cancelKeyUp),
             true,
         )
     }
@@ -181,8 +177,8 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
         const preventAutoFocus = () => {
             // First, blur whatever element is active. This will make sure
             // activeElement is the "default" active element
-            ;(document.activeElement as any).blur()
-            const elem = document.activeElement as any
+            const elem = document.activeElement as HTMLElement
+            elem.blur()
             // ???: We need to set tabIndex, otherwise we won't get focus/blur events!
             elem.tabIndex = 0
             const focusElem = () => elem.focus()
@@ -222,7 +218,7 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
         }
         tryPreventAutoFocus()
     })
-    ;(window as any).tri = Object.assign(Object.create(null), {
+    window["tri"] = Object.assign(Object.create(null), {
         browserBg: webext.browserBg,
         bg: backgroundProxy.backgroundProxy,
         commandline_content,
@@ -322,7 +318,7 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
                     statusIndicator.setAttribute(
                         "style",
                         `border: ${
-                            (container as any).colorCode
+                            container.colorCode
                         } var(--tridactyl-indicator-border-style, solid) var(--tridactyl-indicator-border-width, 1.5px) !important`,
                     )
                 })
@@ -500,7 +496,7 @@ config.getAsync("superignore").then(async TRI_DISABLE => {
     // background for collection. Attach the observer to the window object
     // since there's apparently a bug that causes performance observers to
     // be GC'd even if they're still the target of a callback.
-    ;(window as any).tri = Object.assign(window.tri, {
+    window["tri"] = Object.assign(window.tri, {
         perfObserver: perf.listenForCounters(),
     })
 }) // End of maybe-disable-tridactyl-a-bit wrapper

--- a/src/content.ts
+++ b/src/content.ts
@@ -131,8 +131,9 @@ messaging.addListener("omniscient_content", messaging.attributeCaller(omniscient
 // eslint-disable-next-line @typescript-eslint/require-await
 messaging.addListener("alive", async () => true)
 
-const guardedAcceptKey = (keyevent: KeyboardEvent) => {
-    ContentController.acceptTrustedKey(keyevent)
+const guardedAcceptKey = (keyevent: Event) => {
+    if (!keyseq.isTrustedKeyboardEvent(keyevent)) return
+    ContentController.acceptKey(keyevent)
 }
 function listen(elem) {
     elem.removeEventListener("keydown", guardedAcceptKey, true)

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,10 +1,10 @@
 /** Content script entry point */
 
 // We need to grab a lock because sometimes Firefox will decide to insert the content script in the page multiple times
-if ((window as any).tridactyl_content_lock !== undefined) {
+if (window["tridactyl_content_lock"] !== undefined) {
     throw Error("Trying to load Tridactyl, but it's already loaded.")
 }
-;(window as any).tridactyl_content_lock = "locked"
+window["tridactyl_content_lock"] = "locked"
 
 // Be careful: typescript elides imports that appear not to be used if they're
 // assigned to a name.  If you want an import just for its side effects, make
@@ -48,7 +48,7 @@ try {
     //
     // Broken atm - on https://github.com/tridactyl/tridactyl/pull/3938 clicking onto issues doesn't do anything and we get "permission denied to access object"
 
-    const realwindow = (window as any).wrappedJSObject ?? window // wrappedJSObject not defined on extension pages
+    const realwindow = window["wrappedJSObject"] ?? window // wrappedJSObject not defined on extension pages
 
     const triPushState = (hist => (
         (...args) => {
@@ -131,33 +131,45 @@ messaging.addListener("omniscient_content", messaging.attributeCaller(omniscient
 // eslint-disable-next-line @typescript-eslint/require-await
 messaging.addListener("alive", async () => true)
 
-const guardedAcceptKey = (keyevent: Event) => {
-    if (!keyseq.isTrustedKeyboardEvent(keyevent)) return
-    ContentController.acceptKey(keyevent)
-}
-function listen(elem) {
-    elem.removeEventListener("keydown", guardedAcceptKey, true)
-    elem.removeEventListener("keyup", guardedAcceptKey, true)
+function listen(elem: Window | HTMLElement | HTMLFrameElement) {
     elem.removeEventListener(
-        "keypress",
-        ContentController.canceller.cancelKeyPress,
+        "keydown",
+        keyseq.guarded(ContentController.acceptKey),
         true,
     )
     elem.removeEventListener(
         "keyup",
-        ContentController.canceller.cancelKeyUp,
+        keyseq.guarded(ContentController.acceptKey),
         true,
     )
-    elem.addEventListener("keydown", guardedAcceptKey, true)
-    elem.addEventListener("keyup", guardedAcceptKey, true)
-    elem.addEventListener(
+    elem.removeEventListener(
         "keypress",
-        ContentController.canceller.cancelKeyPress,
+        keyseq.guarded(ContentController.canceller.cancelKeyPress),
+        true,
+    )
+    elem.removeEventListener(
+        "keyup",
+        keyseq.guarded(ContentController.canceller.cancelKeyUp),
+        true,
+    )
+    elem.addEventListener(
+        "keydown",
+        keyseq.guarded(ContentController.acceptKey),
         true,
     )
     elem.addEventListener(
         "keyup",
-        ContentController.canceller.cancelKeyUp,
+        keyseq.guarded(ContentController.acceptKey),
+        true,
+    )
+    elem.addEventListener(
+        "keypress",
+        keyseq.guarded(ContentController.canceller.cancelKeyPress),
+        true,
+    )
+    elem.addEventListener(
+        "keyup",
+        keyseq.guarded(ContentController.canceller.cancelKeyUp),
         true,
     )
 }
@@ -174,8 +186,8 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
     const preventAutoFocus = () => {
         // First, blur whatever element is active. This will make sure
         // activeElement is the "default" active element
-        ;(document.activeElement as any).blur()
-        const elem = document.activeElement as any
+        ;(document.activeElement as HTMLElement).blur()
+        const elem = document.activeElement as HTMLElement
         // ???: We need to set tabIndex, otherwise we won't get focus/blur events!
         elem.tabIndex = 0
         const focusElem = () => elem.focus()
@@ -209,7 +221,7 @@ config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
     }
     tryPreventAutoFocus()
 })
-;(window as any).tri = Object.assign(Object.create(null), {
+window["tri"] = Object.assign(Object.create(null), {
     browserBg: webext.browserBg,
     bg: backgroundProxy.backgroundProxy,
     commandline_content,
@@ -307,7 +319,7 @@ config.getAsync("modeindicator").then(mode => {
                 statusIndicator.setAttribute(
                     "style",
                     `border: ${
-                        (container as any).colorCode
+                        container.colorCode
                     } var(--tridactyl-indicator-border-style, solid) var(--tridactyl-indicator-border-width, 1.5px) !important`,
                 )
             })
@@ -492,7 +504,7 @@ document.addEventListener("readystatechange", checkElemsSurvived)
 // background for collection. Attach the observer to the window object
 // since there's apparently a bug that causes performance observers to
 // be GC'd even if they're still the target of a callback.
-;(window as any).tri = Object.assign(window.tri, {
+window["tri"] = Object.assign(window.tri, {
     perfObserver: perf.listenForCounters(),
 })
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -158,44 +158,13 @@ function listen(elem) {
         ContentController.canceller.cancelKeyUp,
         true,
     )
-}
-listen(window)
-document.addEventListener("readystatechange", _ =>
-    getAllDocumentFrames().forEach(f => listen(f)),
-)
 
-// Prevent pages from automatically focusing elements on load
-config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
-    if (allowautofocus === "false") {
-        return
-    }
-    const preventAutoFocus = () => {
-        // First, blur whatever element is active. This will make sure
-        // activeElement is the "default" active element
-        ;(document.activeElement as any).blur()
-        const elem = document.activeElement as any
-        // ???: We need to set tabIndex, otherwise we won't get focus/blur events!
-        elem.tabIndex = 0
-        const focusElem = () => elem.focus()
-        elem.addEventListener("blur", focusElem)
-        elem.addEventListener("focusout", focusElem)
-        // On top of blur/focusout events, we need to periodically check the
-        // activeElement is the one we want because blur/focusout events aren't
-        // always triggered when document.activeElement changes
-        const interval = setInterval(() => {
-            if (document.activeElement != elem) focusElem()
-        }, 200)
-        // When the user starts interacting with the page, stop resetting focus
-        function stopResettingFocus(event: Event) {
-            if (!event.isTrusted) return
-            elem.removeEventListener("blur", focusElem)
-            elem.removeEventListener("focusout", focusElem)
-            clearInterval(interval)
-            window.removeEventListener("keydown", stopResettingFocus)
-            window.removeEventListener("mousedown", stopResettingFocus)
-        }
-        window.addEventListener("keydown", stopResettingFocus)
-        window.addEventListener("mousedown", stopResettingFocus)
+    // eslint-disable-next-line @typescript-eslint/require-await
+    messaging.addListener("alive", async () => true)
+
+    const guardedAcceptKey = (maybekeyevent: Event) => {
+        if (!keyseq.isTrustedKeyboardEvent(maybekeyevent)) return
+        ContentController.acceptKey(maybekeyevent)
     }
     const tryPreventAutoFocus = () => {
         document.removeEventListener("readystatechange", tryPreventAutoFocus)

--- a/src/content.ts
+++ b/src/content.ts
@@ -34,129 +34,107 @@ import { EditorCmds as editor } from "@src/content/editor"
 /* tslint:disable:import-spacing */
 
 config.getAsync("superignore").then(async TRI_DISABLE => {
-// Set up our controller to execute content-mode excmds. All code
-// running from this entry point, which is to say, everything in the
-// content script, will use the excmds that we give to the module
-// here.
+    // Set up our controller to execute content-mode excmds. All code
+    // running from this entry point, which is to say, everything in the
+    // content script, will use the excmds that we give to the module
+    // here.
 
-if (TRI_DISABLE === "true") return
+    if (TRI_DISABLE === "true") return
 
-try {
+    try {
+        // Add cheap location change event
+        // Adapted from: https://stackoverflow.com/questions/6390341/how-to-detect-if-url-has-changed-after-hash-in-javascript
+        //
+        // Broken atm - on https://github.com/tridactyl/tridactyl/pull/3938 clicking onto issues doesn't do anything and we get "permission denied to access object"
 
-    // Add cheap location change event
-    // Adapted from: https://stackoverflow.com/questions/6390341/how-to-detect-if-url-has-changed-after-hash-in-javascript
-    //
-    // Broken atm - on https://github.com/tridactyl/tridactyl/pull/3938 clicking onto issues doesn't do anything and we get "permission denied to access object"
+        const realwindow = (window as any).wrappedJSObject ?? window // wrappedJSObject not defined on extension pages
 
-    const realwindow = (window as any).wrappedJSObject ?? window // wrappedJSObject not defined on extension pages
+        const triPushState = (
+            hist =>
+            (...args) => {
+                const ret = hist(...args)
+                realwindow.dispatchEvent(new Event("HistoryPushState"))
+                realwindow.dispatchEvent(new Event("HistoryState"))
+                return ret
+            }
+        )(realwindow.history.pushState.bind(realwindow.history))
 
-    const triPushState = (hist => (
-        (...args) => {
-            const ret = hist(...args)
-            realwindow.dispatchEvent(new Event("HistoryPushState"))
+        const triReplaceState = (
+            hist =>
+            (...args) => {
+                const ret = hist(...args)
+                realwindow.dispatchEvent(new Event("HistoryReplaceState"))
+                realwindow.dispatchEvent(new Event("HistoryState"))
+                return ret
+            }
+        )(realwindow.history.replaceState.bind(realwindow.history))
+
+        realwindow.addEventListener("popstate", () => {
             realwindow.dispatchEvent(new Event("HistoryState"))
-            return ret
         })
-    )(realwindow.history.pushState.bind(realwindow.history))
 
-    const triReplaceState = (hist => (
-        (...args) => {
-            const ret = hist(...args)
-            realwindow.dispatchEvent(new Event("HistoryReplaceState"))
-            realwindow.dispatchEvent(new Event("HistoryState"))
-            return ret
-        })
-    )(realwindow.history.replaceState.bind(realwindow.history))
+        history.replaceState = triReplaceState
+        history.pushState = triPushState
 
-    realwindow.addEventListener("popstate", () => {
-        realwindow.dispatchEvent(new Event("HistoryState"))
+        typeof exportFunction == "function" &&
+            exportFunction(triReplaceState, history, {
+                defineAs: "replaceState",
+            })
+        typeof exportFunction == "function" &&
+            exportFunction(triPushState, history, { defineAs: "pushState" })
+    } catch (e) {
+        console.error(e)
+    }
+
+    const controller = await import("@src/lib/controller")
+    const { omniscient_controller } = await import(
+        "@src/lib/omniscient_controller"
+    )
+    const excmds_content = await import("@src/.excmds_content.generated")
+    const hinting_content = await import("@src/content/hinting")
+    // Hook the keyboard up to the controller
+    const ContentController = await import("@src/content/controller_content")
+    // Add various useful modules to the window for debugging
+    const commandline_content = await import("@src/content/commandline_content")
+    const convert = await import("@src/lib/convert")
+    const dom = await import("@src/lib/dom")
+    const excmds = await import("@src/.excmds_content.generated")
+    const finding_content = await import("@src/content/finding")
+    const itertools = await import("@src/lib/itertools")
+    const messaging = await import("@src/lib/messaging")
+    const backgroundProxy = await import("@src/lib/tabs")
+    const State = await import("@src/state")
+    const webext = await import("@src/lib/webext")
+    const perf = await import("@src/perf")
+    const keyseq = await import("@src/lib/keyseq")
+    const native = await import("@src/lib/native")
+    const styling = await import("@src/content/styling")
+    const updates = await import("@src/lib/updates")
+    const urlutils = await import("@src/lib/url_util")
+    const scrolling = await import("@src/content/scrolling")
+    const R = await import("ramda")
+    const visual = await import("@src/lib/visual")
+    const metadata = await import("@src/.metadata.generated")
+    const { tabTgroup } = await import("@src/lib/tab_groups")
+    const completion_providers = await import("@src/completions/providers")
+
+    controller.setExCmds({
+        "": excmds_content,
+        ex: CmdlineCmds,
+        text: EditorCmds,
+        hint: hinting_content.getHintCommands(),
     })
-
-    history.replaceState = triReplaceState
-    history.pushState = triPushState
-
-    typeof(exportFunction) == "function" && exportFunction(triReplaceState, history, {defineAs: "replaceState"})
-    typeof(exportFunction) == "function" && exportFunction(triPushState, history, {defineAs: "pushState"})
-
-} catch (e) {
-    console.error(e)
-}
-
-const controller = await import("@src/lib/controller")
-const { omniscient_controller } = await import("@src/lib/omniscient_controller")
-const excmds_content = await import("@src/.excmds_content.generated")
-const hinting_content = await import("@src/content/hinting")
-// Hook the keyboard up to the controller
-const ContentController = await import("@src/content/controller_content")
-// Add various useful modules to the window for debugging
-const commandline_content = await import("@src/content/commandline_content")
-const convert = await import("@src/lib/convert")
-const dom = await import("@src/lib/dom")
-const excmds = await import("@src/.excmds_content.generated")
-const finding_content = await import("@src/content/finding")
-const itertools = await import("@src/lib/itertools")
-const messaging = await import("@src/lib/messaging")
-const backgroundProxy = await import("@src/lib/tabs")
-const State = await import("@src/state")
-const webext = await import("@src/lib/webext")
-const perf = await import("@src/perf")
-const keyseq = await import("@src/lib/keyseq")
-const native = await import("@src/lib/native")
-const styling = await import("@src/content/styling")
-const updates = await import("@src/lib/updates")
-const urlutils = await import("@src/lib/url_util")
-const scrolling = await import("@src/content/scrolling")
-const R = await import("ramda")
-const visual = await import("@src/lib/visual")
-const metadata = await import("@src/.metadata.generated")
-const { tabTgroup } = await import("@src/lib/tab_groups")
-const completion_providers = await import("@src/completions/providers")
-
-controller.setExCmds({
-    "": excmds_content,
-    ex: CmdlineCmds,
-    text: EditorCmds,
-    hint: hinting_content.getHintCommands(),
-})
-messaging.addListener(
-    "excmd_content",
-    messaging.attributeCaller(excmds_content),
-)
-messaging.addListener(
-    "controller_content",
-    messaging.attributeCaller(controller),
-)
-messaging.addListener("omniscient_content", messaging.attributeCaller(omniscient_controller))
-
-// eslint-disable-next-line @typescript-eslint/require-await
-messaging.addListener("alive", async () => true)
-
-const guardedAcceptKey = (keyevent: KeyboardEvent) => {
-    if (!keyevent.isTrusted) return
-    ContentController.acceptKey(keyevent)
-}
-function listen(elem) {
-    elem.removeEventListener("keydown", guardedAcceptKey, true)
-    elem.removeEventListener(
-        "keypress",
-        ContentController.canceller.cancelKeyPress,
-        true,
+    messaging.addListener(
+        "excmd_content",
+        messaging.attributeCaller(excmds_content),
     )
-    elem.removeEventListener(
-        "keyup",
-        ContentController.canceller.cancelKeyUp,
-        true,
+    messaging.addListener(
+        "controller_content",
+        messaging.attributeCaller(controller),
     )
-    elem.addEventListener("keydown", guardedAcceptKey, true)
-    elem.addEventListener(
-        "keypress",
-        ContentController.canceller.cancelKeyPress,
-        true,
-    )
-    elem.addEventListener(
-        "keyup",
-        ContentController.canceller.cancelKeyUp,
-        true,
+    messaging.addListener(
+        "omniscient_content",
+        messaging.attributeCaller(omniscient_controller),
     )
 
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -166,290 +144,363 @@ function listen(elem) {
         if (!keyseq.isTrustedKeyboardEvent(maybekeyevent)) return
         ContentController.acceptKey(maybekeyevent)
     }
-    const tryPreventAutoFocus = () => {
-        document.removeEventListener("readystatechange", tryPreventAutoFocus)
-        try {
-            preventAutoFocus()
-        } catch (e) {
-            document.addEventListener("readystatechange", tryPreventAutoFocus)
-        }
+    function listen(elem) {
+        elem.removeEventListener("keydown", guardedAcceptKey, true)
+        elem.removeEventListener(
+            "keypress",
+            ContentController.canceller.cancelKeyPress,
+            true,
+        )
+        elem.removeEventListener(
+            "keyup",
+            ContentController.canceller.cancelKeyUp,
+            true,
+        )
+        elem.addEventListener("keydown", guardedAcceptKey, true)
+        elem.addEventListener(
+            "keypress",
+            ContentController.canceller.cancelKeyPress,
+            true,
+        )
+        elem.addEventListener(
+            "keyup",
+            ContentController.canceller.cancelKeyUp,
+            true,
+        )
     }
-    tryPreventAutoFocus()
-})
-;(window as any).tri = Object.assign(Object.create(null), {
-    browserBg: webext.browserBg,
-    bg: backgroundProxy.backgroundProxy,
-    commandline_content,
-    convert,
-    config,
-    completion_providers,
-    controller,
-    dom,
-    editor,
-    excmds,
-    finding_content,
-    hinting_content,
-    itertools,
-    logger,
-    metadata,
-    keyseq,
-    messaging,
-    state,
-    State,
-    scrolling,
-    visual,
-    webext,
-    l: prom => prom.then(console.log).catch(console.error),
-    native,
-    styling,
-    contentLocation: window.location,
-    perf,
-    R,
-    updates,
-    urlutils,
-})
+    listen(window)
+    document.addEventListener("readystatechange", _ =>
+        getAllDocumentFrames().forEach(f => listen(f)),
+    )
 
-logger.info("Loaded commandline content?", commandline_content)
-
-try {
-    dom.setupFocusHandler()
-    dom.hijackPageListenerFunctions()
-} catch (e) {
-    logger.warning("Could not hijack due to CSP:", e)
-}
-
-if (
-    window.location.protocol === "moz-extension:" &&
-    window.location.pathname === "/static/newtab.html"
-) {
-    config.getAsync("newtab").then(newtab => {
-        if (!["about:blank", "about:newtab"].includes(newtab)) {
-            if (newtab) {
-                excmds.open_quiet(newtab)
-            } else {
-                const content = document.getElementById("trinewtab")
-                content.style.display = "block"
-                document.title = "Tridactyl Top Tips & New Tab Page"
+    // Prevent pages from automatically focusing elements on load
+    config.getAsync("preventautofocusjackhammer").then(allowautofocus => {
+        if (allowautofocus === "false") {
+            return
+        }
+        const preventAutoFocus = () => {
+            // First, blur whatever element is active. This will make sure
+            // activeElement is the "default" active element
+            ;(document.activeElement as any).blur()
+            const elem = document.activeElement as any
+            // ???: We need to set tabIndex, otherwise we won't get focus/blur events!
+            elem.tabIndex = 0
+            const focusElem = () => elem.focus()
+            elem.addEventListener("blur", focusElem)
+            elem.addEventListener("focusout", focusElem)
+            // On top of blur/focusout events, we need to periodically check the
+            // activeElement is the one we want because blur/focusout events aren't
+            // always triggered when document.activeElement changes
+            const interval = setInterval(() => {
+                if (document.activeElement != elem) focusElem()
+            }, 200)
+            // When the user starts interacting with the page, stop resetting focus
+            function stopResettingFocus(event: Event) {
+                if (!event.isTrusted) return
+                elem.removeEventListener("blur", focusElem)
+                elem.removeEventListener("focusout", focusElem)
+                clearInterval(interval)
+                window.removeEventListener("keydown", stopResettingFocus)
+                window.removeEventListener("mousedown", stopResettingFocus)
+            }
+            window.addEventListener("keydown", stopResettingFocus)
+            window.addEventListener("mousedown", stopResettingFocus)
+        }
+        const tryPreventAutoFocus = () => {
+            document.removeEventListener(
+                "readystatechange",
+                tryPreventAutoFocus,
+            )
+            try {
+                preventAutoFocus()
+            } catch (e) {
+                document.addEventListener(
+                    "readystatechange",
+                    tryPreventAutoFocus,
+                )
             }
         }
+        tryPreventAutoFocus()
     })
-}
+    ;(window as any).tri = Object.assign(Object.create(null), {
+        browserBg: webext.browserBg,
+        bg: backgroundProxy.backgroundProxy,
+        commandline_content,
+        convert,
+        config,
+        completion_providers,
+        controller,
+        dom,
+        editor,
+        excmds,
+        finding_content,
+        hinting_content,
+        itertools,
+        logger,
+        metadata,
+        keyseq,
+        messaging,
+        state,
+        State,
+        scrolling,
+        visual,
+        webext,
+        l: prom => prom.then(console.log).catch(console.error),
+        native,
+        styling,
+        contentLocation: window.location,
+        perf,
+        R,
+        updates,
+        urlutils,
+    })
 
-// Really bad status indicator
-let statusIndicator
-config.getAsync("modeindicator").then(mode => {
-    if (mode !== "true") return
+    logger.info("Loaded commandline content?", commandline_content)
 
-    // Do we want container indicators?
-    const containerIndicator = config.get("containerindicator")
+    try {
+        dom.setupFocusHandler()
+        dom.hijackPageListenerFunctions()
+    } catch (e) {
+        logger.warning("Could not hijack due to CSP:", e)
+    }
 
-    // Hide indicator in print mode
-    // CSS not explicitly added to the dom doesn't make it to print mode:
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1448507
-    const style = document.createElement("style")
-    style.type = "text/css"
-    style.innerHTML = `@media print {
+    if (
+        window.location.protocol === "moz-extension:" &&
+        window.location.pathname === "/static/newtab.html"
+    ) {
+        config.getAsync("newtab").then(newtab => {
+            if (!["about:blank", "about:newtab"].includes(newtab)) {
+                if (newtab) {
+                    excmds.open_quiet(newtab)
+                } else {
+                    const content = document.getElementById("trinewtab")
+                    content.style.display = "block"
+                    document.title = "Tridactyl Top Tips & New Tab Page"
+                }
+            }
+        })
+    }
+
+    // Really bad status indicator
+    let statusIndicator
+    config.getAsync("modeindicator").then(mode => {
+        if (mode !== "true") return
+
+        // Do we want container indicators?
+        const containerIndicator = config.get("containerindicator")
+
+        // Hide indicator in print mode
+        // CSS not explicitly added to the dom doesn't make it to print mode:
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1448507
+        const style = document.createElement("style")
+        style.type = "text/css"
+        style.innerHTML = `@media print {
         .TridactylStatusIndicator {
             display: none !important;
         }
     }`
 
-    statusIndicator = document.createElement("span")
-    const privateMode = browser.extension.inIncognitoContext
-        ? "TridactylPrivate"
-        : ""
-    statusIndicator.className =
-        "cleanslate TridactylStatusIndicator " +
-        privateMode +
-        " TridactylModenormal "
-
-    // Dynamically sets the border container color.
-    if (containerIndicator === "true") {
-        webext
-            .ownTabContainer()
-            .then(ownTab =>
-                webext.browserBg.contextualIdentities.get(ownTab.cookieStoreId),
-            )
-            .then(container => {
-                statusIndicator.setAttribute(
-                    "style",
-                    `border: ${
-                        (container as any).colorCode
-                    } var(--tridactyl-indicator-border-style, solid) var(--tridactyl-indicator-border-width, 1.5px) !important`,
-                )
-            })
-            .catch(error => {
-                logger.debug(error)
-            })
-    }
-
-    // This listener makes the modeindicator disappear when the mouse goes over it
-    statusIndicator.addEventListener("mouseenter", ev => {
-        const target = ev.target
-        const rect = target.getBoundingClientRect()
-        target.classList.add("TridactylInvisible")
-        const onMouseOut = ev => {
-            // If the mouse event happened out of the mode indicator boundaries
-            if (
-                ev.clientX < rect.x ||
-                ev.clientX > rect.x + rect.with ||
-                ev.clientY < rect.y ||
-                ev.clientY > rect.y + rect.height
-            ) {
-                target.classList.remove("TridactylInvisible")
-                window.removeEventListener("mousemove", onMouseOut)
-            }
-        }
-        window.addEventListener("mousemove", onMouseOut)
-    })
-
-    try {
-        // On quick loading pages, the document is already loaded
-        statusIndicator.textContent = contentState.mode || "normal"
-        document.body.appendChild(statusIndicator)
-        document.head.appendChild(style)
-    } catch (e) {
-        // But on slower pages we wait for the document to load
-        window.addEventListener("DOMContentLoaded", () => {
-            statusIndicator.textContent = contentState.mode || "normal"
-            document.body.appendChild(statusIndicator)
-            document.head.appendChild(style)
-        })
-    }
-
-    addContentStateChangedListener(async (property, oldMode, oldValue, newValue) => {
-        let mode = newValue
-        let suffix = ""
-        let result = ""
-        if (property !== "mode") {
-            if (property === "suffix") {
-                mode = oldMode
-                suffix = newValue
-            } else if (property === "group") {
-                mode = oldMode
-            }
-        }
-
+        statusIndicator = document.createElement("span")
         const privateMode = browser.extension.inIncognitoContext
             ? "TridactylPrivate"
             : ""
         statusIndicator.className =
-            "cleanslate TridactylStatusIndicator " + privateMode
-        if (
-            dom.isTextEditable(document.activeElement) &&
-            !["input", "ignore"].includes(mode)
-        ) {
-            result = "insert"
-            // this doesn't work; statusIndicator.style is full of empty string
-            // statusIndicator.style.borderColor = "green !important"
-            // need to fix loss of focus by click: doesn't do anything here.
-        } else if (
-            mode === "insert" &&
-            !dom.isTextEditable(document.activeElement)
-        ) {
-            result = "normal"
-            // statusIndicator.style.borderColor = "lightgray !important"
-        } else {
-            result = mode
-        }
-        const modeindicatorshowkeys = config.get("modeindicatorshowkeys")
-        if (modeindicatorshowkeys === "true" && suffix !== "") {
-            result = mode + " " + suffix
+            "cleanslate TridactylStatusIndicator " +
+            privateMode +
+            " TridactylModenormal "
+
+        // Dynamically sets the border container color.
+        if (containerIndicator === "true") {
+            webext
+                .ownTabContainer()
+                .then(ownTab =>
+                    webext.browserBg.contextualIdentities.get(
+                        ownTab.cookieStoreId,
+                    ),
+                )
+                .then(container => {
+                    statusIndicator.setAttribute(
+                        "style",
+                        `border: ${
+                            (container as any).colorCode
+                        } var(--tridactyl-indicator-border-style, solid) var(--tridactyl-indicator-border-width, 1.5px) !important`,
+                    )
+                })
+                .catch(error => {
+                    logger.debug(error)
+                })
         }
 
-        const tabGroup = await tabTgroup()
-        if (tabGroup) {
-            result = result + " | " + tabGroup
+        // This listener makes the modeindicator disappear when the mouse goes over it
+        statusIndicator.addEventListener("mouseenter", ev => {
+            const target = ev.target
+            const rect = target.getBoundingClientRect()
+            target.classList.add("TridactylInvisible")
+            const onMouseOut = ev => {
+                // If the mouse event happened out of the mode indicator boundaries
+                if (
+                    ev.clientX < rect.x ||
+                    ev.clientX > rect.x + rect.with ||
+                    ev.clientY < rect.y ||
+                    ev.clientY > rect.y + rect.height
+                ) {
+                    target.classList.remove("TridactylInvisible")
+                    window.removeEventListener("mousemove", onMouseOut)
+                }
+            }
+            window.addEventListener("mousemove", onMouseOut)
+        })
+
+        try {
+            // On quick loading pages, the document is already loaded
+            statusIndicator.textContent = contentState.mode || "normal"
+            document.body.appendChild(statusIndicator)
+            document.head.appendChild(style)
+        } catch (e) {
+            // But on slower pages we wait for the document to load
+            window.addEventListener("DOMContentLoaded", () => {
+                statusIndicator.textContent = contentState.mode || "normal"
+                document.body.appendChild(statusIndicator)
+                document.head.appendChild(style)
+            })
         }
 
-        logger.debug(
-            "statusindicator: ",
-            result,
-            ";",
-            "config",
-            modeindicatorshowkeys,
+        addContentStateChangedListener(
+            async (property, oldMode, oldValue, newValue) => {
+                let mode = newValue
+                let suffix = ""
+                let result = ""
+                if (property !== "mode") {
+                    if (property === "suffix") {
+                        mode = oldMode
+                        suffix = newValue
+                    } else if (property === "group") {
+                        mode = oldMode
+                    }
+                }
+
+                const privateMode = browser.extension.inIncognitoContext
+                    ? "TridactylPrivate"
+                    : ""
+                statusIndicator.className =
+                    "cleanslate TridactylStatusIndicator " + privateMode
+                if (
+                    dom.isTextEditable(document.activeElement) &&
+                    !["input", "ignore"].includes(mode)
+                ) {
+                    result = "insert"
+                    // this doesn't work; statusIndicator.style is full of empty string
+                    // statusIndicator.style.borderColor = "green !important"
+                    // need to fix loss of focus by click: doesn't do anything here.
+                } else if (
+                    mode === "insert" &&
+                    !dom.isTextEditable(document.activeElement)
+                ) {
+                    result = "normal"
+                    // statusIndicator.style.borderColor = "lightgray !important"
+                } else {
+                    result = mode
+                }
+                const modeindicatorshowkeys = config.get(
+                    "modeindicatorshowkeys",
+                )
+                if (modeindicatorshowkeys === "true" && suffix !== "") {
+                    result = mode + " " + suffix
+                }
+
+                const tabGroup = await tabTgroup()
+                if (tabGroup) {
+                    result = result + " | " + tabGroup
+                }
+
+                logger.debug(
+                    "statusindicator: ",
+                    result,
+                    ";",
+                    "config",
+                    modeindicatorshowkeys,
+                )
+                statusIndicator.textContent = result
+                statusIndicator.className +=
+                    " TridactylMode" + statusIndicator.textContent
+
+                if (
+                    config.get("modeindicator") !== "true" ||
+                    config.get("modeindicatormodes", mode) === "false"
+                ) {
+                    statusIndicator.classList.add("TridactylInvisible")
+                } else {
+                    statusIndicator.classList.remove("TridactylInvisble")
+                }
+            },
         )
-        statusIndicator.textContent = result
-        statusIndicator.className +=
-            " TridactylMode" + statusIndicator.textContent
+    })
 
+    let leaveGithubAlone = false // don't wait for the config before adding the listener
+    config.getAsync("leavegithubalone").then(v => {
+        leaveGithubAlone = v === "true"
+    })
+    // attach to window instead of document as it's available earlier
+    // capture: true prevents bubbling before we have had a chance to cancel it
+    window.addEventListener("keydown", protectSlash, { capture: true })
+
+    function protectSlash(e) {
+        if (!e.isTrusted || leaveGithubAlone) return
+        const blacklistKeys = config.get("blacklistkeys") || []
+        if (blacklistKeys.includes(e.key) && contentState.mode === "normal") {
+            e.cancelBubble = true
+            e.stopImmediatePropagation()
+            e.stopPropagation()
+        }
+    }
+
+    // I still don't get lib/messaging.ts
+    const phoneHome = () => browser.runtime.sendMessage("dom_loaded_background")
+
+    document.readyState === "complete" && phoneHome()
+    window.addEventListener("load", () => {
+        phoneHome()
+    })
+
+    document.addEventListener("selectionchange", () => {
+        const selection = document.getSelection()
         if (
-            config.get("modeindicator") !== "true" ||
-            config.get("modeindicatormodes", mode) === "false"
+            contentState.mode == "visual" &&
+            config.get("visualexitauto") == "true" &&
+            selection.isCollapsed
         ) {
-            statusIndicator.classList.add("TridactylInvisible")
-        } else {
-            statusIndicator.classList.remove("TridactylInvisble")
+            contentState.mode = "normal"
+            return
+        }
+        if (
+            contentState.mode !== "normal" ||
+            config.get("visualenterauto") == "false"
+        )
+            return
+        if (!selection.isCollapsed) {
+            contentState.mode = "visual"
         }
     })
-})
 
-let leaveGithubAlone = false // don't wait for the config before adding the listener
-config.getAsync("leavegithubalone").then(v => {
-    leaveGithubAlone = v === "true"
-});
-// attach to window instead of document as it's available earlier
-// capture: true prevents bubbling before we have had a chance to cancel it
-window.addEventListener("keydown", protectSlash, {capture: true})
+    // Try to catch the iframe/status indicator being removed by a script (React again)
+    const checkElemsSurvived = () => {
+        if (document.readyState === "complete") {
+            commandline_content.ensureIframeExists()
 
-function protectSlash(e) {
-    if (!e.isTrusted || leaveGithubAlone ) return
-    const blacklistKeys = config.get("blacklistkeys") || [];
-    if (blacklistKeys.includes(e.key) && contentState.mode === "normal") {
-        e.cancelBubble = true
-        e.stopImmediatePropagation()
-        e.stopPropagation()
+            if (statusIndicator !== undefined)
+                document.body.appendChild(statusIndicator)
+
+            // We only want to check the iframe survived between "interactive" and "complete"
+            document.removeEventListener("readystatechange", checkElemsSurvived)
+        }
     }
-}
+    document.addEventListener("readystatechange", checkElemsSurvived)
 
-// I still don't get lib/messaging.ts
-const phoneHome = () => browser.runtime.sendMessage("dom_loaded_background")
-
-document.readyState === "complete" && phoneHome()
-window.addEventListener("load", () => {
-    phoneHome()
-})
-
-document.addEventListener("selectionchange", () => {
-    const selection = document.getSelection()
-    if (
-        contentState.mode == "visual" &&
-        config.get("visualexitauto") == "true" &&
-        selection.isCollapsed
-    ) {
-        contentState.mode = "normal"
-        return
-    }
-    if (
-        contentState.mode !== "normal" ||
-        config.get("visualenterauto") == "false"
-    )
-        return
-    if (!selection.isCollapsed) {
-        contentState.mode = "visual"
-    }
-})
-
-// Try to catch the iframe/status indicator being removed by a script (React again)
-const checkElemsSurvived = () => {
-    if (document.readyState === "complete") {
-        commandline_content.ensureIframeExists()
-
-        if (statusIndicator !== undefined)
-            document.body.appendChild(statusIndicator)
-
-        // We only want to check the iframe survived between "interactive" and "complete"
-        document.removeEventListener("readystatechange", checkElemsSurvived)
-    }
-}
-document.addEventListener("readystatechange", checkElemsSurvived)
-
-// Listen for statistics from each content script and send them to the
-// background for collection. Attach the observer to the window object
-// since there's apparently a bug that causes performance observers to
-// be GC'd even if they're still the target of a callback.
-;(window as any).tri = Object.assign(window.tri, {
-    perfObserver: perf.listenForCounters(),
-})
-
+    // Listen for statistics from each content script and send them to the
+    // background for collection. Attach the observer to the window object
+    // since there's apparently a bug that causes performance observers to
+    // be GC'd even if they're still the target of a callback.
+    ;(window as any).tri = Object.assign(window.tri, {
+        perfObserver: perf.listenForCounters(),
+    })
 }) // End of maybe-disable-tridactyl-a-bit wrapper

--- a/src/content/controller_content.test.ts
+++ b/src/content/controller_content.test.ts
@@ -1,4 +1,5 @@
 import { acceptTrustedKey } from "@src/content/controller_content"
+import { guarded } from "@src/lib/keyseq"
 
 test.each(["keydown", "keyup"])(
     "synthetic %s events do not reach the key parser",
@@ -8,6 +9,9 @@ test.each(["keydown", "keyup"])(
 
         expect(event.isTrusted).toBe(false)
 
+        const guardedAcceptKey = guarded(accept)
+        expect(guarded(accept)).toBe(guardedAcceptKey)
+        guardedAcceptKey(event)
         acceptTrustedKey(event, accept)
 
         expect(accept).not.toHaveBeenCalled()

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -8,6 +8,8 @@ import {
     minimalKeyFromKeyboardEvent,
     MinimalKey,
     formatKeysForModeIndicator,
+    isTrustedKeyboardEvent,
+    TrustedKeyboardEvent,
 } from "@src/lib/keyseq"
 
 import * as hinting from "@src/content/hinting"
@@ -36,15 +38,15 @@ function mapstrsForMode(mode: string) {
  * A, then B, releases B and then A).
  */
 class KeyCanceller {
-    private keyPress: KeyboardEvent[] = []
-    private keyUp: KeyboardEvent[] = []
+    private keyPress: TrustedKeyboardEvent[] = []
+    private keyUp: TrustedKeyboardEvent[] = []
 
     constructor() {
         this.cancelKeyUp = this.cancelKeyUp.bind(this)
         this.cancelKeyPress = this.cancelKeyPress.bind(this)
     }
 
-    push(ke: KeyboardEvent) {
+    push(ke: TrustedKeyboardEvent) {
         ke.preventDefault()
         ke.stopImmediatePropagation()
 
@@ -57,17 +59,20 @@ class KeyCanceller {
         }
     }
 
-    public cancelKeyPress = (ke: KeyboardEvent) => {
-        if (!ke.isTrusted) return
+    public cancelKeyPress = (ke: Event) => {
+        if (!isTrustedKeyboardEvent(ke)) return
         this.cancelKey(ke, this.keyPress)
     }
 
-    public cancelKeyUp = (ke: KeyboardEvent) => {
-        if (!ke.isTrusted) return
+    public cancelKeyUp = (ke: Event) => {
+        if (!isTrustedKeyboardEvent(ke)) return
         this.cancelKey(ke, this.keyUp)
     }
 
-    private removeKey(ke: KeyboardEvent, kes: KeyboardEvent[]) {
+    private removeKey(
+        ke: TrustedKeyboardEvent,
+        kes: TrustedKeyboardEvent[],
+    ) {
         const index = kes.findIndex(
             ke2 =>
                 ke.altKey === ke2.altKey &&
@@ -83,7 +88,10 @@ class KeyCanceller {
         return true
     }
 
-    private cancelKey(ke: KeyboardEvent, kes: KeyboardEvent[]) {
+    private cancelKey(
+        ke: TrustedKeyboardEvent,
+        kes: TrustedKeyboardEvent[],
+    ) {
         if (this.removeKey(ke, kes) && ke instanceof KeyboardEvent) {
             ke.preventDefault()
             ke.stopImmediatePropagation()
@@ -140,17 +148,28 @@ function* ParserController() {
         try {
             while (true) {
                 generatorIsWaiting = true
-                const keyevent: KeyEventLike = keysToFeed.length ? keysToFeed.shift() : yield
+                const keyevent: KeyEventLike = keysToFeed.length
+                    ? keysToFeed.shift()
+                    : yield
                 generatorIsWaiting = false
+
+                if (
+                    !(keyevent instanceof MinimalKey) &&
+                    !isTrustedKeyboardEvent(keyevent)
+                ) {
+                    logger.warning("Skipped spoofed key event", keyevent)
+                    continue
+                }
 
                 // Don't break old modes with keyup events
                 // TODO: fix this in these parsers directly
                 if (
                     ["hint", "gobble"].includes(contentState.mode) &&
-                    (keyevent instanceof KeyboardEvent ? keyevent.type === "keyup" : keyevent.keyup)
+                    (keyevent instanceof KeyboardEvent
+                        ? keyevent.type === "keyup"
+                        : keyevent.keyup)
                 )
                     continue
-
                 let textEditable = false
 
                 if (keyevent instanceof KeyboardEvent) {
@@ -258,8 +277,8 @@ export function keyMuncher(...keys: KeyEventLike[]) {
 }
 
 /** Feed keys to the ParserController, unless they should be buffered to be later fed to clInput */
-export function acceptKey(keyevent: KeyboardEvent) {
-    function tryBufferingPageKeyForClInput(keyevent: KeyboardEvent) {
+export function acceptKey(keyevent: TrustedKeyboardEvent) {
+    function tryBufferingPageKeyForClInput(keyevent: TrustedKeyboardEvent) {
         if (!mustBufferPageKeysForClInput) return false
         const bufferingDuration = performance.now() - bufferingPageKeysBeginTime
         logger.debug(
@@ -288,9 +307,9 @@ export function acceptKey(keyevent: KeyboardEvent) {
 }
 
 export function acceptTrustedKey(
-    keyevent: KeyboardEvent,
-    accept: (keyevent: KeyboardEvent) => unknown = acceptKey,
+    keyevent: Event,
+    accept: (keyevent: TrustedKeyboardEvent) => unknown = acceptKey,
 ) {
-    if (!keyevent.isTrusted) return
+    if (!isTrustedKeyboardEvent(keyevent)) return
     return accept(keyevent)
 }

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -59,13 +59,11 @@ class KeyCanceller {
         }
     }
 
-    public cancelKeyPress = (ke: Event) => {
-        if (!isTrustedKeyboardEvent(ke)) return
+    public cancelKeyPress = (ke: TrustedKeyboardEvent) => {
         this.cancelKey(ke, this.keyPress)
     }
 
-    public cancelKeyUp = (ke: Event) => {
-        if (!isTrustedKeyboardEvent(ke)) return
+    public cancelKeyUp = (ke: TrustedKeyboardEvent) => {
         this.cancelKey(ke, this.keyUp)
     }
 
@@ -92,7 +90,7 @@ class KeyCanceller {
         ke: TrustedKeyboardEvent,
         kes: TrustedKeyboardEvent[],
     ) {
-        if (this.removeKey(ke, kes) && ke instanceof KeyboardEvent) {
+        if (this.removeKey(ke, kes)) {
             ke.preventDefault()
             ke.stopImmediatePropagation()
         }
@@ -165,14 +163,14 @@ function* ParserController() {
                 // TODO: fix this in these parsers directly
                 if (
                     ["hint", "gobble"].includes(contentState.mode) &&
-                    (keyevent instanceof KeyboardEvent
+                    (!(keyevent instanceof MinimalKey)
                         ? keyevent.type === "keyup"
                         : keyevent.keyup)
                 )
                     continue
                 let textEditable = false
 
-                if (keyevent instanceof KeyboardEvent) {
+                if (!(keyevent instanceof MinimalKey)) {
                     const deepTarget = activeElement(keyevent.target as HTMLElement) || keyevent.target as HTMLElement
                     textEditable = isTextEditable(deepTarget)
 
@@ -226,7 +224,7 @@ function* ParserController() {
                     response,
                 )
 
-                if (response.isMatch && keyevent instanceof KeyboardEvent) {
+                if (response.isMatch && !(keyevent instanceof MinimalKey)) {
                     canceller.push(keyevent)
                 }
 

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -16,7 +16,7 @@ import * as hinting from "@src/content/hinting"
 import * as gobblemode from "@src/parsers/gobblemode"
 import * as generic from "@src/parsers/genericmode"
 import * as nmode from "@src/parsers/nmode"
-import * as Messaging from "@src/lib/messaging";
+import * as Messaging from "@src/lib/messaging"
 import * as config from "@src/lib/config"
 
 const logger = new Logger("controller")
@@ -107,29 +107,42 @@ export const canceller = new KeyCanceller()
 
 let commandlineFrameReadyToReceiveMessages = false
 config.getAsync("noiframe").then(noiframe => {
-    if(noiframe === "true") {
+    if (noiframe === "true") {
         commandlineFrameReadyToReceiveMessages = true
     } else {
-        Messaging.addListener("commandline_frame_ready_to_receive_messages", () => {
-            logger.debug("Received commandline_frame_ready_to_receive_messages")
-            commandlineFrameReadyToReceiveMessages = true
-        })
+        Messaging.addListener(
+            "commandline_frame_ready_to_receive_messages",
+            () => {
+                logger.debug(
+                    "Received commandline_frame_ready_to_receive_messages",
+                )
+                commandlineFrameReadyToReceiveMessages = true
+            },
+        )
     }
 })
 
 let mustBufferPageKeysForClInput = false
 let bufferedPageKeys: string[] = []
 let bufferingPageKeysBeginTime: number
-Messaging.addListener("stop_buffering_page_keys", (message, sender, sendResponse) => {
-    const bufferingDuration = performance.now() - bufferingPageKeysBeginTime;
-    logger.debug("stop_buffering_page_keys request received, responding with bufferedPageKeys = ", bufferedPageKeys
-        + " bufferingDuration = " + bufferingDuration + "ms")
-    sendResponse(Promise.resolve(bufferedPageKeys))
-    // At this point, clInput is focused and the page cannot get any more keyboard events
-    // until it is refocused.
-    mustBufferPageKeysForClInput = false
-    bufferedPageKeys = []
-})
+Messaging.addListener(
+    "stop_buffering_page_keys",
+    (message, sender, sendResponse) => {
+        const bufferingDuration = performance.now() - bufferingPageKeysBeginTime
+        logger.debug(
+            "stop_buffering_page_keys request received, responding with bufferedPageKeys = ",
+            bufferedPageKeys +
+                " bufferingDuration = " +
+                bufferingDuration +
+                "ms",
+        )
+        sendResponse(Promise.resolve(bufferedPageKeys))
+        // At this point, clInput is focused and the page cannot get any more keyboard events
+        // until it is refocused.
+        mustBufferPageKeysForClInput = false
+        bufferedPageKeys = []
+    },
+)
 
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
 function* ParserController() {
@@ -290,7 +303,12 @@ export function acceptKey(keyevent: TrustedKeyboardEvent) {
         // in turn means that the stop_buffering_page_keys message will never be sent to the content/page process.
         // If the content/page process starts buffering keys for clInput, but the stop_buffering_page_keys message is never received,
         // it will keep buffering (and eating events) forever.
-        logger.debug("controller_content Ignoring key event ", keyevent, " since commandline frame is not yet ready to receive messages", keyevent)
+        logger.debug(
+            "controller_content Ignoring key event ",
+            keyevent,
+            " since commandline frame is not yet ready to receive messages",
+            keyevent,
+        )
         return
     }
     if (!tryBufferingPageKeyForClInput(keyevent))

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -7,6 +7,8 @@ import {
     ParserResponse,
     minimalKeyFromKeyboardEvent,
     MinimalKey,
+    isTrustedKeyboardEvent,
+    TrustedKeyboardEvent,
 } from "@src/lib/keyseq"
 import { deepestShadowRoot } from "@src/lib/dom"
 
@@ -57,32 +59,32 @@ function PrintableKey(k) {
  * A, then B, releases B and then A).
  */
 class KeyCanceller {
-    private keyPress: KeyboardEvent[] = []
-    private keyUp: KeyboardEvent[] = []
+    private keyPress: TrustedKeyboardEvent[] = []
+    private keyUp: TrustedKeyboardEvent[] = []
 
     constructor() {
         this.cancelKeyUp = this.cancelKeyUp.bind(this)
         this.cancelKeyPress = this.cancelKeyPress.bind(this)
     }
 
-    push(ke: KeyboardEvent) {
+    push(ke: TrustedKeyboardEvent) {
         ke.preventDefault()
         ke.stopImmediatePropagation()
         this.keyPress.push(ke)
         this.keyUp.push(ke)
     }
 
-    public cancelKeyPress = (ke: KeyboardEvent) => {
-        if (!ke.isTrusted) return
+    public cancelKeyPress = (ke: TrustedKeyboardEvent) => {
+        // if (!ke.isTrusted) return
         this.cancelKey(ke, this.keyPress)
     }
 
-    public cancelKeyUp = (ke: KeyboardEvent) => {
-        if (!ke.isTrusted) return
+    public cancelKeyUp = (ke: TrustedKeyboardEvent) => {
+        // if (!ke.isTrusted) return
         this.cancelKey(ke, this.keyUp)
     }
 
-    private cancelKey(ke: KeyboardEvent, kes: KeyboardEvent[]) {
+    private cancelKey(ke: TrustedKeyboardEvent, kes: TrustedKeyboardEvent[]) {
         const index = kes.findIndex(
             ke2 =>
                 ke.altKey === ke2.altKey &&
@@ -151,6 +153,10 @@ function* ParserController() {
         try {
             while (true) {
                 const keyevent: KeyEventLike = yield
+                if (!isTrustedKeyboardEvent(keyevent)) {
+                    logger.warning("Skipped spoofed key event", keyevent)
+                    continue
+                }
                 let shadowRoot = null
                 let textEditable = false
 
@@ -254,17 +260,25 @@ export const generator = ParserController() // var rather than let stops weirdne
 generator.next()
 
 /** Feed keys to the ParserController, unless they should be buffered to be later fed to clInput */
-export function acceptKey(keyevent: KeyboardEvent) {
-    function tryBufferingPageKeyForClInput(keyevent: KeyboardEvent) {
-        if (!mustBufferPageKeysForClInput)
-            return false;
-        const bufferingDuration = performance.now() - bufferingPageKeysBeginTime;
-        logger.debug("controller_content mustBufferPageKeysForClInput = " + mustBufferPageKeysForClInput
-            + " bufferingDuration = " + bufferingDuration + "ms");
-        const isCharacterKey = keyevent.key.length == 1
-            && !keyevent.metaKey && !keyevent.ctrlKey && !keyevent.altKey && !keyevent.metaKey;
+export function acceptKey(keyevent: TrustedKeyboardEvent) {
+    function tryBufferingPageKeyForClInput(keyevent: TrustedKeyboardEvent) {
+        if (!mustBufferPageKeysForClInput) return false
+        const bufferingDuration = performance.now() - bufferingPageKeysBeginTime
+        logger.debug(
+            "controller_content mustBufferPageKeysForClInput = " +
+                mustBufferPageKeysForClInput +
+                " bufferingDuration = " +
+                bufferingDuration +
+                "ms",
+        )
+        const isCharacterKey =
+            keyevent.key.length == 1 &&
+            !keyevent.metaKey &&
+            !keyevent.ctrlKey &&
+            !keyevent.altKey &&
+            !keyevent.metaKey
         if (isCharacterKey) {
-            bufferedPageKeys.push(keyevent.key);
+            bufferedPageKeys.push(keyevent.key)
             logger.debug("Buffering page keys", bufferedPageKeys)
         }
         canceller.push(keyevent)

--- a/src/lib/keyseq.test.ts
+++ b/src/lib/keyseq.test.ts
@@ -6,6 +6,20 @@ function mk(k, mod?: ks.KeyModifiers) {
     return new ks.MinimalKey(k, mod)
 }
 
+test("isTrustedKeyboardEvent rejects spoofed objects", () => {
+    expect(
+        ks.isTrustedKeyboardEvent({
+            isTrusted: true,
+            view: { KeyboardEvent: { [Symbol.hasInstance]: () => true } },
+        }),
+    ).toBe(false)
+    expect(
+        ks.isTrustedKeyboardEvent(
+            new Proxy({}, { get: () => { throw new Error() } }),
+        ),
+    ).toBe(false)
+})
+
 {
     // {{{ parse and completions
 

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -66,7 +66,10 @@ export class MinimalKey {
     readonly metaKey = false
     readonly shiftKey = false
     translated = false
-    constructor(readonly key: string, modifiers?: KeyModifiers) {
+    constructor(
+        readonly key: string,
+        modifiers?: KeyModifiers,
+    ) {
         if (modifiers !== undefined) {
             for (const mod of Object.keys(modifiers)) {
                 if (

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -29,6 +29,19 @@ import grammar from "@src/grammars/.bracketexpr.generated"
 const bracketexpr_grammar = grammar
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
 
+// unspoofable keyboard events
+// this should be ~the only place in the code that accepts KeyboardEvent
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type TrustedKeyboardEvent = KeyboardEvent & { readonly isTrusted: true }
+
+export function isTrustedKeyboardEvent(ke: any): ke is TrustedKeyboardEvent {
+    if (!ke || typeof ke !== "object") return false
+    if (ke.isTrusted !== true) return false
+    if (ke instanceof KeyboardEvent) return true
+    const win = ke.view
+    return win ? ke instanceof win.KeyboardEvent : false
+}
+
 let KEYCODETRANSLATEMAP = {}
 
 // {{{ General types
@@ -122,7 +135,7 @@ export class MinimalKey {
     }
 }
 
-export type KeyEventLike = MinimalKey | KeyboardEvent
+export type KeyEventLike = MinimalKey | TrustedKeyboardEvent
 
 // }}}
 
@@ -486,7 +499,7 @@ function numericPrefixToExstrSuffix(numericPrefix: MinimalKey[]) {
  * code if config says so.
  */
 export function minimalKeyFromKeyboardEvent(
-    keyEvent: KeyboardEvent,
+    keyEvent: TrustedKeyboardEvent,
 ): MinimalKey {
     const modifiers = {
         altKey: keyEvent.altKey,

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -26,6 +26,7 @@ import { Parser } from "@src/lib/nearley_utils"
 import * as config from "@src/lib/config"
 import * as R from "ramda"
 import grammar from "@src/grammars/.bracketexpr.generated"
+import { memoise } from "@src/lib/memoise"
 const bracketexpr_grammar = grammar
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
 
@@ -33,6 +34,13 @@ const bracketexpr_parser = new Parser(bracketexpr_grammar)
 // this should be ~the only place in the code that accepts KeyboardEvent
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TrustedKeyboardEvent = KeyboardEvent & { readonly isTrusted: true }
+
+const _guarded =
+    (f: (ke: TrustedKeyboardEvent) => void) => (maybekeyevent: Event) => {
+        if (!isTrustedKeyboardEvent(maybekeyevent)) return
+        return f(maybekeyevent)
+    }
+export const guarded = memoise(_guarded)
 
 export function isTrustedKeyboardEvent(ke: any): ke is TrustedKeyboardEvent {
     if (!ke || typeof ke !== "object") return false

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -29,6 +29,20 @@ import grammar from "@src/grammars/.bracketexpr.generated"
 const bracketexpr_grammar = grammar
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
 
+// unspoofable keyboard events
+// this should be ~the only place in the code that accepts KeyboardEvent
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type TrustedKeyboardEvent = KeyboardEvent & { readonly isTrusted: true }
+
+export function isTrustedKeyboardEvent(ke: unknown): ke is TrustedKeyboardEvent {
+    if (!ke || typeof ke !== "object") return false
+    const event = ke as Event & { view?: typeof window }
+    if (event.isTrusted !== true) return false
+    if (event instanceof KeyboardEvent) return true
+    const win = event.view
+    return win ? event instanceof win.KeyboardEvent : false
+}
+
 let KEYCODETRANSLATEMAP = {}
 
 // {{{ General types
@@ -140,7 +154,7 @@ export class MinimalKey {
     }
 }
 
-export type KeyEventLike = MinimalKey | KeyboardEvent
+export type KeyEventLike = MinimalKey | TrustedKeyboardEvent
 
 // }}}
 
@@ -600,7 +614,7 @@ function numericPrefixToExstrSuffix(numericPrefix: MinimalKey[]) {
  * code if config says so.
  */
 export function minimalKeyFromKeyboardEvent(
-    keyEvent: KeyboardEvent,
+    keyEvent: TrustedKeyboardEvent,
 ): MinimalKey {
     const modifiers = {
         altKey: keyEvent.altKey,

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -43,6 +43,7 @@ const _guarded =
 export const guarded = memoise(_guarded)
 
 export function isTrustedKeyboardEvent(ke: any): ke is TrustedKeyboardEvent {
+    if (ke instanceof MinimalKey) return true
     if (!ke || typeof ke !== "object") return false
     if (ke.isTrusted !== true) return false
     if (ke instanceof KeyboardEvent) return true

--- a/src/lib/keyseq.ts
+++ b/src/lib/keyseq.ts
@@ -26,6 +26,7 @@ import { filter, find } from "@src/lib/itertools"
 import { Parser } from "@src/lib/nearley_utils"
 import * as config from "@src/lib/config"
 import grammar from "@src/grammars/.bracketexpr.generated"
+import { memoise } from "@src/lib/memoise"
 const bracketexpr_grammar = grammar
 const bracketexpr_parser = new Parser(bracketexpr_grammar)
 
@@ -34,13 +35,24 @@ const bracketexpr_parser = new Parser(bracketexpr_grammar)
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type TrustedKeyboardEvent = KeyboardEvent & { readonly isTrusted: true }
 
+export const guarded = memoise(
+    (accept: (keyevent: TrustedKeyboardEvent) => unknown) =>
+        (keyevent: Event) => {
+            if (!isTrustedKeyboardEvent(keyevent)) return
+            return accept(keyevent)
+        },
+)
+
 export function isTrustedKeyboardEvent(ke: unknown): ke is TrustedKeyboardEvent {
     if (!ke || typeof ke !== "object") return false
-    const event = ke as Event & { view?: typeof window }
-    if (event.isTrusted !== true) return false
-    if (event instanceof KeyboardEvent) return true
-    const win = event.view
-    return win ? event instanceof win.KeyboardEvent : false
+    try {
+        const event = ke as Event
+        if (event.isTrusted !== true) return false
+        KeyboardEvent.prototype.getModifierState.call(event, "")
+        return true
+    } catch {
+        return false
+    }
 }
 
 let KEYCODETRANSLATEMAP = {}

--- a/src/lib/memoise.ts
+++ b/src/lib/memoise.ts
@@ -1,10 +1,12 @@
 // prevent dumb reactivity on function factories
 export function memoise<TArg, TResult>(fn: (arg: TArg) => TResult) {
-  const cache = new Map<TArg, TResult>()
-  return (arg: TArg): TResult => {
-    if (!cache.has(arg)) {
-      cache.set(arg, fn(arg))
+    const cache = new Map<TArg, { value: TResult }>()
+    return (arg: TArg): TResult => {
+        let cached = cache.get(arg)
+        if (!cached) {
+            cached = { value: fn(arg) }
+            cache.set(arg, cached)
+        }
+        return cached.value
     }
-    return cache.get(arg)!
-  }
 }

--- a/src/lib/memoise.ts
+++ b/src/lib/memoise.ts
@@ -1,0 +1,10 @@
+// prevent dumb reactivity on function factories
+export function memoise<TArg, TResult>(fn: (arg: TArg) => TResult) {
+  const cache = new Map<TArg, TResult>()
+  return (arg: TArg): TResult => {
+    if (!cache.has(arg)) {
+      cache.set(arg, fn(arg))
+    }
+    return cache.get(arg)!
+  }
+}


### PR DESCRIPTION
I got caught out by my own pre-commit hook and it mangled this to fix the formatting. I've tried my best to split it into two commits but didn't manage it perfectly.

~~This currently breaks `keyfeed` which is 1) great, those are untrusted key events but 2) it would be nice to make it work again~~

Blocks #5381