### PR TITLE
Fix display dpi-dependent scroll jitter

### DIFF
--- a/src/content/scrolling.ts
+++ b/src/content/scrolling.ts
@@ -80,15 +80,17 @@ class ScrollingData {
             this.startPos +
             ((this.endPos - this.startPos) * elapsed) / this.duration
         if (this.startPos < this.endPos) {
+            const curPosRounded = Math.ceil(this.elem[this.scrollDirection])
             // We need to ceil() because only highdpi screens have a decimal this.elem[this.pos]
             pixelToScrollTo = Math.ceil(pixelToScrollTo)
             // We *have* to make progress, otherwise we'll think the element can't be scrolled
-            if (pixelToScrollTo == Math.ceil(this.elem[this.scrollDirection]))
-                pixelToScrollTo += 1
+            if (pixelToScrollTo <= curPosRounded)
+                pixelToScrollTo = curPosRounded + 1
         } else {
+            const curPosRounded = Math.floor(this.elem[this.scrollDirection])
             pixelToScrollTo = Math.floor(pixelToScrollTo)
-            if (pixelToScrollTo == Math.floor(this.elem[this.scrollDirection]))
-                pixelToScrollTo -= 1
+            if (pixelToScrollTo >= curPosRounded)
+                pixelToScrollTo = curPosRounded - 1
         }
         return pixelToScrollTo
     }
@@ -96,7 +98,11 @@ class ScrollingData {
     /** Updates the position of this.elem, returns true if the element has been scrolled, false otherwise. */
     private scrollStep(): boolean {
         const prevScrollPos: number = this.elem[this.scrollDirection]
-        this.elem[this.scrollDirection] = this.getStep()
+        const target = this.getStep()
+        this.elem[this.scrollDirection] = target
+        // Ensure endPos value is possible for display dpi
+        if (target === this.endPos)
+            this.endPos = this.elem[this.scrollDirection]
         return prevScrollPos !== this.elem[this.scrollDirection]
     }
 


### PR DESCRIPTION
This addresses #5266

Actual values that can be set for `Element.scrollTop` / `scrollLeft` can change depending on display scaling.

For instance, if I set my display scale to 125% and then run this repeatedly on this page

```
document.scrollingElement.scrollTop = 210
document.scrollingElement.scrollTop
```

the actual value of `document.scrollingElement.scrollTop` alternates between `209.600...` and `210.399...`

Because the value does change, when scrolling with Tridactyl, `scrollStep` always returns `true` and steps are infinitely scheduled, bouncing between the two possible values around the unreachable one.

This pull request adds a check in `scrollStep` to see if we try to scroll to `endPos` and if so, sets `endPos` to the actual value, so that on the next `scrollStep` that definitely reachable value will be the target and it can return `false`.

I also altered the checks in `getStep` which make sure progress is made as I found that smooth scrolling could stop early due to `pixelToScrollTo` accidentally ending up in the wrong direction through unfortunate rounding.