### PR TITLE
fix: unbind default and default config overwritten by mergeDeep

### DIFF
--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,7 +1,11 @@
 import { testAll, testAllObject } from "@src/lib/test_utils"
 import { canonicaliseMapstr } from "@src/lib/keyseq"
 import { default_config } from "@src/lib/config"
+import * as tri_config from "@src/lib/config"
 import { zip } from "ramda"
+
+const tri = { config: tri_config }
+const { getURL, get } = tri.config
 
 const config = new default_config()
 // todo: test subconfigs and platform_defaults
@@ -14,3 +18,63 @@ for (let mode of Object.keys(config).filter(x => x.match(/maps$/))) {
     const mapstrings = Object.keys(config[mode])
     testAll(canonicaliseMapstr, zip(mapstrings, mapstrings))
 }
+
+test("getURL in keymap and config", () => {
+    const nmaps = getURL("https://web.whatsapp.com/", ["nmaps"])
+    expect(nmaps.f).toBe("hint -c [tabindex]:not(.two)>div,a")
+
+    const google = "https://www.google.com/"
+    expect(getURL(google, ["followpagepatterns", "prev"])).toBe("Previous")
+})
+
+test("merge deep should keep null", () => {
+    const a = {}
+    const b = { n: null }
+    const c = tri.config.mergeDeep({}, { n: null })
+    expect(c).toEqual({ n: null })
+})
+
+test("get in default inherit keymap", () => {
+    expect(config["vmaps"]["🕷🕷INHERITS🕷🕷"]).toBe("nmaps")
+    expect("gt" in config["vmaps"]).toBe(false)
+    expect(config["nmaps"].gt).toBeTruthy()
+
+    const vmapsAfterInherit = get("vmaps")
+    const nmaps = get("nmaps")
+    expect(vmapsAfterInherit.gt).toBe(nmaps.gt)
+})
+
+test("keymap unbind default", () => {
+    expect(config["exmaps"]["<Space>"]).toBe(
+        tri.config.DEFAULTS.exmaps["<Space>"],
+    )
+    tri.config.set("exmaps", "<Space>", null)
+    expect(tri.config.USERCONFIG.exmaps["<Space>"]).toBeNull()
+    expect(tri.config.DEFAULTS.exmaps).toBeTruthy()
+
+    const exmaps = get("exmaps")
+    expect(exmaps["<Space>"]).toBeUndefined()
+})
+
+test("get in modified inherit keymap", () => {
+    expect(config["vmaps"]["🕷🕷INHERITS🕷🕷"]).toBe("nmaps")
+    expect("q" in config["vmaps"]).toBe(true)
+    expect("q" in config["nmaps"]).toBe(false)
+
+    tri.config.set("vmaps", "q", null)
+    expect(tri.config.USERCONFIG.vmaps.q).toBeNull()
+
+    const vmapsAfterInherit = get("vmaps")
+    expect(vmapsAfterInherit.q).toBeUndefined()
+})
+
+test("mergeDeep should not pollute arguments", () => {
+    const o1 = { n: { a: 1 } }
+    const o2 = { n: { b: 2 } }
+    const o3 = tri.config.mergeDeep(o1, o2)
+    expect({ o1, o2, o3 }).toEqual({
+        o1: { n: { a: 1 } },
+        o2: { n: { b: 2 } },
+        o3: { n: { a: 1, b: 2 } },
+    })
+})

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -27,6 +27,16 @@ test("getURL in keymap and config", () => {
     expect(getURL(google, ["followpagepatterns", "prev"])).toBe("Previous")
 })
 
