### PR TITLE
Finding: favour StaticRanges

### DIFF
--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,37 +26,35 @@ function getFindHost() {
 
 const NATIVE_HIGHLIGHTS = typeof Highlight === "function" && "highlights" in CSS
 
-const createRangeProxy = (() => {
-    const sharedRange = document.createRange()
-
-    return function(rangeSpec: {
-        startContainer: Node,
-        startOffset: number,
-        endContainer: Node,
-        endOffset: number,
-    }): Range & { ["range"]: StaticRange } {
-        return new Proxy(new StaticRange(rangeSpec), {
-            get(target, prop) {
-                if (prop === "range") return target
-                if (prop !== "toString" && prop in target) return target[prop]
-                if (prop in sharedRange) {
-                    return (...args: any[]) => {
-                        sharedRange.setStart(target.startContainer, target.startOffset)
-                        sharedRange.setEnd(target.endContainer,target.endOffset)
-                        return (sharedRange as any)[prop](...args)
-                    }
-                }
-                return undefined
-            }
-        }) as Range & { ["range"]: StaticRange }
+class SharedRangeView extends StaticRange {
+    private static shared = document.createRange()
+    public toString() {
+        return this.moveSharedRange().toString()
     }
-})()
+    public cloneRange() {
+        return this.moveSharedRange().cloneRange()
+    }
+    public getBoundingClientRect() {
+        return this.moveSharedRange().getBoundingClientRect()
+    }
+    public getClientRects() {
+        return this.moveSharedRange().getClientRects()
+    }
+    get commonAncestorContainer() {
+        return this.moveSharedRange().commonAncestorContainer
+    }
+    private moveSharedRange() {
+        SharedRangeView.shared.setStart(this.startContainer, this.startOffset)
+        SharedRangeView.shared.setEnd(this.endContainer, this.endOffset)
+        return SharedRangeView.shared
+    }
+}
 
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
     private background = `var(--tridactyl-search-highlight-color)`
 
-    constructor(public range: Range) {
+    constructor(public range: SharedRangeView) {
         super()
         {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
@@ -76,7 +74,7 @@ class FindHighlight extends HTMLSpanElement {
 
     static fromFindApi(found, allTextNode: Text[]) {
         return new this(
-            createRangeProxy({
+            new SharedRangeView({
                 startContainer: allTextNode[found.startTextNodePos],
                 startOffset: found.startOffset,
                 endContainer: allTextNode[found.endTextNodePos],
@@ -126,8 +124,11 @@ class FindHighlight extends HTMLSpanElement {
     getClientRects() {
         return this.range.getClientRects()
     }
+    cloneRange() {
+        return this.range.cloneRange()
+    }
     unfocus() {
-        setNativeFocus(this.range["range"], false)
+        setNativeFocus(this.range, false)
         this.background = `var(--tridactyl-search-highlight-color)`
         for (const node of this.children) {
             ;(node as HTMLElement).style.background = this.background
@@ -168,7 +169,7 @@ class FindHighlight extends HTMLSpanElement {
         }
         const focusable = this.queryInRange("a,input,button,details")
         if (focusElement && focusable) focusable.focus()
-        setNativeFocus(this.range["range"], true)
+        setNativeFocus(this.range, true)
         this.background = `var(--tridactyl-search-highlight-active-color)`
         for (const node of this.children) {
             const element = node as HTMLElement
@@ -222,7 +223,7 @@ let nativeHighlights: { normal: Highlight; active: Highlight }
 let nativeRegistry = CSS.highlights
 
 function isHighlightVisible(highlight: FindHighlight) {
-    return DOM.isVisible(nativeHighlights ? highlight.range : highlight)
+    return DOM.isVisible(nativeHighlights ? highlight.range as unknown as Range : highlight)
 }
 
 function setNativeFocus(range: Range | StaticRange, active: boolean) {
@@ -395,11 +396,13 @@ export async function jumpToMatch(searchQuery, option) {
                     const end = match.index + match[0].length
                     while (match.index >= nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
+                    const startContainer = nodes[nodeIndex]
+                    const startOffset = match.index - nodeOffset
                     while (end > nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
-                    const range = createRangeProxy({
-                        startContainer: nodes[nodeIndex],
-                        startOffset: match.index - nodeOffset,
+                    const range = new SharedRangeView({
+                        startContainer,
+                        startOffset,
                         endContainer: nodes[nodeIndex],
                         endOffset: end - nodeOffset,
                     })
@@ -451,7 +454,7 @@ function drawHighlights(highlights) {
         const doc = highlights[0].range.startContainer.ownerDocument
         const win: any = doc.defaultView
         const normal = new win.Highlight()
-        highlights.forEach(highlight => normal.add(highlight.range["range"]))
+        highlights.forEach(highlight => normal.add(highlight.range))
         const active = new win.Highlight()
         nativeRegistry = win.CSS.highlights
         normal.priority = 2147483646

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,8 +26,17 @@ function getFindHost() {
 
 const NATIVE_HIGHLIGHTS = typeof Highlight === "function" && "highlights" in CSS
 
-class SharedRangeView extends StaticRange {
+class SharedRangeView {
     private static shared = document.createRange()
+    private _staticRange: StaticRange
+    constructor(rangeSpec: {
+        startContainer: Node,
+        startOffset: number,
+        endContainer: Node,
+        endOffset: number,
+    }) {
+        this._staticRange = new StaticRange(rangeSpec)
+    }
     public toString() {
         return this.moveSharedRange().toString()
     }
@@ -40,8 +49,26 @@ class SharedRangeView extends StaticRange {
     public getClientRects() {
         return this.moveSharedRange().getClientRects()
     }
+    public isVisible() {
+        return DOM.isVisible(this.moveSharedRange())
+    }
     get commonAncestorContainer() {
         return this.moveSharedRange().commonAncestorContainer
+    }
+    get staticRange() {
+        return this._staticRange
+    }
+    get startContainer() {
+        return this._staticRange.startContainer
+    }
+    get startOffset() {
+        return this._staticRange.startOffset
+    }
+    get endContainer() {
+        return this._staticRange.endContainer
+    }
+    get endOffset() {
+        return this._staticRange.endOffset
     }
     private moveSharedRange() {
         SharedRangeView.shared.setStart(this.startContainer, this.startOffset)
@@ -53,8 +80,9 @@ class SharedRangeView extends StaticRange {
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
     private background = `var(--tridactyl-search-highlight-color)`
+    private staticRange: StaticRange
 
-    constructor(public range: SharedRangeView) {
+    constructor(public rangeView: SharedRangeView) {
         super()
         {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
@@ -63,6 +91,7 @@ class FindHighlight extends HTMLSpanElement {
                 this[key] = proto[key]
             }
         }
+        this.staticRange = rangeView.staticRange
         this.style.position = "absolute"
         this.style.top = "0px"
         this.style.left = "0px"
@@ -119,16 +148,16 @@ class FindHighlight extends HTMLSpanElement {
     }
 
     getBoundingClientRect() {
-        return this.range.getBoundingClientRect()
+        return this.rangeView.getBoundingClientRect()
     }
     getClientRects() {
-        return this.range.getClientRects()
+        return this.rangeView.getClientRects()
     }
     cloneRange() {
-        return this.range.cloneRange()
+        return this.rangeView.cloneRange()
     }
     unfocus() {
-        setNativeFocus(this.range, false)
+        setNativeFocus(this.staticRange, false)
         this.background = `var(--tridactyl-search-highlight-color)`
         for (const node of this.children) {
             ;(node as HTMLElement).style.background = this.background
@@ -147,7 +176,7 @@ class FindHighlight extends HTMLSpanElement {
             getBoundingClientRect: () => this.getBoundingClientRect(),
             parentElement: null,
         }
-        let parent = this.range.commonAncestorContainer
+        let parent = this.rangeView.commonAncestorContainer
         if (parent.nodeType !== Node.ELEMENT_NODE) {
             parent = parent.parentElement
         }
@@ -169,7 +198,7 @@ class FindHighlight extends HTMLSpanElement {
         }
         const focusable = this.queryInRange("a,input,button,details")
         if (focusElement && focusable) focusable.focus()
-        setNativeFocus(this.range, true)
+        setNativeFocus(this.staticRange, true)
         this.background = `var(--tridactyl-search-highlight-active-color)`
         for (const node of this.children) {
             const element = node as HTMLElement
@@ -177,7 +206,7 @@ class FindHighlight extends HTMLSpanElement {
         }
     }
     queryInRange(selector: string): HTMLElement | null {
-        const range = this.range
+        const range = this.staticRange
         const rangeEndNode = range.endContainer
         if (range.startContainer.ownerDocument !== document) return null
 
@@ -223,7 +252,7 @@ let nativeHighlights: { normal: Highlight; active: Highlight }
 let nativeRegistry = CSS.highlights
 
 function isHighlightVisible(highlight: FindHighlight) {
-    return DOM.isVisible(nativeHighlights ? highlight.range as unknown as Range : highlight)
+    return nativeHighlights ? highlight.rangeView.isVisible() : DOM.isVisible(highlight)
 }
 
 function setNativeFocus(range: Range | StaticRange, active: boolean) {
@@ -451,10 +480,10 @@ export async function jumpToMatch(searchQuery, option) {
 
 function drawHighlights(highlights) {
     if (NATIVE_HIGHLIGHTS) {
-        const doc = highlights[0].range.startContainer.ownerDocument
+        const doc = highlights[0].staticRange.startContainer.ownerDocument
         const win: any = doc.defaultView
         const normal = new win.Highlight()
-        highlights.forEach(highlight => normal.add(highlight.range))
+        highlights.forEach(highlight => normal.add(highlight.staticRange))
         const active = new win.Highlight()
         nativeRegistry = win.CSS.highlights
         normal.priority = 2147483646
@@ -502,7 +531,7 @@ async function findCompletionMatches(generation) {
     const headingIndexes = new Map()
     for (let index = 0; index < highlights.length; ++index) {
         const highlight = highlights[index]
-        const range = highlight.range
+        const range = highlight.rangeView
         const doc: Document = range.startContainer.ownerDocument
         const walker = doc.createTreeWalker(doc, NodeFilter.SHOW_TEXT)
         walker.currentNode = range.startContainer
@@ -707,5 +736,5 @@ export async function jumpToNextMatch(n: number, searchFromView = false) {
 }
 
 export function currentMatchRange(): Range {
-    return lastHighlights[selected].range.cloneRange()
+    return lastHighlights[selected].rangeView.cloneRange()
 }

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,30 +26,37 @@ function getFindHost() {
 
 const NATIVE_HIGHLIGHTS = typeof Highlight === "function" && "highlights" in CSS
 
-// Too many live Ranges cause slowdown
-// StaticRanges don't, but also don't have clientRects
-// Use this one Range and set its start/end to get clientRects
-const reuseRange = document.createRange()
+const createRangeProxy = (() => {
+    const sharedRange = document.createRange()
 
-function setReuseRange(staticRange: StaticRange) {
-    reuseRange.setStart(staticRange.startContainer, staticRange.startOffset)
-    reuseRange.setEnd(staticRange.endContainer, staticRange.endOffset)
-    return reuseRange
-}
-
-function staticRangeBoundingRect(staticRange: StaticRange) {
-    return setReuseRange(staticRange).getBoundingClientRect()
-}
-
-function staticRangeClientRects(staticRange: StaticRange) {
-    return setReuseRange(staticRange).getClientRects()
-}
+    return function(rangeSpec: {
+        startContainer: Node,
+        startOffset: number,
+        endContainer: Node,
+        endOffset: number,
+    }): Range & { ["range"]: StaticRange } {
+        return new Proxy(new StaticRange(rangeSpec), {
+            get(target, prop) {
+                if (prop === "range") return target
+                if (prop !== "toString" && prop in target) return target[prop]
+                if (prop in sharedRange) {
+                    return (...args: any[]) => {
+                        sharedRange.setStart(target.startContainer, target.startOffset)
+                        sharedRange.setEnd(target.endContainer,target.endOffset)
+                        return (sharedRange as any)[prop](...args)
+                    }
+                }
+                return undefined
+            }
+        }) as Range & { ["range"]: StaticRange }
+    }
+})()
 
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
     private background = `var(--tridactyl-search-highlight-color)`
 
-    constructor(public range: StaticRange) {
+    constructor(public range: Range) {
         super()
         {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
@@ -68,12 +75,14 @@ class FindHighlight extends HTMLSpanElement {
     }
 
     static fromFindApi(found, allTextNode: Text[]) {
-        return new this(new StaticRange({
-            startContainer: allTextNode[found.startTextNodePos],
-            startOffset: found.startOffset,
-            endContainer: allTextNode[found.endTextNodePos],
-            endOffset: found.endOffset,
-        }))
+        return new this(
+            createRangeProxy({
+                startContainer: allTextNode[found.startTextNodePos],
+                startOffset: found.startOffset,
+                endContainer: allTextNode[found.endTextNodePos],
+                endOffset: found.endOffset,
+            })
+        )
     }
 
     updateRectsPosition(rects = this.getClientRects()) {
@@ -112,13 +121,13 @@ class FindHighlight extends HTMLSpanElement {
     }
 
     getBoundingClientRect() {
-        return staticRangeBoundingRect(this.range)
+        return this.range.getBoundingClientRect()
     }
     getClientRects() {
-        return staticRangeClientRects(this.range)
+        return this.range.getClientRects()
     }
     unfocus() {
-        setNativeFocus(this.range, false)
+        setNativeFocus(this.range["range"], false)
         this.background = `var(--tridactyl-search-highlight-color)`
         for (const node of this.children) {
             ;(node as HTMLElement).style.background = this.background
@@ -137,7 +146,7 @@ class FindHighlight extends HTMLSpanElement {
             getBoundingClientRect: () => this.getBoundingClientRect(),
             parentElement: null,
         }
-        let parent = setReuseRange(this.range).commonAncestorContainer
+        let parent = this.range.commonAncestorContainer
         if (parent.nodeType !== Node.ELEMENT_NODE) {
             parent = parent.parentElement
         }
@@ -159,7 +168,7 @@ class FindHighlight extends HTMLSpanElement {
         }
         const focusable = this.queryInRange("a,input,button,details")
         if (focusElement && focusable) focusable.focus()
-        setNativeFocus(this.range, true)
+        setNativeFocus(this.range["range"], true)
         this.background = `var(--tridactyl-search-highlight-active-color)`
         for (const node of this.children) {
             const element = node as HTMLElement
@@ -213,10 +222,10 @@ let nativeHighlights: { normal: Highlight; active: Highlight }
 let nativeRegistry = CSS.highlights
 
 function isHighlightVisible(highlight: FindHighlight) {
-    return DOM.isVisible(nativeHighlights ? setReuseRange(highlight.range) : highlight)
+    return DOM.isVisible(nativeHighlights ? highlight.range : highlight)
 }
 
-function setNativeFocus(range: StaticRange, active: boolean) {
+function setNativeFocus(range: Range | StaticRange, active: boolean) {
     if (!nativeHighlights) return
     nativeHighlights.normal[active ? "delete" : "add"](range)
     nativeHighlights.active[active ? "add" : "delete"](range)
@@ -386,12 +395,16 @@ export async function jumpToMatch(searchQuery, option) {
                     const end = match.index + match[0].length
                     while (match.index >= nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
-                    reuseRange.setStart(nodes[nodeIndex], match.index - nodeOffset)
                     while (end > nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
-                    reuseRange.setEnd(nodes[nodeIndex], end - nodeOffset)
-                    if (reuseRange.toString() !== match[0]) continue
-                    found.push(new FindHighlight(new StaticRange(reuseRange)))
+                    const range = createRangeProxy({
+                        startContainer: nodes[nodeIndex],
+                        startOffset: match.index - nodeOffset,
+                        endContainer: nodes[nodeIndex],
+                        endOffset: end - nodeOffset,
+                    })
+                    if (range.toString() !== match[0]) continue
+                    found.push(new FindHighlight(range))
                 } catch (_) {}
             }
         }
@@ -438,7 +451,7 @@ function drawHighlights(highlights) {
         const doc = highlights[0].range.startContainer.ownerDocument
         const win: any = doc.defaultView
         const normal = new win.Highlight()
-        highlights.forEach(highlight => normal.add(highlight.range))
+        highlights.forEach(highlight => normal.add(highlight.range["range"]))
         const active = new win.Highlight()
         nativeRegistry = win.CSS.highlights
         normal.priority = 2147483646

--- a/src/content/finding.ts
+++ b/src/content/finding.ts
@@ -26,11 +26,30 @@ function getFindHost() {
 
 const NATIVE_HIGHLIGHTS = typeof Highlight === "function" && "highlights" in CSS
 
+// Too many live Ranges cause slowdown
+// StaticRanges don't, but also don't have clientRects
+// Use this one Range and set its start/end to get clientRects
+const reuseRange = document.createRange()
+
+function setReuseRange(staticRange: StaticRange) {
+    reuseRange.setStart(staticRange.startContainer, staticRange.startOffset)
+    reuseRange.setEnd(staticRange.endContainer, staticRange.endOffset)
+    return reuseRange
+}
+
+function staticRangeBoundingRect(staticRange: StaticRange) {
+    return setReuseRange(staticRange).getBoundingClientRect()
+}
+
+function staticRangeClientRects(staticRange: StaticRange) {
+    return setReuseRange(staticRange).getClientRects()
+}
+
 class FindHighlight extends HTMLSpanElement {
     public top = Infinity
     private background = `var(--tridactyl-search-highlight-color)`
 
-    constructor(public range: Range) {
+    constructor(public range: StaticRange) {
         super()
         {
             // https://bugzilla.mozilla.org/show_bug.cgi?id=1716685
@@ -49,10 +68,12 @@ class FindHighlight extends HTMLSpanElement {
     }
 
     static fromFindApi(found, allTextNode: Text[]) {
-        const range = allTextNode[0].ownerDocument.createRange()
-        range.setStart(allTextNode[found.startTextNodePos], found.startOffset)
-        range.setEnd(allTextNode[found.endTextNodePos], found.endOffset)
-        return new this(range)
+        return new this(new StaticRange({
+            startContainer: allTextNode[found.startTextNodePos],
+            startOffset: found.startOffset,
+            endContainer: allTextNode[found.endTextNodePos],
+            endOffset: found.endOffset,
+        }))
     }
 
     updateRectsPosition(rects = this.getClientRects()) {
@@ -91,10 +112,10 @@ class FindHighlight extends HTMLSpanElement {
     }
 
     getBoundingClientRect() {
-        return this.range.getBoundingClientRect()
+        return staticRangeBoundingRect(this.range)
     }
     getClientRects() {
-        return this.range.getClientRects()
+        return staticRangeClientRects(this.range)
     }
     unfocus() {
         setNativeFocus(this.range, false)
@@ -116,7 +137,7 @@ class FindHighlight extends HTMLSpanElement {
             getBoundingClientRect: () => this.getBoundingClientRect(),
             parentElement: null,
         }
-        let parent = this.range.commonAncestorContainer
+        let parent = setReuseRange(this.range).commonAncestorContainer
         if (parent.nodeType !== Node.ELEMENT_NODE) {
             parent = parent.parentElement
         }
@@ -192,10 +213,10 @@ let nativeHighlights: { normal: Highlight; active: Highlight }
 let nativeRegistry = CSS.highlights
 
 function isHighlightVisible(highlight: FindHighlight) {
-    return DOM.isVisible(nativeHighlights ? highlight.range : highlight)
+    return DOM.isVisible(nativeHighlights ? setReuseRange(highlight.range) : highlight)
 }
 
-function setNativeFocus(range: Range, active: boolean) {
+function setNativeFocus(range: StaticRange, active: boolean) {
     if (!nativeHighlights) return
     nativeHighlights.normal[active ? "delete" : "add"](range)
     nativeHighlights.active[active ? "add" : "delete"](range)
@@ -365,13 +386,12 @@ export async function jumpToMatch(searchQuery, option) {
                     const end = match.index + match[0].length
                     while (match.index >= nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
-                    const range = nodes[0].ownerDocument.createRange()
-                    range.setStart(nodes[nodeIndex], match.index - nodeOffset)
+                    reuseRange.setStart(nodes[nodeIndex], match.index - nodeOffset)
                     while (end > nodeOffset + lengths[nodeIndex])
                         nodeOffset += lengths[nodeIndex++]
-                    range.setEnd(nodes[nodeIndex], end - nodeOffset)
-                    if (range.toString() !== match[0]) continue
-                    found.push(new FindHighlight(range))
+                    reuseRange.setEnd(nodes[nodeIndex], end - nodeOffset)
+                    if (reuseRange.toString() !== match[0]) continue
+                    found.push(new FindHighlight(new StaticRange(reuseRange)))
                 } catch (_) {}
             }
         }


### PR DESCRIPTION
For #5483

Avoid creating too many `Range`s, instead store `StaticRange`s for `:find` matches.

Set the start/end of one real `Range` so that we can still get client rects.

I haven't been too thorough here, for instance I'm not sure where `currentMatchRange` might be used and that might need to return a real `Range`.

I'll leave this as a draft as more of a suggested fix