### PR TITLE
prevent insubstantial LAST_USED_INPUT on page focus

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -553,7 +553,7 @@ function onPageFocus(elem: HTMLElement): boolean {
     elem = elem.shadowRoot
         ? (elem.shadowRoot.activeElement as HTMLElement)
         : elem
-    if (isTextEditable(elem)) {
+    if (isTextEditable(elem) && isSubstantial(elem)) {
         LAST_USED_INPUT = elem
     }
     const setting =


### PR DESCRIPTION
The `:focusinput` excmd ignores insubstantial elements, but the page focus listener does not. This means that it's possible for an unusable input to be set as `LAST_USED_INPUT` which `:focusinput` will try and fail to focus.

Described in #5174 and potentially #5410 (an input is hidden in google's AI overview section)

This PR just adds the same `isSubstantial` check that `:focusinput` uses to the page focus listener to avoid that situation.