### PR TITLE
Allow `keyfeed` keybinds

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -129,6 +129,9 @@ Messaging.addListener("stop_buffering_page_keys", (message, sender, sendResponse
     bufferedPageKeys = []
 })
 
+let keysToFeed: KeyEventLike[] = []
+let generatorIsWaiting = true
+
 /** Accepts keyevents, resolves them to maps, maps to exstrs, executes exstrs */
 function* ParserController() {
     const parsers: {
@@ -150,7 +153,9 @@ function* ParserController() {
         let keyEvents: MinimalKey[] = []
         try {
             while (true) {
-                const keyevent: KeyEventLike = yield
+                generatorIsWaiting = true
+                const keyevent: KeyEventLike = keysToFeed.length ? keysToFeed.shift() : yield
+                generatorIsWaiting = false
                 let shadowRoot = null
                 let textEditable = false
 
@@ -252,6 +257,16 @@ function* ParserController() {
 
 export const generator = ParserController() // var rather than let stops weirdness in repl.
 generator.next()
+
+export function keyMuncher(...keys: KeyEventLike[]) {
+    if (keys.length === 0) return
+    if (generatorIsWaiting) {
+        keysToFeed = keysToFeed.concat(keys)
+        generator.next(keysToFeed.shift())
+    } else {
+        keysToFeed = keysToFeed.concat(keys)
+    }
+}
 
 /** Feed keys to the ParserController, unless they should be buffered to be later fed to clInput */
 export function acceptKey(keyevent: KeyboardEvent) {

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -113,7 +113,7 @@ let ALL_EXCMDS
 import * as controller from "@src/lib/controller"
 
 //#content_helper
-import { generator as KEY_MUNCHER } from "@src/content/controller_content"
+import { keyMuncher as KEY_MUNCHER } from "@src/content/controller_content"
 
 /**
  * Used to store the types of the parameters for each excmd for
@@ -6270,7 +6270,7 @@ export async function keyfeed(...args: string[]) {
     }
 
     for (const k of keyseq) {
-        usePage ? spoofKey(k) : KEY_MUNCHER.next(k)
+        usePage ? spoofKey(k) : KEY_MUNCHER(k)
         await sleep(10)
     }
 }


### PR DESCRIPTION
Issue: #5403

When bound, `:keyfeed` would call `generator.next()` before the generator had yielded.

This PR separates out keys fed from `:keyfeed` and makes sure to only call `generator.next()` once the generator is ready.