### PR TITLE
Improve `fillcmdline` key buffering

### DIFF
--- a/src/content/controller_content.ts
+++ b/src/content/controller_content.ts
@@ -213,17 +213,6 @@ function* ParserController() {
 
                 if (response.exstr) {
                     exstr = response.exstr
-                    if (
-                        (exstr.startsWith("fillcmdline") || exstr.startsWith("current_url")) &&
-                        !exstr.startsWith("fillcmdline_tmp") &&
-                        !exstr.startsWith("fillcmdline_nofocus") &&
-                        config.get("noiframe") !== "true"
-                    ) {
-                        logger.debug("Starting buffering of page keys")
-                        bufferingPageKeysBeginTime = performance.now()
-                        mustBufferPageKeysForClInput = true
-                        bufferedPageKeys = []
-                    }
                     break
                 } else {
                     keyEvents = response.keys
@@ -250,6 +239,13 @@ function* ParserController() {
 
 export const generator = ParserController() // var rather than let stops weirdness in repl.
 generator.next()
+
+export function startBufferingPageKeys() {
+    logger.debug("Starting buffering of page keys")
+    bufferingPageKeysBeginTime = performance.now()
+    mustBufferPageKeysForClInput = true
+    bufferedPageKeys = []
+}
 
 export function keyMuncher(...keys: KeyEventLike[]) {
     if (keys.length === 0) return

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -4037,9 +4037,9 @@ export async function fillcmdline(...strarr: string[]) {
         throw new Error("fillcmdline --wait cannot be run from the commandline")
     }
     const str = strarr.join(" ")
+    startBufferingPageKeys()
     await showcmdline(false)
     logger.debug("excmds fillcmdline sending fillcmdline to commandline_frame")
-    startBufferingPageKeys()
     return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true /*trailspace*/, true /*focus*/, wait])
 }
 
@@ -4047,8 +4047,8 @@ export async function fillcmdline(...strarr: string[]) {
 //#content
 export async function fillcmdline_notrail(...strarr: string[]) {
     const str = strarr.join(" ")
-    await showcmdline(false)
     startBufferingPageKeys()
+    await showcmdline(false)
     return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false /*trailspace*/, true /*focus*/])
 }
 

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -113,7 +113,7 @@ let ALL_EXCMDS
 import * as controller from "@src/lib/controller"
 
 //#content_helper
-import { keyMuncher as KEY_MUNCHER } from "@src/content/controller_content"
+import { keyMuncher as KEY_MUNCHER, startBufferingPageKeys } from "@src/content/controller_content"
 
 /**
  * Used to store the types of the parameters for each excmd for
@@ -4024,7 +4024,7 @@ export function hidecmdline() {
     CommandLineContent.hide_and_blur()
 }
 
-/** 
+/**
 * Set the current value of the commandline to string *with* a trailing space.
 *
 * `fillcmdline --wait` will only return after the command line is closed. It can only be invoked in binds to avoid deadlock.
@@ -4039,6 +4039,7 @@ export async function fillcmdline(...strarr: string[]) {
     const str = strarr.join(" ")
     await showcmdline(false)
     logger.debug("excmds fillcmdline sending fillcmdline to commandline_frame")
+    startBufferingPageKeys()
     return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, true /*trailspace*/, true /*focus*/, wait])
 }
 
@@ -4047,6 +4048,7 @@ export async function fillcmdline(...strarr: string[]) {
 export async function fillcmdline_notrail(...strarr: string[]) {
     const str = strarr.join(" ")
     await showcmdline(false)
+    startBufferingPageKeys()
     return Messaging.messageOwnTab("commandline_frame", "fillcmdline", [str, false /*trailspace*/, true /*focus*/])
 }
 


### PR DESCRIPTION
I noticed that binding to a command beginning with `fillcmdline` causes keypresses to stop working due to the key buffering.

```
:bind e fillcmdline_uhoh
```

And since we only check for `exstr`s starting with `fillcmdline` to begin buffering keys, we miss any aliases for `fillcmdline` or `fillcmdline_notrail`, as well as `composite` commands including them.

This PR adds a `startBufferingPageKeys` function that can be called from the excmds themselves to avoid both of those cases.