### PR TITLE
feat: add hintnames random option for shuffled hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -762,13 +762,13 @@ function* hintnames_words(n: number): IterableIterator<string> {
     )
 }
 
-/** Randomly shuffled lexicographic hintnames.
- * Shuffles standard hints so that nearby DOM elements get different first characters,
+/** Reversed lexicographic hintnames.
+ * Reverses each hint so that nearby DOM elements get different first characters,
  * making typed filtering more effective. See #3880.
  * @hidden */
-function* hintnames_random(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
+function* hintnames_reverse(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
     const hints = [...islice(hintnames_simple(hintchars), n)]
-    yield* shuffleArray(hints)
+    yield* hints.map(hint => hint.split("").reverse().join(""))
 }
 
 /** @hidden */
@@ -783,8 +783,8 @@ function* hintnames(
             yield* hintnames_uniform(n, hintchars)
         case "words":
             yield* hintnames_words(n)
-        case "random":
-            yield* hintnames_random(n, hintchars)
+        case "reverse":
+            yield* hintnames_reverse(n, hintchars)
         default:
             yield* hintnames_short(n, hintchars)
     }

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -762,6 +762,15 @@ function* hintnames_words(n: number): IterableIterator<string> {
     )
 }
 
+/** Randomly shuffled lexicographic hintnames.
+ * Shuffles standard hints so that nearby DOM elements get different first characters,
+ * making typed filtering more effective. See #3880.
+ * @hidden */
+function* hintnames_random(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
+    const hints = [...islice(hintnames_simple(hintchars), n)]
+    yield* shuffleArray(hints)
+}
+
 /** @hidden */
 function* hintnames(
     n: number,
@@ -774,6 +783,8 @@ function* hintnames(
             yield* hintnames_uniform(n, hintchars)
         case "words":
             yield* hintnames_words(n)
+        case "random":
+            yield* hintnames_random(n, hintchars)
         default:
             yield* hintnames_short(n, hintchars)
     }

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -767,7 +767,7 @@ function* hintnames_words(n: number): IterableIterator<string> {
  * making typed filtering more effective. See #3880.
  * @hidden */
 function* hintnames_reverse(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
-    const hints = [...islice(hintnames_simple(hintchars), n)]
+    const hints = [...islice(hintnames_uniform(n, hintchars), n)]
     yield* hints.map(hint => hint.split("").reverse().join(""))
 }
 

--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -767,8 +767,7 @@ function* hintnames_words(n: number): IterableIterator<string> {
  * making typed filtering more effective. See #3880.
  * @hidden */
 function* hintnames_reverse(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
-    const hints = [...islice(hintnames_uniform(n, hintchars), n)]
-    yield* hints.map(hint => hint.split("").reverse().join(""))
+    yield* map(hintnames_uniform(n, hintchars), hint => hint.split("").reverse().join(""))
 }
 
 /** @hidden */

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -897,9 +897,9 @@ export class default_config {
     hintfiltermode: "simple" | "vimperator" | "vimperator-reflow" = "simple"
 
     /**
-     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*). `random` shuffles standard hints so nearby elements get different first characters.
+     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*). `reverse` reverses each hint so nearby elements get different first characters.
      */
-    hintnames: "short" | "numeric" | "uniform" | "words" | "random" = "short"
+    hintnames: "short" | "numeric" | "uniform" | "words" | "reverse" = "short"
 
     /**
      * Whether to display the names for hints in uppercase.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -897,9 +897,9 @@ export class default_config {
     hintfiltermode: "simple" | "vimperator" | "vimperator-reflow" = "simple"
 
     /**
-     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*)
+     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*). `random` shuffles standard hints so nearby elements get different first characters.
      */
-    hintnames: "short" | "numeric" | "uniform" | "words" = "short"
+    hintnames: "short" | "numeric" | "uniform" | "words" | "random" = "short"
 
     /**
      * Whether to display the names for hints in uppercase.


### PR DESCRIPTION
## Summary

Adds a new `hintnames random` option that generates standard lexicographic hints and shuffles them with Fisher-Yates, so nearby DOM elements get different first characters.

This makes typed filtering more effective on pages with many hints clustered together.

## Problem

When there are >26 hints, they are generated lexicographically in DOM order:

```
aa as ad af ag
```

If these hints are on nearby elements, typing `a` still leaves many similar hints (`as`, `ad`, `af`), making it hard to narrow down the target.

With `hintnames random`:

```
aa sa da fa ga
```

Now typing `s` immediately filters to `sa`, which is on a specific element.

## Usage

```
:set hintnames random
```

## Implementation

- `hintnames_random(n, hintchars)` collects all `n` hints from the standard lexicographic stream and shuffles them with Fisher-Yates
- Uses the existing `shuffleArray` helper
- Added `"random"` to the `hintnames` config type

Fixes #3880