+test("getURL in keymap and config in mock mode", () => {
+    mockUrl("https://web.whatsapp.com/", () => {
+        const nmaps = get("nmaps")
+        expect(nmaps.f).toBe("hint -c [tabindex]:not(.two)>div,a")
+    })
+    mockUrl("https://www.google.com/", () => {
+        expect(get("followpagepatterns", "prev")).toBe("Previous")
+    })
+})
+
 test("merge deep should keep null", () => {
     const a = {}
     const b = { n: null }
@@ -77,4 +87,59 @@ test("mergeDeep should not pollute arguments", () => {
         o2: { n: { b: 2 } },
         o3: { n: { a: 1, b: 2 } },
     })
+})
+
+function mockUrl(u, fn) {
+    const tri0 = window.tri
+    window.tri = { contentLocation: { href: u } }
+    fn()
+    window.tri = tri0
+}
+
+test("merge object when default undefined", () => {
+    const u = "youtube"
+    const m = "mycustommaps"
+    const cmd = "js alert(`j`)"
+    const cmdk = "js alert(`k`)"
+    expect(tri.config.DEFAULTS[m]).toBeUndefined()
+
+    tri.config.set(m, "J", cmd)
+    expect(tri.config.USERCONFIG[m]).toEqual({ J: cmd })
+    expect(tri.config.DEFAULTS[m]).toBeUndefined()
+
+    expect(tri.config.getDynamic(m)).toEqual({ J: cmd })
+    expect(tri.config.getDynamic(m, "J")).toBe(cmd)
+
+    tri.config.setURL(u, m, "K", cmdk)
+
+    // what we fix is how the get() function merges user and site config
+    // so we have to mock url for the get() instead of calling getURL
+    mockUrl(u, () => {
+        expect(tri.config.getDynamic(m)).toEqual({ J: cmd, K: cmdk })
+        expect(tri.config.getDynamic(m, "J")).toBe(cmd)
+        expect(tri.config.getDynamic(m, "K")).toBe(cmdk)
+    })
+})
+
+test("merge object when user config undefined", () => {
+    const u = "youtube"
+    const obj = "followpagepatterns"
+    const val = "go-next"
+    const prev = tri.config.get(obj, "prev")
+    expect(typeof tri.config.get(obj, "next")).toBe("string")
+    const orig = tri.config.get(obj, "next")
+    expect(tri.config.DEFAULTS[obj]["next"]).toBe(orig)
+    expect(tri.config.USERCONFIG[obj]).toBeUndefined()
+
+    tri.config.setURL(u, obj, "next", val)
+    expect(tri.config.get(obj, "next")).toBe(orig)
+    expect(tri.config.DEFAULTS[obj].next).toBe(orig)
+    expect(tri.config.USERCONFIG[obj]).toBeUndefined()
+
+    mockUrl(u, () => {
+        expect(tri.config.get(obj, "next")).toBe(val)
+        expect(tri.config.get(obj)).toEqual({ next: val, prev: prev })
+    })
+
+    expect(tri.config.USERCONFIG.subconfigs[u][obj]).toEqual({ next: val })
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1956,8 +1956,8 @@ function setDeepProperty(obj, value, target) {
  * Merges two objects and any child objects they may have
  */
 export function mergeDeep(o1, o2) {
-    if (o1 === null) return Object.assign({}, o2)
-    const r = Array.isArray(o1) ? o1.slice() : Object.create(o1)
+    if (o1 === null) return o(o2)
+    const r = Array.isArray(o1) ? o1.slice() : o({})
     Object.assign(r, o1, o2)
     if (o2 === undefined) return r
     Object.keys(o1)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1919,14 +1919,14 @@ export function getDeepProperty(obj, target: string[]) {
             return getDeepProperty(obj[target[0]], target.slice(1))
         } else {
             return getDeepProperty(
-                mergeDeepCull(get(obj["🕷🕷INHERITS🕷🕷"]), obj)[target[0]],
+                mergeDeep(get(obj["🕷🕷INHERITS🕷🕷"]), obj)[target[0]],
                 target.slice(1),
             )
         }
     } else {
         if (obj === undefined || obj === null) return obj
         if (obj["🕷🕷INHERITS🕷🕷"] !== undefined) {
-            return mergeDeepCull(get(obj["🕷🕷INHERITS🕷🕷"]), obj)
+            return mergeDeep(get(obj["🕷🕷INHERITS🕷🕷"]), obj)
         } else {
             return obj
         }
@@ -1965,9 +1965,7 @@ export function mergeDeep(o1, o2) {
             key => typeof o1[key] === "object" && typeof o2[key] === "object",
         )
         .forEach(key =>
-            r[key] == null
-                ? null
-                : Object.assign(r[key], mergeDeep(o1[key], o2[key])),
+            r[key] == null ? null : (r[key] = mergeDeep(o1[key], o2[key])),
         )
     return r
 }
@@ -2010,7 +2008,7 @@ export function getURL(url: string, target: string[]) {
     const deflt = _getURL(DEFAULTS, url, target)
     if (user === undefined || user === null) return deflt
     if (typeof user !== "object" || typeof deflt !== "object") return user
-    return mergeDeepCull(deflt, user)
+    return mergeDeep(deflt, user)
 }
 
 /** Get the value of the key target.
@@ -2036,14 +2034,14 @@ export function get(target_typed?: keyof default_config, ...target: string[]) {
 
     // Merge results if there's a default value and it's not an Array or primitive.
     if (typeof defult === "object") {
-        return mergeDeepCull(mergeDeepCull(defult, user), site)
+        return removeNull(mergeDeep(mergeDeep(defult, user), site))
     } else {
         if (site !== undefined) {
-            return site
+            return removeNull(site)
         } else if (user !== undefined) {
-            return user
+            return removeNull(user)
         } else {
-            return defult
+            return removeNull(defult)
         }
     }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2035,6 +2035,8 @@ export function get(target_typed?: keyof default_config, ...target: string[]) {
     // Merge results if there's a default value and it's not an Array or primitive.
     if (typeof defult === "object") {
         return removeNull(mergeDeep(mergeDeep(defult, user), site))
+    } else if (defult === undefined && user && typeof user === "object") {
+        return removeNull(mergeDeep(user, site))
     } else {
         if (site !== undefined) {
             return removeNull(site)


### PR DESCRIPTION
The mergeDeepCull set a unbind key (null) to undefined. In get and getURL, there are multiple merge operations, and undefined is ignored in the following merge.

We still need to remove null because null cause problem in keymap. In most situation, we access the config with `tri.config.get` method, so remove removeNull at return statement in get method is enough.