### PR TITLE
Let insert mode work for input elements in closed shadow DOMs

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -27,7 +27,7 @@ import {
 import { CmdlineCmds } from "@src/content/commandline_cmds"
 import { EditorCmds } from "@src/content/editor"
 
-import { getAllDocumentFrames } from "@src/lib/dom"
+import { getAllDocumentFrames, activeElement } from "@src/lib/dom"
 
 import state from "@src/state"
 import { EditorCmds as editor } from "@src/content/editor"
@@ -362,7 +362,7 @@ config.getAsync("modeindicator").then(mode => {
         }
 
         if (
-            dom.isTextEditable(document.activeElement) &&
+            dom.isTextEditable(activeElement()) &&
             !["input", "ignore"].includes(mode)
         ) {
             result = "insert"
@@ -371,7 +371,7 @@ config.getAsync("modeindicator").then(mode => {
             // need to fix loss of focus by click: doesn't do anything here.
         } else if (
             mode === "insert" &&
-            !dom.isTextEditable(document.activeElement)
+            !dom.isTextEditable(activeElement())
         ) {
             result = "normal"
             // statusIndicator.style.borderColor = "lightgray !important"

--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -1,4 +1,4 @@
-import { isTextEditable } from "@src/lib/dom"
+import { isTextEditable, activeElement } from "@src/lib/dom"
 import { contentState, ModeName } from "@src/content/state_content"
 import Logger from "@src/lib/logging"
 import * as controller from "@src/lib/controller"
@@ -8,7 +8,6 @@ import {
     minimalKeyFromKeyboardEvent,
     MinimalKey,
 } from "@src/lib/keyseq"
-import { deepestShadowRoot } from "@src/lib/dom"
 
 import * as hinting from "@src/content/hinting"
 import * as gobblemode from "@src/parsers/gobblemode"
@@ -156,18 +155,12 @@ function* ParserController() {
                 generatorIsWaiting = true
                 const keyevent: KeyEventLike = keysToFeed.length ? keysToFeed.shift() : yield
                 generatorIsWaiting = false
-                let shadowRoot = null
                 let textEditable = false
 
                 if (keyevent instanceof KeyboardEvent) {
-                    shadowRoot = deepestShadowRoot(
-                        (keyevent.target as Element).shadowRoot,
-                    )
+                    const deepTarget = activeElement(keyevent.target as HTMLElement) || keyevent.target as HTMLElement
+                    textEditable = isTextEditable(deepTarget)
 
-                    textEditable =
-                        shadowRoot === null
-                            ? isTextEditable(keyevent.target as Element)
-                            : isTextEditable(shadowRoot.activeElement)
                     // Accumulate key events. The parser will cut this
                     // down whenever it's not a valid prefix of a known
                     // binding, so it can't grow indefinitely unless you

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -1365,7 +1365,7 @@ window.addEventListener("HistoryState", addTabHistory)
 /** Blur (unfocus) the active element and enter normal mode */
 //#content
 export function unfocus() {
-    ;((document.activeElement.shadowRoot ? DOM.deepestShadowRoot(document.activeElement.shadowRoot) : document).activeElement as HTMLInputElement).blur()
+    ((DOM.activeElement() || document.activeElement) as HTMLInputElement)?.blur()
     contentState.mode = "normal"
 }
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -343,7 +343,7 @@ function getShadowElementsBySelector(selector: string) {
         const root = roots.pop() as ShadowRoot
         root.querySelectorAll("*").forEach(elem => {
             if ((elem as HTMLElement).openOrClosedShadowRoot) {
-                roots.push(elem.openOrClosedShadowRoot)
+                roots.push((elem as HTMLElement).openOrClosedShadowRoot)
                 try {
                     elems = elems.concat(
                         ...roots[roots.length - 1].querySelectorAll(selector),

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -340,13 +340,15 @@ function getShadowElementsBySelector(selector: string) {
     const roots: (Document | ShadowRoot)[] = [document]
 
     while (roots.length) {
-        const root = roots.pop()
+        const root = roots.pop() as ShadowRoot
         root.querySelectorAll("*").forEach(elem => {
-            if ((elem as any).openOrClosedShadowRoot) {
-                roots.push((elem as any).openOrClosedShadowRoot)
-                elems = elems.concat(
-                    ...roots[roots.length - 1].querySelectorAll(selector),
-                )
+            if ((elem as HTMLElement).openOrClosedShadowRoot) {
+                roots.push(elem.openOrClosedShadowRoot)
+                try {
+                    elems = elems.concat(
+                        ...roots[roots.length - 1].querySelectorAll(selector),
+                    )
+                } catch {}
             }
         })
     }
@@ -550,9 +552,11 @@ export function getLastUsedInput(): HTMLElement {
  *  https://bugzilla.mozilla.org/show_bug.cgi?id=1406825
  * */
 function onPageFocus(elem: HTMLElement): boolean {
-    elem = elem.shadowRoot
-        ? (elem.shadowRoot.activeElement as HTMLElement)
-        : elem
+    try {
+        elem = elem.openOrClosedShadowRoot
+            ? elem.openOrClosedShadowRoot.activeElement as HTMLElement
+            : elem
+    } catch {}
     if (isTextEditable(elem) && isSubstantial(elem)) {
         LAST_USED_INPUT = elem
     }
@@ -602,7 +606,7 @@ export function setupFocusHandler(): void {
     }
     const handler = e => {
         let elem = e.target as HTMLElement
-        const r = elem.shadowRoot
+        const r = elem.openOrClosedShadowRoot
         if (!r) {
             setFocus(elem)
             return
@@ -611,9 +615,15 @@ export function setupFocusHandler(): void {
             // r[handler] will handle it
             return
         }
-        while (elem.shadowRoot) {
-            listen(elem.shadowRoot)
-            elem = elem.shadowRoot.activeElement as HTMLElement
+        while (elem.openOrClosedShadowRoot) {
+            try {
+                listen(elem.openOrClosedShadowRoot)
+                elem = elem.openOrClosedShadowRoot.activeElement as HTMLElement
+            } catch {
+                // Inaccessible closed shadow
+                knownRoot.add(r)
+                break
+            }
             if (!elem) return
         }
         setFocus(elem)
@@ -778,10 +788,39 @@ export function simulateClick(
 export function deepestShadowRoot(sr: ShadowRoot | null): ShadowRoot | null {
     if (sr === null) return sr
     let shadowRoot = sr
-    while (shadowRoot.activeElement?.shadowRoot != null) {
-        shadowRoot = shadowRoot.activeElement.shadowRoot
+    while ((shadowRoot.activeElement as HTMLElement)?.openOrClosedShadowRoot != null) {
+        try {
+            shadowRoot = (shadowRoot.activeElement as HTMLElement).openOrClosedShadowRoot
+        } catch {
+            // Restricted shadow, may not be able to access its properties
+            break
+        }
     }
     return shadowRoot
+}
+
+/** Return the active element, within shadow DOMs or iframes if necessary. */
+export function activeElement(elem = document.activeElement) {
+    while (elem !== null) {
+        while ((elem as HTMLElement).openOrClosedShadowRoot !== null) {
+            try {
+                elem = (elem as HTMLElement).openOrClosedShadowRoot.activeElement
+            } catch {
+                // Restricted shadow root, can't access activeElement property
+                return elem
+            }
+            if (!elem) return null
+        }
+        if (elem.tagName !== "IFRAME") return elem
+        // Search within iframes if they're accessible
+        try {
+            const iframeActiveElem = (elem as HTMLIFrameElement).contentDocument.activeElement
+            if (!iframeActiveElem) return elem
+            elem = iframeActiveElem
+        } catch (e) {
+            return elem
+        }
+    }
 }
 
 export function getElementCentre(el) {

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -56,16 +56,16 @@ interface HTMLElement {
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
     inert: boolean
 
+    // Firefox-only (?) Element attribute
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot
+    openOrClosedShadowRoot: ShadowRoot | null
+
     // Let's be future proof:
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
     focus(options?: any): void
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren
     replaceChildren(...nodes: Node[]): void
-
-    // Firefox-only (?) Element attribute
-    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot
-    openOrClosedShadowRoot: ShadowRoot | null
 }
 
 /* eslint-disable @typescript-eslint/ban-types */

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -62,6 +62,10 @@ interface HTMLElement {
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren
     replaceChildren(...nodes: Node[]): void
+
+    // Firefox-only (?) Element attribute
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot
+    openOrClosedShadowRoot: ShadowRoot | null
 }
 
 /* eslint-disable @typescript-eslint/ban-types */


### PR DESCRIPTION
Related issue: #5411, where Tridactyl won't enter insert mode when an input element is in a closed shadow DOM.

`openOrClosedShadowRoot` over `shadowRoot` lets us get into closed shadow roots.

This PR replaces all (I believe) uses of `shadowRoot` with `openOrClosedShadowRoot`.

It also adds an `activeElement` function in `dom.ts` which can be used over `document.activeElement` and will work for active elements in shadow DOMs (or iframes), mainly so the mode indicator can correctly update.

I have previously run into a situation where a closed shadow DOM was restricted. If I remember correctly, the only time I've seen that is when using `:reader`, so in a `moz-extension://` url.

Due to that, I've wrapped anything that tries to access a shadow root's property in a `try ... catch` that should stop that causing trouble.