### PR TITLE
fix(styling): restore theme injection broken by Firefox 149

### DIFF
--- a/src/content/styling.ts
+++ b/src/content/styling.ts
@@ -23,14 +23,14 @@ const THEMED_ELEMENTS = []
 
 let insertedHintElemCSS = false
 const hintElemCss = {
-    allFrames: true,
+    frameId: 0,
     matchAboutBlank: true,
     code: "",
 }
 
 let insertedCSS = false
 const customCss = {
-    allFrames: true,
+    frameId: 0,
     matchAboutBlank: true,
     code: "",
 }


### PR DESCRIPTION
## Problem

Firefox 149 removed `tabs.insertCSS/removeCSS` into `moz-extension:` documents ([bug 2015559](https://bugzilla.mozilla.org/show_bug.cgi?id=2015559)) and the [removal is now enforced in Firefox 152](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/152#changes_for_add-on_developers). This change broke theme injection.

With `allFrames: true`, `tabs.insertCSS` injected into all frames including the commandline iframe (a `moz-extension:` page), causing the call to fail in Firefox 152.

## Fix

- Replace `allFrames:true` with `frameId:0` so `tabs.insertCSS` only targets the main web page frame

## Testing

1. Set a non-default theme: `:colourscheme tokyonight`
2. Open the command line (`:`), should show tokyonight colours
3. Check the mode indicator in the bottom-right, should show tokyonight colours
4. Enter `:help`, the tridactyl help pages, should show tokyonight colours
5. Press `f` and check hints, should show tokyonight colours too
6. Repeat with `:colourscheme dark` and `:colourscheme auto` and the rest of the colourschemes