### PR TITLE
Fix builds in worktrees

### DIFF
--- a/scripts/authors.sh
+++ b/scripts/authors.sh
@@ -12,7 +12,7 @@ authors="../../build/static/authors.html"
 sed "/REPLACETHIS/,$ d" authors.html > "$authors"
 
 # If we're in a git repo, refresh the cache
-if [ -d "../../.git/" ]; then
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     git shortlog -sn HEAD | cut -c8- | awk '!seen[$0]++' | sed 's/^/<p>/' | sed 's/$/<\/p>/' > ../../.build_cache/authors
 fi
 


### PR DESCRIPTION
authors.html assumed there would always be a .git
directory, which is not true in worktrees
