### PR TITLE
feat: add hintnames reverse option for shuffled hints

### DIFF
--- a/src/content/hinting.ts
+++ b/src/content/hinting.ts
@@ -762,6 +762,14 @@ function* hintnames_words(n: number): IterableIterator<string> {
     )
 }
 
+/** Reversed lexicographic hintnames.
+ * Reverses each hint so that nearby DOM elements get different first characters,
+ * making typed filtering more effective. See #3880.
+ * @hidden */
+function* hintnames_reverse(n: number, hintchars = defaultHintChars()): IterableIterator<string> {
+    yield* map(hintnames_uniform(n, hintchars), hint => hint.split("").reverse().join(""))
+}
+
 /** @hidden */
 function* hintnames(
     n: number,
@@ -774,6 +782,8 @@ function* hintnames(
             yield* hintnames_uniform(n, hintchars)
         case "words":
             yield* hintnames_words(n)
+        case "reverse":
+            yield* hintnames_reverse(n, hintchars)
         default:
             yield* hintnames_short(n, hintchars)
     }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -897,9 +897,9 @@ export class default_config {
     hintfiltermode: "simple" | "vimperator" | "vimperator-reflow" = "simple"
 
     /**
-     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*)
+     * Whether to optimise for the shortest possible names for each hint, or to use a simple numerical ordering. If set to `numeric` or `words`, overrides `hintchars` setting. `words` uses random three letter English words (and therefore works badly with hintfiltermode vimperator*). `reverse` reverses each hint so nearby elements get different first characters.
      */
-    hintnames: "short" | "numeric" | "uniform" | "words" = "short"
+    hintnames: "short" | "numeric" | "uniform" | "words" | "reverse" = "short"
 
     /**
      * Whether to display the names for hints in uppercase.


### PR DESCRIPTION
Fixes #3880

Adds a new  option that reverses each hint lexicographically so nearby DOM elements get different first characters, making typed filtering more effective.

Changes:
- src/content/hinting.ts: Added `hintnames_reverse` function and wired it into the `hintnames` switch
- src/lib/config.ts: Added `reverse` to `hintnames` type and updated documentation

Usage: `:set hintnames reverse`