### PR TITLE
Fix #5493: add :splitnext

### DIFF
--- a/src/excmds.test.ts
+++ b/src/excmds.test.ts
@@ -217,6 +217,27 @@ test("`changelistjump` skips closed tabs", async () => {
     ])
 })
 
+test.each([
+    [7, [[2, { active: true }]]],
+    [-1, []],
+    [undefined, []],
+])(
+    "`splitnext` handles split view ID %s",
+    async (splitViewId, expectedCalls) => {
+        const query = jest.mocked(browser.tabs.query)
+        const update = jest.mocked(browser.tabs.update)
+        update.mockClear()
+        query.mockResolvedValueOnce([
+            { id: 1, active: true, splitViewId },
+            { id: 2, active: false, splitViewId },
+        ] as browser.tabs.Tab[])
+
+        await backgroundExcmds.splitnext()
+        expect(query).toHaveBeenLastCalledWith({ currentWindow: true })
+        expect(update.mock.calls).toEqual(expectedCalls)
+    },
+)
+
 test("`nativeopen` targets the running macOS Firefox application", async () => {
     jest.mocked(browser.runtime.getPlatformInfo).mockResolvedValue({
         arch: "x86-64",

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -2739,6 +2739,16 @@ async function tabIndexSetActive(index: number | string) {
     return tabSetActive(await idFromIndex(index))
 }
 
+/** Switch focus to the other side of the current split view, if it exists */
+//#background
+export async function splitnext() {
+    const tabs = await browser.tabs.query({ currentWindow: true })
+    const splitViewId = tabs.find(tab => tab.active)?.splitViewId
+    if (splitViewId === undefined || splitViewId < 0) return
+    const next = tabs.find(tab => !tab.active && tab.splitViewId === splitViewId)
+    if (next) return tabSetActive(next.id)
+}
+
 /** Switch to the first tab in Firefox's tab order. */
 //#background
 export async function tabfirst() {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -325,6 +325,7 @@ export class default_config {
         K: "tabnext",
         gt: "tabnext_gt",
         gT: "tabprev",
+        gs: "splitnext", // c-w w is reserved for closing windows
         // "<c-n>": "tabnext_gt", // c-n is reserved for new window
         // "<c-p>": "tabprev",
         "g^": "tabfirst",

--- a/src/tridactyl.d.ts
+++ b/src/tridactyl.d.ts
@@ -20,6 +20,12 @@ interface HTMLElement {
     openOrClosedShadowRoot: ShadowRoot | null
 }
 
+declare namespace browser.tabs {
+    interface Tab {
+        splitViewId?: number
+    }
+}
+
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 // these functions really can be anything, ditto for the objects
 declare function exportFunction(


### PR DESCRIPTION
Two main things to bikeshed before I merge this:

1) is :splitnext a good name for this? might we want to use it for instead going to the next pair of split tabs?

2) is `gs` the best bind we can think of? in Vim, `<C-w>w` is used, but we can't do that by default because `<C-w>` closes windows. in Vim, `gs` ... makes Vim sleep. really. i don't understand at all why that needed a default bind. anyway, maybe we save `gs` for creating a split view like we use `gd` for tab detach, and use `gh`, `gl` and `gw` for navigating between panes in a split?

Plenty of time to bikeshed too because I promised myself no new features until 1.25.0 is out
