### PR TITLE
Make implicit any error in sensitive parts of the code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -286,6 +286,9 @@ module.exports = {
             "files": ["src/content.ts", "src/commandline_frame.ts"],
             "rules": {
                 "@typescript-eslint/no-explicit-any": "error",
+                "@typescript-eslint/no-unsafe-assignment": "error",
+                "@typescript-eslint/no-unsafe-call": "error",
+                "@typescript-eslint/no-unsafe-argument": "error",
                 "@typescript-eslint/ban-types": [
                     "error",
                     {


### PR DESCRIPTION
addEventListener is easy to use with implicit any which circumvents all of the checks

this tries to stop that from happening, but it also makes loads of totally safe stuff
that uses any trigger the linter too, so that needs fixing, but i can't be bothered
right this second so let's shove it on the backlog

supersedes #5390
