### PR TITLE
Use `IntersectionObserver` to check element visibility

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1223,14 +1223,16 @@ function pushSpace() {
 
     @hidden
 */
-export function hintables(
+export async function hintables(
     selectors = DOM.HINTTAGS_selectors,
     withjs = false,
     includeInvisible = false,
 ) {
     const visibleFilter = DOM.isVisibleFilter(includeInvisible)
     const elems = changeHintablesToLargestChild(
-        DOM.getElemsBySelector(selectors, []).filter(visibleFilter),
+        includeInvisible
+            ? DOM.getElemsBySelector(selectors, [])
+            : ((await DOM.getVisibleElemsBySelector(selectors)))
     )
     const hintables: Hintables[] = [{ elements: elems }]
     if (withjs) {

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -1228,7 +1228,11 @@ export async function hintables(
     withjs = false,
     includeInvisible = false,
 ) {
-    const visibleFilter = DOM.isVisibleFilter(includeInvisible)
+    if (withjs) DOM.pruneHintworthyJSElems()
+    const jsElems = withjs ? Array.from(DOM.hintworthy_js_elems) : []
+    const visibleJSElems = withjs && !includeInvisible
+        ? DOM.getVisibleElemsBySelector(null, [], jsElems)
+        : jsElems
     const elems = changeHintablesToLargestChild(
         includeInvisible
             ? DOM.getElemsBySelector(selectors, [])
@@ -1236,12 +1240,9 @@ export async function hintables(
     )
     const hintables: Hintables[] = [{ elements: elems }]
     if (withjs) {
-        DOM.pruneHintworthyJSElems()
         hintables.push({
             elements: changeHintablesToLargestChild(
-                Array.from(DOM.hintworthy_js_elems).filter(
-                    el => visibleFilter(el) && !elems.includes(el),
-                ),
+                (await visibleJSElems).filter(el => !elems.includes(el)),
             ),
             hintclasses: ["TridactylJSHint"],
         })

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5400,8 +5400,8 @@ export async function hint(...args: string[]): Promise<any> {
         }
     }
 
+    const hintables = await config.hintables()
     return new Promise(async (resolve, reject) => {
-        const hintables = await config.hintables()
 
         // If the user specified a callback, eval it, else use the default
         // action which performs the action matching the open mode

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5400,8 +5400,8 @@ export async function hint(...args: string[]): Promise<any> {
         }
     }
 
-    return new Promise((resolve, reject) => {
-        const hintables = config.hintables()
+    return new Promise(async (resolve, reject) => {
+        const hintables = await config.hintables()
 
         // If the user specified a callback, eval it, else use the default
         // action which performs the action matching the open mode

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -290,7 +290,7 @@ export function isVisible(thing: Element | Range) {
 
 /** More accurate element visibility checking than isVisible.
  */
-export async function getVisibleElemsBySelector(selector = "*", filters: ElementFilter[] = []): Promise<HTMLElement[]> {
+export async function getVisibleElemsBySelector(selector: string | null = "*", filters: ElementFilter[] = [], elements: Element[] = []): Promise<HTMLElement[]> {
     // Get frames with an accessible ItersectionObserver constructor (including top window)
     const frameWins = [window as any].concat(
         ...getAllDocumentFrames()
@@ -310,9 +310,11 @@ export async function getVisibleElemsBySelector(selector = "*", filters: Element
     // Create IntersectionObservers in all frames
     return Promise.all(
         frameWins.map(async win => {
-            const elems = Array.from(
-                win.document.querySelectorAll(selector),
-            ).concat(...getShadowElementsBySelector(selector, win.document))
+            const elems = selector
+                ? Array.from(
+                    win.document.querySelectorAll(selector),
+                ).concat(...getShadowElementsBySelector(selector, win.document))
+                : elements.filter(elem => elem.ownerDocument === win.document)
             if (elems.length === 0) {
                 return []
             }

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -288,6 +288,92 @@ export function isVisible(thing: Element | Range) {
     /* return true */
 }
 
+/** More accurate element visibility checking than isVisible.
+ */
+export async function getVisibleElemsBySelector(selector = "*", filters: ElementFilter[] = []) {
+    // Get frames with an accessible ItersectionObserver constructor (including top window)
+    const frameWins = [window as any].concat(
+        ...getAllDocumentFrames()
+            .filter(frame => {
+                try {
+                    return (
+                        (frame.contentWindow as Window & typeof globalThis).IntersectionObserver &&
+                        isVisible(frame)
+                    )
+                } catch (e) {
+                    return false
+                }
+            })
+            .map(frame => frame.contentWindow),
+    )
+
+    // Create IntersectionObservers in all frames
+    return Promise.all(
+        frameWins.map(async win => {
+            const elems = Array.from(
+                win.document.querySelectorAll(selector),
+            ).concat(...getShadowElementsBySelector(selector, win.document))
+            if (elems.length === 0) {
+                return []
+            }
+
+            // Entries won't be available immediately, wait for a promise
+            return new Promise(resolve => {
+                const visible: HTMLElement[] = []
+                let observer
+                let started = false
+                try {
+                    observer = new win.IntersectionObserver(
+                        entries => {
+                            started = true
+                            for (const entry of entries) {
+                                if (
+                                    entry.isIntersecting &&
+                                    entry.boundingClientRect.width > 3 &&
+                                    entry.boundingClientRect.height > 3
+                                ) {
+                                    visible.push(entry.target)
+                                }
+                            }
+                            observer.disconnect()
+
+                            resolve(visible)
+                        },
+                        { threshold: 0.01 },
+                    )
+                    elems.forEach(elem => observer.observe(elem))
+                } catch (e) {
+                    resolve([])
+                }
+
+                // Just in case the IntersectionObserver fails somehow (can this happen?)
+                setTimeout(() => {
+                    if (!started) {
+                        logger.error("IntersectionObserver failed to observe")
+                        observer.disconnect()
+                        resolve([])
+                    }
+                }, 500)
+            })
+        }),
+    ).then(intersectingElems =>
+        intersectingElems
+            .flat()
+            .filter(el => isPainted(el as HTMLElement) &&
+                filters.every(filter => filter(el as HTMLElement))
+            )
+    )
+}
+
+// Like isVisible with no rect checks
+// Useful to catch "visibility: hidden;" css rule which eludes the IntersectionObserver
+export function isPainted(elem: HTMLElement) {
+    const s = getComputedStyle(elem)
+    return (
+        s.visibility !== "hidden" && s.display !== "none" && s.opacity !== "0"
+    )
+}
+
 /** Return all frames that belong to the document (frames that belong to
  * extensions are ignored).
  *
@@ -335,9 +421,9 @@ export function getSelector(e: HTMLElement) {
 }
 
 /* Get all the elements that match the given selector inside shadow DOM */
-function getShadowElementsBySelector(selector: string) {
+function getShadowElementsBySelector(selector: string, within = document) {
     let elems = []
-    const roots: (Document | ShadowRoot)[] = [document]
+    const roots: (Document | ShadowRoot)[] = [within]
 
     while (roots.length) {
         const root = roots.pop() as ShadowRoot

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -290,7 +290,7 @@ export function isVisible(thing: Element | Range) {
 
 /** More accurate element visibility checking than isVisible.
  */
-export async function getVisibleElemsBySelector(selector = "*", filters: ElementFilter[] = []) {
+export async function getVisibleElemsBySelector(selector = "*", filters: ElementFilter[] = []): Promise<HTMLElement[]> {
     // Get frames with an accessible ItersectionObserver constructor (including top window)
     const frameWins = [window as any].concat(
         ...getAllDocumentFrames()
@@ -361,7 +361,7 @@ export async function getVisibleElemsBySelector(selector = "*", filters: Element
             .flat()
             .filter(el => isPainted(el as HTMLElement) &&
                 filters.every(filter => filter(el as HTMLElement))
-            )
+            ) as HTMLElement[]
     )
 }
 

--- a/src/lib/hint_util.ts
+++ b/src/lib/hint_util.ts
@@ -370,7 +370,7 @@ export class HintConfig implements HintOptions {
         }
     }
 
-    defaultHintables() {
+    async defaultHintables() {
         // Use the default selectors to find hintable elements
         switch (this.openMode) {
             case OpenMode.YankText:
@@ -423,14 +423,18 @@ export class HintConfig implements HintOptions {
         }
     }
 
-    public hintables() {
-        let hintables = this.includeDefaultHintables ? this.defaultHintables() : []
+    public async hintables() {
+        let hintables = this.includeDefaultHintables
+            ? await this.defaultHintables()
+            : []
         if (this.selectors.length > 0) {
-            hintables = hintables.concat(hinting.hintables(
-                this.selectors.join(" "),
-                this.jshints,
-                this.includeInvisible,
-            ))
+            hintables = hintables.concat(
+                await hinting.hintables(
+                    this.selectors.join(" "),
+                    this.jshints,
+                    this.includeInvisible,
+                ),
+            )
         }
         const textFilter = this.textFilter
         const exclude = this.selectorsExclude.join(" ")


### PR DESCRIPTION
Addresses issues #5350, #5372 where lots of unhelpful hints show up on some sites.

This adds a `getVisibleElemsBySelector` function to `dom.ts` which uses `IntersectionObserver`s to decide whether elements are visible.

The `IntersectionObserver` technique doesn't work for elements with a `visibility: hidden;` rule so there's also an `isPainted` function to filter such elements out.

The result is that some elements which would be considered visible are correctly ignored, making hinting much more usable on certain sites:

current:
<img width="572" height="245" alt="current" src="https://github.com/user-attachments/assets/0c0ed8de-36a0-4ac8-8dd3-34120ec726ac" />

intersection observer:
<img width="574" height="313" alt="intersection-observer" src="https://github.com/user-attachments/assets/4df92fd4-d944-43d4-b975-dfbb9233d31d" />

Intersection observers have no entries when first created so the function is async to resolve once it's populated. This means that to use it for hints, some other `async`s / `awaits` are sprinkled around.

Mostly that shouldn't be an issue, but it would break any user scripts which use `tri.hinting_content.hintables` which is now async.