### PR TITLE
Fix storage races

### DIFF
--- a/browser-targets.json
+++ b/browser-targets.json
@@ -1,6 +1,6 @@
 {
     "firefox": {
-        "minimumVersion": "91.1.0",
+        "minimumVersion": "94.0",
         "manifestVersionPath": [
             "applications",
             "gecko",

--- a/src/background.ts
+++ b/src/background.ts
@@ -234,6 +234,7 @@ const messages = {
     config_background: {
         clear: config.clear,
         pull: config.pull,
+        push: config.push,
         set: config.set,
         unset: config.unset,
     },

--- a/src/background.ts
+++ b/src/background.ts
@@ -231,6 +231,12 @@ browser.tabs.onCreated.addListener(aucon.tabCreatedListener)
 // An object to collect all of our statistics in one place.
 const statsLogger: perf.StatsLogger = new perf.StatsLogger()
 const messages = {
+    config_background: {
+        clear: config.clear,
+        pull: config.pull,
+        set: config.set,
+        unset: config.unset,
+    },
     excmd_background: excmds_background,
     controller_background: controller,
     performance_background: statsLogger,

--- a/src/background/config_rc.ts
+++ b/src/background/config_rc.ts
@@ -53,7 +53,6 @@ export async function writeRc(conf: string, force = false, filename = "auto") {
 
 export async function runRc(rc: string) {
     for (const cmd of rcFileToExCmds(rc)) {
-        await new Promise(resolve => setTimeout(resolve, 100))
         await controller.acceptExCmd(cmd)
     }
 }

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -855,8 +855,6 @@ export async function mktridactylrc(...args: string[]) {
  *
  * The RC file is just a bunch of Tridactyl excmds (i.e, the stuff on this help page). Settings persist in local storage. There's an [example file](https://raw.githubusercontent.com/tridactyl/tridactyl/master/.tridactylrc) if you want it.
  *
- * There is a [bug](https://github.com/tridactyl/tridactyl/issues/1409) where not all lines of the RC file are executed if you use `sanitise` at the top of it. We instead recommend you put `:bind ZZ composite sanitise tridactyllocal; qall` in your RC file and use `ZZ` to exit Firefox.
- *
  * @param args the file/URL to open. For files: must be an absolute path, but can contain environment variables and things like ~.
  */
 //#background

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5118,7 +5118,7 @@ export async function sanitise(...args: string[]) {
     // Tridactyl-specific items
     if (dts.commandline === true) state.cmdHistory = []
     delete dts.commandline
-    if (dts.tridactyllocal === true) await browser.storage.local.clear()
+    if (dts.tridactyllocal === true) await config.clear()
     delete dts.tridactyllocal
     if (dts.tridactylsync === true) await browser.storage.sync.clear()
     delete dts.tridactylsync

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,6 +37,7 @@ const removeNull = R.when(
 
 /** @hidden */
 const CONFIGNAME = "userconfig"
+const CONFIG_WRITE = "userconfig-write"
 const BACKGROUND_URL = browser.runtime.getURL("_generated_background_page.html")
 const IN_BACKGROUND = !BACKGROUND_URL || BACKGROUND_URL === window.location.href
 /** @hidden */
@@ -59,10 +60,24 @@ function schlepp(settings) {
 /** @hidden */
 export let USERCONFIG = o({})
 let STORE_QUEUE = Promise.resolve()
+let EXCLUSIVE_QUEUE = Promise.resolve()
+let EXCLUSIVE_PENDING = 0
+let WRITE_ID = 0
+const WRITE_SESSION = `${Date.now()}-${Math.random()}:`
+const PENDING_WRITES = new Set<string>()
 
-function store(operation: () => Promise<void>) {
+function store<T>(operation: () => Promise<T>) {
     const pending = STORE_QUEUE.then(operation)
     STORE_QUEUE = pending.catch(() => undefined)
+    return pending
+}
+
+function exclusively<T>(operation: () => Promise<T>) {
+    EXCLUSIVE_PENDING++
+    const pending = EXCLUSIVE_QUEUE.then(operation)
+    EXCLUSIVE_QUEUE = pending.catch(() => undefined).then(() => {
+        EXCLUSIVE_PENDING--
+    })
     return pending
 }
 
@@ -2114,10 +2129,13 @@ export async function getAsync(
  * Does not synchronise custom themes due to storage constraints.
  */
 export async function push() {
-    const local_conf = await browser.storage.local.get(CONFIGNAME)
-    // eslint-disable-next-line @typescript-eslint/dot-notation
-    delete local_conf[CONFIGNAME]["customthemes"]
-    return browser.storage.sync.set(local_conf)
+    if (!IN_BACKGROUND) return mutateInBackground("push", [])
+    return exclusively(async () => {
+        if (!INITIALISED) await getAsync()
+        const userconfig = structuredClone(USERCONFIG)
+        delete userconfig["customthemes"]
+        return browser.storage.sync.set({ [CONFIGNAME]: userconfig })
+    })
 }
 
 /*
@@ -2125,10 +2143,12 @@ export async function push() {
  */
 export async function pull() {
     if (!IN_BACKGROUND) return mutateInBackground("pull", [])
-    if (!INITIALISED) await getAsync()
-    const synced = await browser.storage.sync.get(CONFIGNAME)
-    USERCONFIG = synced[CONFIGNAME] || o({})
-    return save()
+    return exclusively(async () => {
+        if (!INITIALISED) await getAsync()
+        const synced = await browser.storage.sync.get(CONFIGNAME)
+        USERCONFIG = synced[CONFIGNAME] || o({})
+        return save()
+    })
 }
 
 /** @hidden
@@ -2166,6 +2186,7 @@ export async function set(...args) {
         return mutateInBackground("set", args)
     }
 
+    if (EXCLUSIVE_PENDING) await EXCLUSIVE_QUEUE
     if (!INITIALISED) await getAsync()
     setDeepProperty(USERCONFIG, value, target)
     return save()
@@ -2181,6 +2202,7 @@ export function unsetURL(pattern, ...target) {
 /** Delete the key at target in USERCONFIG if it exists
  * @hidden */
 export async function unset(...target) {
+    if (IN_BACKGROUND && EXCLUSIVE_PENDING) await EXCLUSIVE_QUEUE
     if (IN_BACKGROUND && !INITIALISED) await getAsync()
     const parent = getDeepProperty(USERCONFIG, target.slice(0, -1))
     if (parent !== undefined) delete parent[target[target.length - 1]]
@@ -2193,9 +2215,12 @@ export async function clear() {
         USERCONFIG = o({})
         return mutateInBackground("clear", [])
     }
+    if (EXCLUSIVE_PENDING) await EXCLUSIVE_QUEUE
     if (!INITIALISED) await getAsync()
+    const old = USERCONFIG
     USERCONFIG = o({})
-    return store(() => browser.storage.local.clear())
+    await store(() => browser.storage.local.clear())
+    notifyChangeListeners(old, USERCONFIG)
 }
 
 /** Save the config back to storage API.
@@ -2208,7 +2233,16 @@ export async function clear() {
 export async function save() {
     const settingsobj = o({})
     settingsobj[CONFIGNAME] = structuredClone(USERCONFIG)
-    return store(() => browser.storage.local.set(settingsobj))
+    if (IN_BACKGROUND) {
+        settingsobj[CONFIG_WRITE] = WRITE_SESSION + ++WRITE_ID
+        PENDING_WRITES.add(settingsobj[CONFIG_WRITE])
+    }
+    return store(() =>
+        browser.storage.local.set(settingsobj).catch(error => {
+            PENDING_WRITES.delete(settingsobj[CONFIG_WRITE])
+            throw error
+        }),
+    )
 }
 
 /** Updates the config to the latest version.
@@ -2459,6 +2493,15 @@ async function init() {
 /** @hidden */
 const changeListeners = new Map()
 
+function notifyChangeListeners(oldConfig, newConfig) {
+    changeListeners.forEach((listeners, key) => {
+        const old = oldConfig[key] === undefined ? DEFAULTS[key] : oldConfig[key]
+        const next = newConfig[key] === undefined ? DEFAULTS[key] : newConfig[key]
+        if (JSON.stringify(old) !== JSON.stringify(next))
+            listeners.forEach(f => f(old, next))
+    })
+}
+
 /** @hidden
  * @param name The name of a "toplevel" config setting (i.e. "nmaps", not "nmaps.j")
  * @param listener A function to call when the value of $name is modified in the config. Takes the previous and new value as parameters.
@@ -2620,18 +2663,29 @@ const parseConfigHelper = (pconf, parseobj, prefix = []) => {
 // Listen for changes to the storage and update the USERCONFIG if appropriate.
 // TODO: BUG! Sync and local storage are merged at startup, but not by this thing.
 browser.storage.onChanged.addListener((changes, areaname) => {
-    if (IN_BACKGROUND) return
+    if (IN_BACKGROUND) {
+        if (areaname !== "local") return
+        const write = changes[CONFIG_WRITE]?.newValue
+        if (PENDING_WRITES.delete(write)) {
+            const { newValue = {}, oldValue = {} } = changes[CONFIGNAME] || {}
+            notifyChangeListeners(oldValue, newValue)
+            return
+        }
+        if (CONFIGNAME in changes) {
+            exclusively(async () => {
+                await STORE_QUEUE
+                if (!INITIALISED) await getAsync()
+                const old = USERCONFIG
+                const stored = await browser.storage.local.get(CONFIGNAME)
+                USERCONFIG = stored[CONFIGNAME] || o({})
+                notifyChangeListeners(old, USERCONFIG)
+            }).catch(console.error)
+        }
+        return
+    }
     if (CONFIGNAME in changes) {
         const { newValue, oldValue } = changes[CONFIGNAME]
         const old = oldValue || {}
-
-        function triggerChangeListeners(key, value = newValue[key]) {
-            const arr = changeListeners.get(key)
-            if (arr) {
-                const v = old[key] === undefined ? DEFAULTS[key] : old[key]
-                arr.forEach(f => f(v, value))
-            }
-        }
 
         if (areaname === "sync") {
             // Probably do something here with push/pull?
@@ -2654,19 +2708,12 @@ browser.storage.onChanged.addListener((changes, areaname) => {
             // TODO: this should be a deep comparison but this is better than nothing
             changedKeys.forEach(key => (USERCONFIG[key] = newValue[key]))
             unsetKeys.forEach(key => delete USERCONFIG[key])
-
-            // Trigger listeners
-            unsetKeys.forEach(key => triggerChangeListeners(key, DEFAULTS[key]))
-
-            changedKeys.forEach(key => triggerChangeListeners(key))
+            notifyChangeListeners(old, newValue)
         } else {
             // newValue is undefined when calling browser.storage.AREANAME.clear()
             // If newValue is undefined and AREANAME is the same value as STORAGELOC, the user wants to clean their config
             USERCONFIG = o({})
-
-            Object.keys(old)
-                .filter(key => old[key] !== DEFAULTS[key])
-                .forEach(key => triggerChangeListeners(key, DEFAULTS[key]))
+            notifyChangeListeners(old, USERCONFIG)
         }
     }
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -35,6 +35,8 @@ const removeNull = R.when(
 
 /** @hidden */
 const CONFIGNAME = "userconfig"
+const BACKGROUND_URL = browser.runtime.getURL("_generated_background_page.html")
+const IN_BACKGROUND = !BACKGROUND_URL || BACKGROUND_URL === window.location.href
 /** @hidden */
 const WAITERS = []
 /** @hidden */
@@ -54,6 +56,17 @@ function schlepp(settings) {
 
 /** @hidden */
 export let USERCONFIG = o({})
+let STORE_QUEUE = Promise.resolve()
+
+function store(operation: () => Promise<void>) {
+    const pending = STORE_QUEUE.then(operation)
+    STORE_QUEUE = pending.catch(() => undefined)
+    return pending
+}
+
+function mutateInBackground(command, args) {
+    return browser.runtime.sendMessage({ type: "config_background", command, args })
+}
 
 /** @hidden
  * Ideally, LoggingLevel should be in logging.ts and imported from there. However this would cause a circular dependency, which webpack can't deal with
@@ -2080,6 +2093,7 @@ export async function getAsync(
     ...target: string[]
 ) {
     if (INITIALISED) {
+        if (IN_BACKGROUND) return get(target_typed, ...target)
         // TODO: consider storing keys directly
         const browserconfig = await browser.storage.local.get(CONFIGNAME)
         USERCONFIG = browserconfig[CONFIGNAME] || o({})
@@ -2108,7 +2122,11 @@ export async function push() {
  * Replaces the local configuration with the configuration from your sync storage. Does not merge: it overwrites.
  */
 export async function pull() {
-    return browser.storage.local.set(await browser.storage.sync.get(CONFIGNAME))
+    if (!IN_BACKGROUND) return mutateInBackground("pull", [])
+    if (!INITIALISED) await getAsync()
+    const synced = await browser.storage.sync.get(CONFIGNAME)
+    USERCONFIG = synced[CONFIGNAME] || o({})
+    return save()
 }
 
 /** @hidden
@@ -2141,14 +2159,14 @@ export async function set(...args) {
     const target = args.slice(0, args.length - 1)
     const value = args[args.length - 1]
 
-    if (INITIALISED) {
-        // wait for storage to settle, otherwise we could clobber a previous incomplete set()
+    if (!IN_BACKGROUND) {
         setDeepProperty(USERCONFIG, value, target)
-
-        return save()
-    } else {
-        setDeepProperty(USERCONFIG, value, target)
+        return mutateInBackground("set", args)
     }
+
+    if (!INITIALISED) await getAsync()
+    setDeepProperty(USERCONFIG, value, target)
+    return save()
 }
 
 /** @hidden
@@ -2160,10 +2178,22 @@ export function unsetURL(pattern, ...target) {
 
 /** Delete the key at target in USERCONFIG if it exists
  * @hidden */
-export function unset(...target) {
+export async function unset(...target) {
+    if (IN_BACKGROUND && !INITIALISED) await getAsync()
     const parent = getDeepProperty(USERCONFIG, target.slice(0, -1))
     if (parent !== undefined) delete parent[target[target.length - 1]]
+    if (!IN_BACKGROUND) return mutateInBackground("unset", target)
     return save()
+}
+
+export async function clear() {
+    if (!IN_BACKGROUND) {
+        USERCONFIG = o({})
+        return mutateInBackground("clear", [])
+    }
+    if (!INITIALISED) await getAsync()
+    USERCONFIG = o({})
+    return store(() => browser.storage.local.clear())
 }
 
 /** Save the config back to storage API.
@@ -2175,8 +2205,8 @@ export function unset(...target) {
  */
 export async function save() {
     const settingsobj = o({})
-    settingsobj[CONFIGNAME] = USERCONFIG
-    return browser.storage.local.set(settingsobj)
+    settingsobj[CONFIGNAME] = JSON.parse(JSON.stringify(USERCONFIG))
+    return store(() => browser.storage.local.set(settingsobj))
 }
 
 /** Updates the config to the latest version.
@@ -2588,6 +2618,7 @@ const parseConfigHelper = (pconf, parseobj, prefix = []) => {
 // Listen for changes to the storage and update the USERCONFIG if appropriate.
 // TODO: BUG! Sync and local storage are merged at startup, but not by this thing.
 browser.storage.onChanged.addListener((changes, areaname) => {
+    if (IN_BACKGROUND) return
     if (CONFIGNAME in changes) {
         const { newValue, oldValue } = changes[CONFIGNAME]
         const old = oldValue || {}
@@ -2633,7 +2664,7 @@ browser.storage.onChanged.addListener((changes, areaname) => {
 
             Object.keys(old)
                 .filter(key => old[key] !== DEFAULTS[key])
-                .forEach(key => triggerChangeListeners(key))
+                .forEach(key => triggerChangeListeners(key, DEFAULTS[key]))
         }
     }
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -21,6 +21,8 @@ import * as binding from "@src/lib/binding"
 import * as platform from "@src/lib/platform"
 import { DeepPartial } from "tsdef"
 
+declare function structuredClone<T>(value: T): T // delete me once we move off typescript 3
+
 /* Remove all nulls from objects recursively
  * NB: also applies to arrays
  */
@@ -2205,7 +2207,7 @@ export async function clear() {
  */
 export async function save() {
     const settingsobj = o({})
-    settingsobj[CONFIGNAME] = JSON.parse(JSON.stringify(USERCONFIG))
+    settingsobj[CONFIGNAME] = structuredClone(USERCONFIG)
     return store(() => browser.storage.local.set(settingsobj))
 }
 


### PR DESCRIPTION
My thesis here is that #1409 is caused thusly:

```
# write to storage to update some key (1)
# write to storage to update some other key (2)
# storage listener fires and config gets updated to (1)
# write to storage to update some other key (3)
# runtime config is now (1,3) without (2)
```

and so we can fix it by binning our firefox storage listeners.

to do that we:

1) make the background config object our single source of truth, not the firefox storage
2) add a queue to make sure storage gets written in the order we expect
3) rewrite firefoxsyncpush/pull to no longer rely on the storage change listener

then the storage listener is only used for updating content scripts, where order doesn't matter as much because we're not setting the entire state every time they request a small change.

i _think_ the only breaking change is that user scripts that directly use `storage.set` rather than `config.set` might see some odd behaviour