### PR TITLE
Add excmd flag suggestions to excmd completion while typing

### DIFF
--- a/scripts/convert_typedoc_metadata.js
+++ b/scripts/convert_typedoc_metadata.js
@@ -40,13 +40,16 @@ function convertMetadata(project) {
                 .map(part => part.text || "")
                 .join("")
             const flagText = text.split(/\r?\n[ \t]*\r?\n/, 1)[0]
-            const m = /^(-\S+)[ \t]+([^\n]+)\n*([\s\S]*)$/.exec(flagText.trim())
+            const m = /^(-\S+)(?:[ \t]+\{(\w+)\})?[ \t]+([^\n]+)\n*([\s\S]*)$/.exec(
+                flagText.trim(),
+            )
             if (!m) continue
-            const [, flag, short, rest] = m
+            const [, flag, group, short, rest] = m
             const elaboration = rest.trim()
             flags[flag] = {
                 short,
                 description: elaboration ? `${short}\n\n${elaboration}` : short,
+                ...(group ? { group } : {}),
             }
         }
         return flags

--- a/scripts/typedoc-theme.mjs
+++ b/scripts/typedoc-theme.mjs
@@ -272,11 +272,13 @@ function parseFlagTag(tag) {
         ]
         break
     }
-    const m = /^(-\S+)[ \t]+([^\n]+)\n*([\s\S]*)$/.exec(text.trim())
+    const m = /^(-\S+)(?:[ \t]+\{(\w+)\})?[ \t]+([^\n]+)\n*([\s\S]*)$/.exec(
+        text.trim(),
+    )
     if (!m) return undefined
-    const [, flag, short, rest] = m
+    const [, flag, group, short, rest] = m
     const elaboration = rest.trim()
