### PR TITLE
Fix #5045: add optional tab argument to :tabmove

### DIFF
--- a/src/excmds.ts
+++ b/src/excmds.ts
@@ -3338,7 +3338,7 @@ export async function undo(item = "recent"): Promise<number> {
 }
 
 /**
- * Move the current tab to be just in front of the index specified.
+ * Move a tab, defaulting to the current one, to be just in front of the index specified.
  *
  * Known bug: This supports relative movement with `tabmove +pos` and `tabmove -pos`, but autocomplete doesn't know that yet and will override positive and negative indexes.
  *
@@ -3349,10 +3349,12 @@ export async function undo(item = "recent"): Promise<number> {
  * @param index New index for the current tab.
  *
  * 1,start,^ are aliases for the first index. 0,end,$ are aliases for the last index.
+ *
+ * @param tabToMove Which tab to move. Defaults to the current tab.
  */
 //#background
-export async function tabmove(index = "$") {
-    const aTab = await activeTab()
+export async function tabmove(index = "$", tabToMove?: string) {
+    const aTab = await tabFromIndex(tabToMove)
     if (index === "#") {
         const previousTab = await prevActiveTab()
         if (previousTab.index - aTab.index === 1) {


### PR DESCRIPTION
  Fixes #5045.
  `tabmove` ignored extra arguments and always moved the active tab, so `ex.execute_ex_on_completion_args tabmove -1` over the buffer list moved the wrong tab. It now takes an optional second argument (the tab to move), resolved with `tabFromIndex`, defaulting to the current tab.

  ### Human test
  1. Open 4 tabs; stay on tab 1.
  2. `bind --mode=ex <A-j> ex.execute_ex_on_completion_args tabmove +1`
  3. `b`, select tab 3, press `<A-j>` → tab 3 moves (previously tab 1 moved). ✓
  4. With pinned tabs: selecting an unpinned tab moves the correct one. ✓
  5. Regression: `<<` / `>>` / `:tabmove 2` still act on the active tab. ✓

Note: Human test was done in a MacBook, so the bind I used was `bind --mode=ex <C-j> ex.execute_ex_on_completion_args tabmove +1`

  ### Scope note
  Uses the standard buffer-list numbering (what the issue's flow uses).
  The `:tabmove`-prefixed completion's physical/pinned-group numbering is a separate concern and left out of scope.
