### PR TITLE
Fix #4076: do not use real URLs in history completions

### DIFF
--- a/src/completions/History.ts
+++ b/src/completions/History.ts
@@ -34,7 +34,7 @@ class HistoryCompletionOption
             <td class="title">${page.title}</td>
             <td class="content">
                 ${page.search ? "Search " : ""}
-                <a class="url" target="_blank" href=${page.url}>${Completions.decodeUrlForDisplay(page.url)}</a>
+                <span class="url">${Completions.decodeUrlForDisplay(page.url)}</span>
             </td>
         </tr>`
     }


### PR DESCRIPTION
Fix #4076 by swapping hrefs for spans in history completions

I don't know how I feel about this

Does anyone use the fact that the links are links to click on them or copy them easily?

If we do it, we should expand it to all URLs in the command line (e.g. :tab completions)