-    return [flag, short, elaboration, trailing]
+    return [flag, group, short, elaboration, trailing]
 }
 
 function renderFlagList(context, parsed) {
@@ -284,7 +286,7 @@ function renderFlagList(context, parsed) {
     return h(
         "ul",
         { class: "tsd-tag-flag tsd-parameter-list" },
-        parsed.map(([flag, short, elaboration]) =>
+        parsed.map(([flag, , short, elaboration]) =>
             h(
                 "li",
                 null,
@@ -321,8 +323,8 @@ class TridactylTheme extends DefaultTheme {
                     tag.skipRendering = true
                     const parsed = parseFlagTag(tag)
                     if (!parsed) continue
-                    const [flag, short, elaboration, trailing] = parsed
-                    flagRun.push([flag, short, elaboration])
+                    const [flag, group, short, elaboration, trailing] = parsed
+                    flagRun.push([flag, group, short, elaboration])
                     if (trailing.length === 0) continue
                     flushFlags()
                     const headingCount = page.pageHeadings.length

--- a/src/commandline_frame.ts
+++ b/src/commandline_frame.ts
@@ -34,6 +34,7 @@ import { ExcmdCompletionSource } from "@src/completions/Excmd"
 import { ExtensionsCompletionSource } from "@src/completions/Extensions"
 import { FileSystemCompletionSource } from "@src/completions/FileSystem"
 import { FindCompletionSource } from "@src/completions/Find"
+import { FlagCompletionSource } from "@src/completions/Flag"
 import { GotoCompletionSource } from "@src/completions/Goto"
 import { GuisetCompletionSource } from "@src/completions/Guiset"
 import { GlossaryCompletionSource } from "@src/completions/Glossary"
@@ -148,6 +149,7 @@ export function enableCompletions() {
             TabAllCompletionSource,
             BufferCompletionSource,
             ExcmdCompletionSource,
+            FlagCompletionSource,
             ThemeCompletionSource,
             TabHistoryCompletionSource,
             CompositeCompletionSource,

--- a/src/completions/Flag.ts
+++ b/src/completions/Flag.ts
@@ -1,0 +1,121 @@
+import * as Completions from "@src/completions"
+import { flagsFor } from "@src/lib/excmd_flags"
+
+export class FlagCompletionOption
+    extends Completions.CompletionOptionHTML
+    implements Completions.CompletionOptionFuse {
+    public fuseKeys = []
+
+    constructor(
+        public value: string,
+        flag: string,
+        label: string,
+    ) {
+        super()
+        this.fuseKeys.push(flag, label)
+        this.html = html`<tr class="FlagCompletionOption option">
+            <td class="flag">${flag}</td>
+            <td class="documentation">${label}</td>
+        </tr>`
+    }
+}
+
+// e.g. "hint -Jc" -> { cmdWord: "hint", combined: "Jc" }.
+// Returns undefined once the user moves past the flag token (hit a space)
+function typingFlagToken(
+    exstr: string,
+): { cmdWord: string; combined: string } | undefined {
+    const trimmed = exstr.replace(/^\s+/, "")
+    const spaceIdx = trimmed.search(/\s/)
+    if (spaceIdx === -1) return undefined
+
+    const cmdWord = trimmed.slice(0, spaceIdx)
+    const afterCmd = trimmed.slice(spaceIdx).replace(/^\s+/, "")
+    if (afterCmd.search(/\s/) !== -1) return undefined
+    if (afterCmd !== "" && !afterCmd.startsWith("-")) return undefined
+
+    return { cmdWord, combined: afterCmd.slice(1) }
+}
+
+export class FlagCompletionSource extends Completions.CompletionSourceFuse {
+    public options: FlagCompletionOption[]
+
+    constructor(private _parent) {
+        super([], "FlagCompletionSource", "flags", { trailingSpace: false })
+        this._parent.appendChild(this.node)
+    }
+
+    async filter(exstr: string) {
+        this.lastExstr = exstr
+        return this.onInput(exstr)
+    }
+
+    async onInput(exstr: string) {
+        return this.updateOptions(exstr)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    updateChain(exstr = this.lastExstr, options = this.options) {
+        this.state = this.options.length > 0 ? "normal" : "hidden"
+        this.updateDisplay()
+    }
+
+    select(option: FlagCompletionOption) {
+        this.completion = option.value
+        option.state = "focused"
+        this.lastFocused = option
+    }
+
+    private updateOptions(exstr: string) {
+        this.options = []
+
+        const typing = typingFlagToken(exstr)
+        const metaFlags = typing && flagsFor(typing.cmdWord)
+        if (typing && metaFlags) {
+            const { cmdWord, combined } = typing
+            const used = new Set(combined.split(""))
+            // groups already spoken for by chars already typed
+            const claimedGroups = new Set(
+                Array.from(used)
+                    .map(ch => metaFlags[`-${ch}`]?.group)
+                    .filter(Boolean),
+            )
+            const couldStillBeMultiChar = Object.keys(metaFlags).some(
+                flag =>
+                    flag.slice(1).length > 1 &&
+                    flag.slice(1).startsWith(combined),
+            )
+            // past the multi-char stage, every char must be a real flag or it's a typo
+            const validSoFar =
+                couldStillBeMultiChar ||
+                Array.from(used).every(ch => metaFlags[`-${ch}`] !== undefined)
+
+            for (const [flag, meta] of validSoFar
+                ? Object.entries(metaFlags)
+                : []) {
+                const name = flag.slice(1)
+                if (name.length === 1) {
+                    if (used.has(name)) continue
+                    if (meta.group && claimedGroups.has(meta.group)) continue
+                    const value = `${cmdWord} -${combined}${name}`
+                    this.options.push(
+                        new FlagCompletionOption(
+                            value,
+                            `-${combined}${name}`,
+                            meta.short,
+                        ),
+                    )
+                } else if (name.startsWith(combined)) {
+                    // -pipe/-W/-fr/-wp take the rest of the line, offer them whole
+                    const value = `${cmdWord} ${flag} `
+                    this.options.push(
+                        new FlagCompletionOption(value, flag, meta.short),
+                    )
+                }
+            }
+        }
+
+        this.options.forEach(o => (o.state = "normal"))
+        return this.updateChain()
+    }
+}

--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -5532,38 +5532,38 @@ const KILL_STACK: Element[] = []
  *
  * #### Hinting action flags (only one can be specified):
  *
- * @flag -t open in a new foreground tab
- * @flag -b open in background
- * @flag -y copy (yank) link's target to clipboard
- * @flag -p copy an element's text to the clipboard
- * @flag -h select an element (as if you click-n-dragged over it)
- * @flag -P copy an element's title/alt text to the clipboard
- * @flag -r read an element's text with text-to-speech
- * @flag -i view an image
- * @flag -I view an image in a new tab
- * @flag -k irreversibly deletes an element from the page (until reload)
- * @flag -K hides an element on the page
+ * @flag -t {action} open in a new foreground tab
+ * @flag -b {action} open in background
+ * @flag -y {action} copy (yank) link's target to clipboard
+ * @flag -p {action} copy an element's text to the clipboard
+ * @flag -h {action} select an element (as if you click-n-dragged over it)
+ * @flag -P {action} copy an element's title/alt text to the clipboard
+ * @flag -r {action} read an element's text with text-to-speech
+ * @flag -i {action} view an image
+ * @flag -I {action} view an image in a new tab
+ * @flag -k {action} irreversibly deletes an element from the page (until reload)
+ * @flag -K {action} hides an element on the page
  * - Hidden elements can be restored using [[elementunhide]].
- * @flag -s save (download) the linked resource
- * @flag -S save the linked image
- * @flag -a save-as the linked resource
- * @flag -A save-as the linked image
- * @flag -; focus an element and set it as the element or the child of the element to scroll
- * @flag -# yank an element's anchor URL to clipboard
- * @flag -w open in new window
- * @flag -wp open in new private window
- * @flag -z scroll an element to the top of the viewport
- * @flag -pipe `selector key`, e.g, `-pipe a href` returns the URL of the chosen link on a page.
+ * @flag -s {action} save (download) the linked resource
+ * @flag -S {action} save the linked image
+ * @flag -a {action} save-as the linked resource
+ * @flag -A {action} save-as the linked image
+ * @flag -; {action} focus an element and set it as the element or the child of the element to scroll
+ * @flag -# {action} yank an element's anchor URL to clipboard
+ * @flag -w {action} open in new window
+ * @flag -wp {action} open in new private window
+ * @flag -z {action} scroll an element to the top of the viewport
+ * @flag -pipe {action} `selector key`, e.g, `-pipe a href` returns the URL of the chosen link on a page.
  * - Only makes sense with `composite`, e.g, `composite hint -pipe .some-class>a textContent | yank`.
  * - If you don't select a hint (i.e. press `<Esc>`), will return an empty string.
  * - Most useful when used like `-c` to do things other than opening links.
  * - NB: the query selector cannot contain any spaces.
- * @flag -W `excmd...` pass hint href as the final argument to excmd and execute.
+ * @flag -W {action} `excmd...` pass hint href as the final argument to excmd and execute.
  * - e.g, `hint -W mpvsafe` to open YouTube videos.
  * - NB: passing it to bare [[exclaim]] is dangerous - see `get exaliases.mpvsafe` for an example of how to do it safely.
  * - The usual [[composite]] caveats for `;` and `|` in URLs apply.
  * - If you need to use a query selector, use `-pipe` instead.
- * @flag -F [callback] - run a custom callback on the selected hint
+ * @flag -F {action} [callback] - run a custom callback on the selected hint
  * - e.g. `hint -JF e => {tri.excmds.tabopen("-b",e.href); e.remove()}`.
  *
  * #### Element selection flags
@@ -5585,10 +5585,10 @@ const KILL_STACK: Element[] = []
  *
  * #### Hinting mode selection:
  *
- * - -q* quick (or rapid) hints mode. Stay in hint mode until you press `<Esc>`, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
- *     - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
- * - -! execute all hints without waiting for a selection
- *     - For example, `hint -!bf Comments` opens in background tabs all visible links whose text matches `Comments`
+ * @flag -q quick (or rapid) hints mode. Stay in hint mode until you press `<Esc>`, e.g. `:hint -qb` to open multiple hints in the background or `:hint -qW excmd` to execute excmd once for each hint. This will return an array containing all elements or the result of executed functions (e.g. `hint -qpipe a href` will return an array of links).
+ * - For example, use `bind ;jg hint -Jc .rc > .r > a` on google.com to generate hints only for clickable search results of a given query
+ * @flag -! execute all hints without waiting for a selection
+ * - For example, `hint -!bf Comments` opens in background tabs all visible links whose text matches `Comments`
  *
  * #### Deprecated options:
  *

--- a/src/lib/excmd_flags.ts
+++ b/src/lib/excmd_flags.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared helper for locating an excmd's `@flag` metadata.
+ */
+
+import * as Metadata from "@src/lib/metadata"
+import type { FlagMeta } from "@src/lib/metadata"
+
+export type { FlagMeta }
+
+/** The `@flag` metadata map for a command, if any. */
+export function flagsFor(
+    cmdWord: string,
+): Record<string, FlagMeta> | undefined {
+    return Metadata.getFlags(Metadata.excmdsFunctions[cmdWord])
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -37,6 +37,19 @@ export function paramTypes(fnNode: Node | undefined): Node[] {
     return fnNode?.params || []
 }
 
+export interface FlagMeta {
+    short: string
+    description: string
+    /** Mutual-exclusion group, e.g. "action" for hint's "only one can be specified" flags. */
+    group?: string
+}
+
+export function getFlags(
+    fnNode: Node | undefined,
+): Record<string, FlagMeta> | undefined {
+    return fnNode?.flags
+}
+
 function intrinsicName(t) {
     switch (t.name) {
         case "string":

--- a/src/static/css/commandline.css
+++ b/src/static/css/commandline.css
@@ -272,6 +272,15 @@ a.url:hover {
     width: 100%;
 }
 
+.FlagCompletionOption td.flag {
+    padding-left: 0.5em;
+    width: 20%;
+}
+
+.FlagCompletionOption td.documentation {
+    width: 100%;
+}
+
 .SettingsCompletionSource td.title {
     padding-left: 0.5rem;
 }


### PR DESCRIPTION
## Summary

Follow-up to #5511, @bovine3dom asked if we could reuse the new `@flag` metadata for excmd completions, so that's what this does.

Typing `hint` followed by a space now pops up a completion box listing its flags with the short label from `@flag`:

- Single-char flags (`-t`, `-b`, `-c`, ...) combine into whatever token you've already typed, in any order, so typing `-Jc` still offers `-t` etc.
- Multi-char ones (like `-pipe`, `-fr`, `-wp`) are shown as their whole string.

## Mutual-exclusion groups

`hint` has "only one can be specified" action flags (`-t`, `-b`, `-y`, ...), so once you've picked `-t` we shouldn't keep suggesting `-b`/`-y`/etc alongside it.

`@flag` now takes an optional `{group}` marker (`@flag -t {action} ...`). Any flag sharing a group already present in the token gets excluded from suggestions.

Applied `{action}` to hint's 23 mutually-exclusive action flags. The rest (element selection, hinting mode) can be combined freely.

## Testing

- [ ] Typing `:hint -` shows the flag completion box with labels for each command and their flag short description
- [ ] Typing `hint -t` does not suggest any other `{action}` group flags like `-b`/`-y`, but instead suggests `-c`/`-J`/etc
- [ ] Typing `hint -ft` (mixing an ungrouped flag with an action flag) still excludes other action flags, same as `-t` alone
- [ ] Typing `hint -pi` offers completing to `-pipe`, `hint -w` offers `hint -wp`, and both suggest `-c`/`-J`/etc
- [ ] Typing an incorrect flag like `hint -Q` or `hint -tQ` does not return any suggestions
- [ ] Picking a multi-char flag (`-pipe`, `-W`, ...) inserts it with a trailing space
- [ ] Helps docs still render hint's flag list the same as before (no visible changes there)

## Screenshots

### `hint -`
<img width="1366" height="568" alt="image" src="https://github.com/user-attachments/assets/3efa7ede-5936-4613-bf01-39573ff94f1f" />

### `hint -p`
<img width="2048" height="336" alt="image" src="https://github.com/user-attachments/assets/314f9703-9a52-4378-8a52-620f0d32345e" />

### `hint -Jc`
<img width="1385" height="572" alt="image" src="https://github.com/user-attachments/assets/4471dcf5-7108-4786-b518-84e8058e343f" />


